### PR TITLE
Fixes deprecated django.conf.urls.defaults

### DIFF
--- a/mathics/urls.py
+++ b/mathics/urls.py
@@ -18,7 +18,7 @@ u"""
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 from django.conf import settings
 

--- a/mathics/web/urls.py
+++ b/mathics/web/urls.py
@@ -18,7 +18,7 @@ u"""
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns(
     'mathics.web.views',


### PR DESCRIPTION
Fixes deprecated django.conf.urls.defaults imports
django.conf.urls.defaults is removed in Django 1.6
