### PR TITLE
fix MatrixForm, TableForm command line formatting #153

### DIFF
--- a/mathics/main.py
+++ b/mathics/main.py
@@ -93,7 +93,7 @@ class TerminalShell(object):
 
 
 def to_output(text):
-    return '\n      . '.join(text.splitlines())
+    return '\n        '.join(text.splitlines())
 
 
 def out_callback(out):


### PR DESCRIPTION
Current Behaviour:

```
In[1]:= {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}} // MatrixForm
Out[1]= 1   0   0
 . 
 . 0   1   0
 . 
 . 0   0   1

In[2]:=
```

Fix:

```
In[1]:= {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}} // MatrixForm
Out[1]= 1   0   0
      . 
      . 0   1   0
      . 
      . 0   0   1

In[2]:=
```

Proposed new formatting (This PR):

```
In[1]:= {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}} // MatrixForm
Out[1]= 1   0   0

        0   1   0

        0   0   1

In[2]:=
```

I think it looks cleaner without the dots, but I'm interested in what other people think.

For reference, MMA8 does this 

```
In[1]:= {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}} // MatrixForm

Out[1]//MatrixForm= 1   0   0

                    0   1   0

                    0   0   1

In[2]:= 
```
