### PR TITLE
refactor timeout evaluation

### DIFF
--- a/mathics/main.py
+++ b/mathics/main.py
@@ -25,6 +25,7 @@ from mathics.core.definitions import Definitions
 from mathics.core.expression import Integer
 from mathics.core.evaluation import Evaluation
 from mathics import print_version, print_license, get_version_string
+from mathics import settings
 
 
 class TerminalShell(object):
@@ -84,7 +85,9 @@ class TerminalShell(object):
         return '{1}Out[{2}{0}{3}]= {4}'.format(line_number, *self.outcolors)
 
     def evaluate(self, text):
-        evaluation = Evaluation(text, self.definitions, timeout=30,
+        evaluation = Evaluation(text,
+                                self.definitions,
+                                timeout=settings.TIMEOUT,
                                 out_callback=out_callback)
         for result in evaluation.results:
             if result.result is not None:

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,8 @@ else:
 
 # General Requirements
 INSTALL_REQUIRES += ['sympy==0.7.2', 'django>=1.2', 'ply>=3.4',
-                     'argparse', 'python-dateutil', 'colorama']
+                     'argparse', 'python-dateutil', 'colorama',
+                     'interruptingcow']
 
 # strange SandboxError with SymPy 0.6.7 in Sage (writing to ~/.sage/tmp)
 


### PR DESCRIPTION
This should be less fragile than using the `threading` module.
