### PR TITLE
Various fixes for docs

### DIFF
--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -1144,6 +1144,10 @@ class Indeterminate(Builtin):
     <dt>'Indeterminate'
         <dd>represents an indeterminate result.
     </dl>
+
+    >> 0^0
+     : Indeterminate expression 0 ^ 0 encountered.
+     = Indeterminate
     """
 
 

--- a/mathics/builtin/attributes.py
+++ b/mathics/builtin/attributes.py
@@ -14,6 +14,13 @@ from mathics.builtin.assignment import get_symbol_list
 
 class Attributes(Builtin):
     u"""
+    <dl>
+    <dt>'Attributes'[$symbol$]
+        <dd>returns the attributes of $symbol$.
+    <dt>'Attributes'[$symbol$] = {$attr1$, $attr2$}
+        <dd>sets the attributes of $symbol$, replacing any existing attributes.
+    </dl>
+
     >> Attributes[Plus]
      = {Flat, Listable, NumericFunction, OneIdentity, Orderless, Protected}
     'Attributes' always considers the head of an expression:
@@ -50,9 +57,16 @@ class Attributes(Builtin):
 
 class SetAttributes(Builtin):
     """
+    <dl>
+    <dt>'SetAttributes'[$symbol$, $attrib$]
+        <dd>adds $attrib$ to $symbol$'s attributes.
+    </dl>
+
     >> SetAttributes[f, Flat]
     >> Attributes[f]
      = {Flat}
+
+    Multiple attributes can be set at the same time using lists:
     >> SetAttributes[{f, g}, {Flat, Orderless}]
     >> Attributes[g]
      = {Flat, Orderless}
@@ -82,6 +96,11 @@ class SetAttributes(Builtin):
 
 class ClearAttributes(Builtin):
     """
+    <dl>
+    <dt>'ClearAttributes'[$symbol$, $attrib$]
+        <dd>removes $attrib$ from $symbol$'s attributes.
+    </dl>
+
     >> SetAttributes[f, Flat]
     >> Attributes[f]
      = {Flat}
@@ -118,6 +137,11 @@ class ClearAttributes(Builtin):
 
 class Protect(Builtin):
     """
+    <dl>
+    <dt>'Protect'[$symbol$]
+        <dd>gives $symbol$ the attribute 'Protected'.
+    </dl>
+
     >> A = {1, 2, 3};
     >> Protect[A]
     >> A[[2]] = 4;
@@ -134,6 +158,12 @@ class Protect(Builtin):
 
 
 class Unprotect(Builtin):
+    """
+    <dl>
+    <dt>'Unprotect'[$symbol$]
+        <dd>removes the 'Protected' attribute from $symbol$.
+    </dl>
+    """
 
     attributes = ('HoldAll',)
 
@@ -144,6 +174,12 @@ class Unprotect(Builtin):
 
 class Protected(Predefined):
     """
+    <dl>
+    <dt>'Protected'
+        <dd>is an attribute that prevents values on a symbol from
+        being modified.
+    </dl>
+
     Values of 'Protected' symbols cannot be modified:
     >> Attributes[p] = {Protected};
     >> p = 2;
@@ -179,7 +215,14 @@ class Protected(Predefined):
 
 class ReadProtected(Predefined):
     """
-    Values associated with 'ReadProtected' symbols cannot be read:
+    <dl>
+    <dt>'ReadProtected'
+        <dd>is an attribute that prevents values on a symbol from
+        being read.
+    </dl>
+
+    Values associated with 'ReadProtected' symbols cannot be seen in
+    'Definition':
     >> ClearAll[p]
     >> p = 3;
     >> Definition[p]
@@ -192,6 +235,12 @@ class ReadProtected(Predefined):
 
 class Locked(Predefined):
     """
+    <dl>
+    <dt>'Locked'
+        <dd>is an attribute that prevents attributes on a symbol from
+        being modified.
+    </dl>
+
     The attributes of 'Locked' symbols cannot be modified:
     >> Attributes[lock] = {Flat, Locked};
     >> SetAttributes[lock, {}]
@@ -212,7 +261,19 @@ class Locked(Predefined):
 
 class Flat(Predefined):
     """
+    <dl>
+    <dt>'Flat'
+        <dd>is an attribute that specifies that nested occurrences of
+        a function should be automatically flattened.
+    </dl>
+
+    A symbol with the 'Flat' attribute represents an associative
+    mathematical operation:
     >> SetAttributes[f, Flat]
+    >> f[a, f[b, c]]
+     = f[a, b, c]
+
+    'Flat' is taken into account in pattern matching:
     >> f[a, b, c] /. f[a, b] -> d
      = f[d, c]
 
@@ -243,17 +304,37 @@ class Flat(Predefined):
 
 class Orderless(Predefined):
     """
