### PR TITLE
Add readline tab completion

### DIFF
--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -170,7 +170,8 @@ class Definitions(object):
             ctx_pattern, short_pattern = pattern.rsplit('`', 1)
             ctx_pattern = ((ctx_pattern + '`')
                            .replace('@', '[^A-Z`]+')
-                           .replace('*', '.*'))
+                           .replace('*', '.*')
+                           .replace('$', r'\$'))
         else:
             short_pattern = pattern
             # start with a group matching the accessible contexts
@@ -181,7 +182,8 @@ class Definitions(object):
 
         short_pattern = (short_pattern
                          .replace('@', '[^A-Z]+')
-                         .replace('*', '[^`]*'))
+                         .replace('*', '[^`]*')
+                         .replace('$', r'\$'))
         regex = re.compile('^' + ctx_pattern + short_pattern + '$')
 
         return [name for name in self.get_names() if regex.match(name)]


### PR DESCRIPTION
This was some work that was based on the context branch. Pressing tab in the console interface completes the symbol under the cursor. By default it only completes symbols which are accessible through the context path.
