### PR TITLE
Relax Django version check to allow 1.6.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ else:
     INSTALL_REQUIRES = ['cython>=0.15.1']
 
 # General Requirements
-INSTALL_REQUIRES += ['sympy==0.7.3', 'django==1.6', 'ply>=3.4',
+INSTALL_REQUIRES += ['sympy==0.7.3', 'django >= 1.6, < 1.7', 'ply>=3.4',
                      'argparse', 'python-dateutil', 'colorama',
                      'interruptingcow']
 


### PR DESCRIPTION
I've got Django 1.6.1 installed via a distro package. This change lets Mathics start up, rather than forcing setup.py to fetch and install 1.6 exactly.