+    <dl>
+    <dt>'Orderless'
+        <dd>is an attribute indicating that the leaves in an
+        expression f[a, b, c] can be placed in any order.
+    </dl>
+
+    The leaves of an 'Orderless' function are automatically sorted:
     >> SetAttributes[f, Orderless]
     >> f[c, a, b, a + b, 3, 1.0]
      = f[1., 3, a, b, c, a + b]
+
+    A symbol with the 'Orderless' attribute represents a commutative
+    mathematical operation.
+    >> f[a, b] == f[b, a]
+     = True
+
+    'Orderless' affects pattern matching:
     >> SetAttributes[f, Flat]
-    >> f[a, b, c] /. f[a, b] -> d
-     = f[c, d]
+    >> f[a, b, c] /. f[a, c] -> d
+     = f[b, d]
     """
 
 
 class OneIdentity(Predefined):
     """
+    <dl>
+    <dt>'OneIdentity'
+        <dd>is an attribute specifying that $f$[$x$] should be treated
+        as equivalent to $x$ in pattern matching.
+    </dl>
+
     'OneIdentity' affects pattern matching:
     >> SetAttributes[f, OneIdentity]
     >> a /. f[args___] -> {args}
@@ -266,6 +347,12 @@ class OneIdentity(Predefined):
 
 class SequenceHold(Predefined):
     """
+    <dl>
+    <dt>'SequenceHold'
+        <dd>is an attribute that prevents 'Sequence' objects from being
+        spliced into a function's arguments.
+    </dl>
+
     Normally, 'Sequence' will be spliced into a function:
     >> f[Sequence[a, b]]
      = f[a, b]
@@ -284,20 +371,46 @@ class SequenceHold(Predefined):
 
 
 class HoldFirst(Predefined):
-    pass
+    """
+    <dl>
+    <dt>'HoldFirst'
+        <dd>is an attribute specifying that the first argument of a
+        function should be left unevaluated.
+    </dl>
+    """
 
 
 class HoldRest(Predefined):
-    pass
+    """
+    <dl>
+    <dt>'HoldRest'
+        <dd>is an attribute specifying that all but the first argument
+        of a function should be left unevaluated.
+    </dl>
+    """
 
 
 class HoldAll(Predefined):
-    pass
+    """
+    <dl>
+    <dt>'HoldAll'
+        <dd>is an attribute specifying that all arguments of a
+        function should be left unevaluated.
+    </dl>
+    """
 
 
 class HoldAllComplete(Predefined):
     """
-    'HoldAllComplete' even prevents upvalues from being used, and includes 'SequenceHold'.
+    <dl>
+    <dt>'HoldAllComplete'
+        <dd>is an attribute that includes the effects of 'HoldAll' and
+        'SequenceHold', and also protects the function from being
+        affected by the upvalues of any arguments.
+    </dl>
+
+    'HoldAllComplete' even prevents upvalues from being used, and
+    includes 'SequenceHold'.
     >> SetAttributes[f, HoldAllComplete]
     >> f[a] ^= 3;
     >> f[a]
@@ -309,6 +422,12 @@ class HoldAllComplete(Predefined):
 
 class NHoldAll(Predefined):
     """
+    <dl>
+    <dt>'NHoldAll'
+        <dd>is an attribute that protects all arguments of a
+        function from numeric evaluation.
+    </dl>
+
     >> N[f[2, 3]]
      = f[2., 3.]
     >> SetAttributes[f, NHoldAll]
@@ -318,15 +437,33 @@ class NHoldAll(Predefined):
 
 
 class NHoldFirst(Predefined):
-    pass
+    """
+    <dl>
+    <dt>'NHoldFirst'
+        <dd>is an attribute that protects the first argument of a
+        function from numeric evaluation.
+    </dl>
+    """
 
 
 class NHoldRest(Predefined):
-    pass
+    """
+    <dl>
+    <dt>'NHoldRest'
+        <dd>is an attribute that protects all but the first argument
+        of a function from numeric evaluation.
+    </dl>
+    """
 
 
 class Listable(Predefined):
     """
+    <dl>
+    <dt>'Listable'
+        <dd>is an attribute specifying that a function should be
+        automatically applied to each element of a list.
+    </dl>
+
     >> SetAttributes[f, Listable]
     >> f[{1, 2, 3}, {4, 5, 6}]
      = {f[1, 4], f[2, 5], f[3, 6]}
