### PR TITLE
Fixes behaviour of plot with defined symbols (addresses #150)

### DIFF
--- a/mathics/builtin/calculus.py
+++ b/mathics/builtin/calculus.py
@@ -117,7 +117,7 @@ class D(SympyFunction):
         'D[f_, x_, rest__]': 'D[D[f, x], rest]',
 
         'D[expr_, {x_, n_Integer?NonNegative}]': (
-            'Module[{}, Nest[Function[{t}, D[t, x]], expr, n]]'),
+            'Module[{t}, Nest[Function[{t}, D[t, x]], expr, n]]'),
     }
 
     def apply(self, f, x, evaluation):


### PR DESCRIPTION
As pointed out in #150, symbols passed as arguments to Plot are left unevaluated thus ignoring the possibility that these symbols contain expressions that can be plotted. The added lines check if the argument of plot has been defined and is different than the plotting variable, if this is the case the definition of the symbol is used as the plotting function. If the symbol's name is equal to the plotting variable it is left unevaluated (as mathematica does).

The same is repeated for List arguments, going through the elements of the List. Nested Lists are "flattened" in order to be able to plot all of the symbols in them (as mathematica does).
