### PR TITLE
Adaptive plot sampling algorithm, Automatic PlotRange, Mesh and MaxRecursion options

### DIFF
--- a/mathics/builtin/plot.py
+++ b/mathics/builtin/plot.py
@@ -185,6 +185,9 @@ class Plot(Builtin):
         maxrecursion = self.get_option(options, 'MaxRecursion', evaluation)
         if maxrecursion.get_name() == 'Automatic':
             maxrecursion = 3
+        elif maxrecursion.has_form('DirectedInfinity',1) and str(maxrecursion) == 'DirectedInfinity[1]':
+            maxrecursion = 15
+            evaluation.message('Plot', 'invmaxrec', maxrecursion, 15)
         elif maxrecursion.has_form('Integer'):
             maxrecursion = maxrecursion.to_python()
             assert(isinstance(maxrecursion, int))


### PR DESCRIPTION
 automatic_plot_range function is used for two things
    Scaling the plot for use with adaptive sampling
    PlotRange->Automatic option (default) passed to Plot[]

This should make plots smoother and improve the automatic PlotRange

Handle PlotRange->{{xmin,xmax},{ymin,ymax}}. (Other forms will need to be added later)

Mesh and MaxRecursion Plot options too.
