### PR TITLE
no need to require mpmath since it's included with sympy

### DIFF
--- a/mathics/__init__.py
+++ b/mathics/__init__.py
@@ -9,7 +9,7 @@ def get_version():
     version = {}
     
     import sympy
-    import mpmath
+    import sympy.mpmath as mpmath
     
     from django.core.exceptions import ImproperlyConfigured
     

--- a/mathics/builtin/algebra.py
+++ b/mathics/builtin/algebra.py
@@ -4,7 +4,7 @@ from mathics.builtin.base import Builtin
 from mathics.core.expression import Expression, Integer, from_sympy
 
 import sympy
-import mpmath
+import sympy.mpmath as mpmath
 
 def sympy_factor(expr_sympy):
     try:

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -8,8 +8,8 @@ Basic arithmetic functions, including complex number arithmetic.
 
 from __future__ import with_statement
 
-import mpmath
 import sympy
+import sympy.mpmath as mpmath
 
 from mathics.builtin.base import Builtin, Predefined, BinaryOperator, PrefixOperator, PostfixOperator, Test, SympyFunction, SympyConstant
 from mathics.core.expression import Expression, Number, Integer, Rational, Real, Symbol, Complex, String

--- a/mathics/builtin/combinatorial.py
+++ b/mathics/builtin/combinatorial.py
@@ -3,7 +3,7 @@
 from __future__ import with_statement
 
 import sympy
-import mpmath
+import sympy.mpmath as mpmath
 
 from mathics.builtin.base import Builtin, Predefined, BinaryOperator
 from mathics.core.expression import Expression, Integer, Real, Number, Symbol, from_sympy

--- a/mathics/builtin/exptrig.py
+++ b/mathics/builtin/exptrig.py
@@ -11,7 +11,7 @@ rules are not implemented yet.
 from __future__ import with_statement
 
 import sympy
-import mpmath
+import sympy.mpmath as mpmath
 
 from mathics.builtin.base import Builtin, Predefined, SympyConstant, SympyFunction
 from mathics.core.expression import Number, Real, Expression, Integer, from_sympy

--- a/mathics/builtin/numeric.py
+++ b/mathics/builtin/numeric.py
@@ -8,8 +8,8 @@ Precision is not "guarded" through the evaluation process. Only integer precisio
 However, things like 'N[Pi, 100]' should work as expected.
 """
 
-import mpmath
 import sympy
+import sympy.mpmath as mpmath
 
 from mathics.builtin.base import Builtin, Predefined
 from mathics.core.numbers import dps, mpmath2sympy, prec, convert_base

--- a/mathics/builtin/specialfunctions.py
+++ b/mathics/builtin/specialfunctions.py
@@ -4,7 +4,7 @@
 Special functions
 """
 
-import mpmath
+import sympy.mpmath as mpmath
 
 from mathics.builtin.base import Builtin
 from mathics.builtin.arithmetic import _MPMathFunction

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -19,7 +19,7 @@ u"""
 """
 
 import sympy
-import mpmath
+import sympy.mpmath as mpmath
 import re
 import operator
 try:

--- a/mathics/core/numbers.py
+++ b/mathics/core/numbers.py
@@ -21,7 +21,7 @@ u"""
 from __future__ import with_statement
 
 import sympy
-import mpmath
+import sympy.mpmath as mpmath
 from math import log
 
 from mathics.core.util import unicode_superscript

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ else:
     INSTALL_REQUIRES = ['cython>=0.15.1']
 
 # General Requirements
-INSTALL_REQUIRES += ['sympy==0.7.2', 'mpmath>=0.15', 'django>=1.2', 'ply>=3.4',
+INSTALL_REQUIRES += ['sympy==0.7.2', 'django>=1.2', 'ply>=3.4',
     'argparse', 'python-dateutil', 'colorama']
 
 # strange SandboxError with SymPy 0.6.7 in Sage (writing to ~/.sage/tmp)


### PR DESCRIPTION
This should speed up the install slightly since users now only have to download mpmath once (as part of sympy).
