### PR TITLE
lock Djano at 1.6 (for this release)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ else:
     INSTALL_REQUIRES = ['cython>=0.15.1']
 
 # General Requirements
-INSTALL_REQUIRES += ['sympy==0.7.3', 'django>=1.5.5', 'ply>=3.4',
+INSTALL_REQUIRES += ['sympy==0.7.3', 'django==1.6', 'ply>=3.4',
                      'argparse', 'python-dateutil', 'colorama',
                      'interruptingcow']
 


### PR DESCRIPTION
Django 1.7 no longer supports Python 2.6.

I suggest we lock `django==1.6` then drop Python 2.6 for the next release (as we originally planned).
