### PR TITLE
Fixed MatrixForm behaviour on matrices containing products

### DIFF
--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -1744,9 +1744,7 @@ class String(Atom):
                         '<mo form="prefix" lspace="0.2em" rspace="0">%s</mo>'
                         % encode_mathml(text))
                 if text == u'\u2062':
-                    return (
-                        '<mo form="prefix" lspace="0" rspace="0.2em">%s</mo>'
-                        % encode_mathml(text))
+                    return '<mo form="prefix" lspace="0" rspace="0.2em"> </mo>'
                 return '<mo>%s</mo>' % encode_mathml(text)
             elif is_symbol_name(text):
                 return '<mi>%s</mi>' % encode_mathml(text)


### PR DESCRIPTION
Calling `MatrixForm` on a matrix containing a product of symbols raises an exception related to the InvisibleSpace character used to represent the product. This commit replaces the InvisibleSpace character with a white space avoiding the problem.
