### PR TITLE
Windows APPDATA environment variable.

### DIFF
--- a/mathics/settings.py
+++ b/mathics/settings.py
@@ -55,7 +55,7 @@ MANAGERS = ADMINS
 
 ROOT_DIR = pkg_resources.resource_filename('mathics', '') + '/'
 if sys.platform.startswith('win'):
-    DATA_DIR = os.environ['APPDATA'].replace(os.path.sep, '/') + '/Python/Mathics/'
+    DATA_DIR = os.environ['APPDATA'].replace(os.sep, '/') + '/Python/Mathics/'
 else:
     DATA_DIR = path.expanduser('~/.local/var/mathics/')
 #if not path.exists(DATA_DIR):


### PR DESCRIPTION
Hi.
I changed mathics/settings.py so that %APPDATA% can be interpreted correctly.
DATA_DIR = '%APPDATA%/Python/Mathics/' as in the previous code causes a directory named '%APPDATA%' to be created on database initialization.
