### PR TITLE
Minor setup.py fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,6 @@ class initialize(Command):
         try:
             subprocess.check_call(
                 [sys.executable, 'mathics/manage.py', 'syncdb', '--noinput'])
-            os.chmod(database_file, 0o766)
             print("")
             print("Mathics initialized successfully.")
         except subprocess.CalledProcessError:


### PR DESCRIPTION
This PR makes "setup.py intialize" propagate an error from manage.py back to the caller of setup.py.

It also removes a chmod to 0766 (`rwxrw-rw-`). It looked like this was in the original sources, and I couldn't find a comment explaining how these permissions were chosen. Since mathicsserver works fine as long as the database is readable and writable, and since most users probably run mathicsserver locally, widening the permissions by default could be surprising.