@@ -338,4 +475,19 @@ class Listable(Predefined):
 
 
 class Constant(Predefined):
-    pass
+    """
+    <dl>
+    <dt>'Constant'
+        <dd>is an attribute that indicates that a symbol is a constant.
+    </dl>
+
+    Mathematical constants like 'E' have attribute 'Constant':
+    >> Attributes[E]
+     = {Constant, Protected, ReadProtected}
+
+    Constant symbols cannot be used as variables in 'Solve' and
+    related functions:
+    >> Solve[x + E == 0, E]
+     : E is not a valid variable.
+     = Solve[E + x == 0, E]
+    """

--- a/mathics/builtin/calculus.py
+++ b/mathics/builtin/calculus.py
@@ -743,11 +743,25 @@ class Solve(Builtin):
 
 
 class Reals(Builtin):
-    pass
+    """
+    <dl>
+    <dt>'Reals'
+        <dd>is the set of real numbers.
+    </dl>
+
+    Limit a solution to real numbers:
+    >> Solve[x^3 == 1, x, Reals]
+     = {{x -> 1}}
+    """
 
 
 class Complexes(Builtin):
-    pass
+    """
+    <dl>
+    <dt>'Complexes'
+        <dd>is the set of complex numbers.
+    </dl>
+    """
 
 
 class Limit(Builtin):

--- a/mathics/builtin/diffeqns.py
+++ b/mathics/builtin/diffeqns.py
@@ -13,8 +13,8 @@ from mathics.core.convert import sympy_symbol_prefix, from_sympy
 class DSolve(Builtin):
     """
     <dl>
-    <dt>'DSolve[$eq$, $y[x]$, $x$]'
-        <dd>solves a differential equation for the function $y[x]$.
+    <dt>'DSolve[$eq$, $y$[$x$], $x$]'
+        <dd>solves a differential equation for the function $y$[$x$].
     </dl>
 
     >> DSolve[y''[x] == 0, y[x], x]

--- a/mathics/builtin/diffeqns.py
+++ b/mathics/builtin/diffeqns.py
@@ -151,6 +151,9 @@ class DSolve(Builtin):
 
 class C(Builtin):
     """
-    'C'[$n$] represents the $n$th constant in a solution to a
-    differential equation.
+    <dl>
+    <dt>'C'[$n$]
+        <dd>represents the $n$th constant in a solution to a
+        differential equation.
+    </dl>
     """

--- a/mathics/builtin/files.py
+++ b/mathics/builtin/files.py
@@ -354,7 +354,7 @@ class Byte(Builtin):
     """
     <dl>
     <dt>'Byte'
-      <dd>is a data type for 'Read'
+      <dd>is a data type for 'Read'.
     </dl>
     """
 
@@ -363,7 +363,7 @@ class Character(Builtin):
     """
     <dl>
     <dt>'Character'
-      <dd>is a data type for 'Read'
+      <dd>is a data type for 'Read'.
     </dl>
     """
 
@@ -372,7 +372,7 @@ class Expression_(Builtin):
     """
     <dl>
     <dt>'Expression'
-      <dd>is a data type for 'Read'
+      <dd>is a data type for 'Read'.
     </dl>
     """
     name = 'Expression'
@@ -382,7 +382,7 @@ class Number_(Builtin):
     """
     <dl>
     <dt>'Number'
-      <dd>is a data type for 'Read'
+      <dd>is a data type for 'Read'.
     </dl>
     """
     name = 'Number'
@@ -392,7 +392,7 @@ class Record(Builtin):
     """
     <dl>
     <dt>'Record'
-      <dd>is a data type for 'Read'
+      <dd>is a data type for 'Read'.
     </dl>
     """
 
@@ -401,7 +401,7 @@ class Word(Builtin):
     """
     <dl>
     <dt>'Word'
