### PR TITLE
Added Build status to Readme.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Contributing
 
 Please feel encouraged to contribute to Mathics! Create your own fork, make the desired changes, commit, and make a pull request.
 
-[![Build Status](https://secure.travis-ci.org/poeschko/Mathics.png?branch=master)](https://travis-ci.org/poeschko/Mathics)
+.. image:: https://secure.travis-ci.org/poeschko/Mathics.png?branch=master
 
 License
 -------


### PR DESCRIPTION
This pull request adds an image which shows the build status of Mathics on travis-ci to the Contributing section of Readme.md. 

It's not that there is a high chance someone will start contributing right away because of this but it can make this probability a bit higher.
