### PR TITLE
Changed behaviour of Dot acting on matrices in MatrixForm

### DIFF
--- a/mathics/builtin/tensors.py
+++ b/mathics/builtin/tensors.py
@@ -173,7 +173,7 @@ class Dot(BinaryOperator):
     rules = {
         'Dot[a_List, b_List]': 'Inner[Times, a, b, Plus]',
     }
-        
+
 
 class Inner(Builtin):
     """


### PR DESCRIPTION
When Dot is passed 2 arguments it calls directly Inner but this gives a wrong result if the two matrices are in MatrixForm (see #145) and raises an error if only one of them is in MatrixForm since it detectes that the heads of the two arguments are different. The proposed change mimics the behaviour of Mathematica, if one or both matrices are in MatrixForm, the expression is left unevaluated.