-      <dd>is a data type for 'Read'
+      <dd>is a data type for 'Read'.
     </dl>
     """
 

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -1842,28 +1842,55 @@ class Orange(_ColorObject):
 
 
 class Automatic(Builtin):
-    # todo: doc
-    pass
+    '''
+    <dl>
+    <dt>'Automatic'
+        <dd>is used to specify an automatically computed option value.
+    </dl>
+
+    'Automatic' is the default for 'PlotRange', 'ImageSize', and other
+    graphical options:
+
+    >> Cases[Options[Plot], _ :> Automatic]
+     = {Exclusions :> Automatic, ImageSize :> Automatic, MaxRecursion :> Automatic, PlotRange :> Automatic, PlotRangePadding :> Automatic}
+    '''
 
 
 class Tiny(Builtin):
-    # todo: doc
-    pass
+    '''
+    <dl>
+    <dt>'ImageSize' -> 'Tiny'
+        <dd>produces a tiny image.
+    </dl>
+    '''
+
 
 
 class Small(Builtin):
-    # todo: doc
-    pass
+    '''
+    <dl>
+    <dt>'ImageSize' -> 'Small'
+        <dd>produces a small image.
+    </dl>
+    '''
 
 
 class Medium(Builtin):
-    # todo: doc
-    pass
+    '''
+    <dl>
+    <dt>'ImageSize' -> 'Medium'
+        <dd>produces a medium-sized image.
+    </dl>
+    '''
 
 
 class Large(Builtin):
-    # todo: doc
-    pass
+    '''
+    <dl>
+    <dt>'ImageSize' -> 'Large'
+        <dd>produces a large image.
+    </dl>
+    '''
 
 
 GLOBALS = system_symbols_dict({

--- a/mathics/doc/doc.py
+++ b/mathics/doc/doc.py
@@ -25,7 +25,6 @@ from os import listdir, path
 import pickle
 
 from django.utils.html import escape, linebreaks
-from django.template.defaultfilters import slugify
 from django.utils.safestring import mark_safe
 
 from mathics import settings
@@ -33,6 +32,7 @@ from mathics import settings
 from mathics import builtin
 from mathics.builtin import get_module_doc
 from mathics.core.evaluation import Message, Print
+from mathics.doc.utils import slugify
 
 CHAPTER_RE = re.compile('(?s)<chapter title="(.*?)">(.*?)</chapter>')
 SECTION_RE = re.compile('(?s)(.*?)<section title="(.*?)">(.*?)</section>')

--- a/mathics/doc/doc.py
+++ b/mathics/doc/doc.py
@@ -110,7 +110,10 @@ def filter_comments(doc):
 
 def strip_system_prefix(name):
     if name.startswith('System`'):
-        return name[len('System`'):]
+        stripped_name = name[len('System`'):]
+        # don't return Private`sym for System`Private`sym
+        if '`' not in stripped_name:
+            return stripped_name
     return name
 
 

--- a/mathics/doc/utils.py
+++ b/mathics/doc/utils.py
@@ -1,0 +1,47 @@
+# -*- coding: utf8 -*-
+
+u"""
+    Mathics: a general-purpose computer algebra system
+    Copyright (C) 2011-2013 The Mathics Team
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import re
+import unicodedata
+
+from django.template.defaultfilters import register, stringfilter
+from django.utils import six
+from django.utils.functional import allow_lazy
+from django.utils.safestring import mark_safe
+
+
+def slugify_symbol(value):
+    value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore').decode('ascii')
+    value = re.sub('[^$`\w\s-]', '', value).strip().lower()
+    return mark_safe(re.sub('[-\s`]+', '-', value))
+slugify_symbol = allow_lazy(slugify_symbol, six.text_type)
+
+
+@register.filter(is_safe=True)
+@stringfilter
+def slugify(value):
+    """
+    Converts to lowercase, removes non-word characters apart from '$',
+    and converts spaces to hyphens. Also strips leading and trailing
+    whitespace.
+
+    Based on the Django version, but modified to preserve '$'.
+    """
+    return slugify_symbol(value)

--- a/mathics/web/urls.py
+++ b/mathics/web/urls.py
@@ -36,5 +36,5 @@ urlpatterns = patterns(
     ('^(?P<ajax>(?:ajax/)?)doc/(?P<part>[\w-]+)/(?P<chapter>[\w-]+)/$',
      'doc_chapter'),
     ('^(?P<ajax>(?:ajax/)?)doc/(?P<part>[\w-]+)/(?P<chapter>[\w-]+)/'
-     '(?P<section>[\w-]+)/$', 'doc_section'),
+     '(?P<section>[$\w-]+)/$', 'doc_section'),
 )


### PR DESCRIPTION
This is a fix for some doc issues introduced in the context branch. Adding `$Context` exposed a problem where dollar signs weren't significant in doc links. I've tried to fix this but I'm definitely not a Django expert, so it'd be good to know if this isn't right.

I plan to add more stuff to this soon to document some undocumented symbols that came in with the context branch, but it'd be good to know if what I've got so far is along the right lines.