### PR TITLE
Correct Sum behaviour when using Range to generate index values (addresses #149)

### DIFF
--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -1220,8 +1220,6 @@ class _IterationFunction(Builtin):
 
     attributes = ('HoldAll',)
     rules = {
-#        '%(name)s[expr_, {i_Symbol, imax_}]': (
-#            '%(name)s[expr, {i, 1, imax, 1}]'),
         '%(name)s[expr_, {i_Symbol, imin_, imax_}]': (
             '%(name)s[expr, {i, imin, imax, 1}]'),
     }


### PR DESCRIPTION
At the moment the code assumes that `imax_` in `'%(name)s[expr_, {i_Symbol, imax_}]'` is an integer and defines a rule to generate an expression that is processed by `apply_iter`. This is not always the case since `imax_` can be something like `Range[...]`. The modified code removes the rule above and introduces a check on `imax_` (`apply_range`) in order to choose which one is the correct function to use. This solves #149.
