### PR TITLE
input should be shown first

### DIFF
--- a/mathics/main.py
+++ b/mathics/main.py
@@ -84,8 +84,8 @@ def main():
     trailing_ops = ['+', '-', '/', '*'] # TODO all binary operators?
 
     if args.execute:
-        evaluation = Evaluation(args.execute, definitions, timeout=30, out_callback=out_callback)
         print ">> %s" % args.execute
+        evaluation = Evaluation(args.execute, definitions, timeout=30, out_callback=out_callback)
         for result in evaluation.results:
                 if result.result is not None:
                     print ' = %s' % to_output(unicode(result.result))           


### PR DESCRIPTION
This pull request makes sure that when you run mathics form command line (when you only want the result) errors are printed after the input.

Here is what happens now:

```
$ mathics -e "+1+2"
 : Parse error at or near token +.
>> +1+2
```

 After this pull request:

```
$ mathics -e "+1+2"
>> +1+2
 : Parse error at or near token +.
```
