### PR TITLE
move benchmarks to after_script section for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ install:
   - "python setup.py install"
 script:
   - "python mathics/test.py"
+after_script:
   - "python mathics/benchmark.py"
 notifications:
   email: false


### PR DESCRIPTION
This should fix #87.

As an experiment I broke some tests and the [Travis build fails](https://travis-ci.org/sn6uv/Mathics/builds/4543727) as expected.
