### PR TITLE
Plot3D

### DIFF
--- a/mathics/builtin/plot.py
+++ b/mathics/builtin/plot.py
@@ -787,22 +787,20 @@ class _Plot3D(Builtin):
                     return
                 elif v1 is None or v2 is None or v3 is None:
                     # 'triforce' pattern recursion to find the edge of defined region
-                    #      (x1,y1)
+                    #         1
                     #         /\
-                    #        /__\
+                    #      4 /__\ 6
                     #       /\  /\
                     #      /__\/__\
-                    # (x2,y2)    (x3,y3)
+                    #     2   5    3
                     if depth < 2:
-                        triangle(x1, y1, (x1 + x2) / 2, (y1 + y2) / 2,
-                                 (x1 + x3) / 2, (y1 + y3) / 2, depth + 1)
-                        triangle(x2, y2, (x1 + x2) / 2, (y1 + y2) / 2,
-                                 (x2 + x3) / 2, (y2 + y3) / 2, depth + 1)
-                        triangle(x3, y3, (x1 + x3) / 2, (y1 + y3) / 2,
-                                 (x2 + x3) / 2, (y2 + y3) / 2, depth + 1)
-                        triangle((x1 + x2) / 2, (y1 + y2) / 2, (x2 + x3) / 2,
-                                 (y2 + y3) / 2, (x1 + x3) / 2, (y1 + y3) / 2,
-                                 depth + 1)
+                        x4, y4 = 0.5 * (x1 + x2), 0.5 * (y1 + y2)
+                        x5, y5 = 0.5 * (x2 + x3), 0.5 * (y2 + y3)
+                        x6, y6 = 0.5 * (x1 + x3), 0.5 * (y1 + y3)
+                        triangle(x1, y1, x4, y4, x6, y6, depth + 1)
+                        triangle(x4, y4, x2, y2, x5, y5, depth + 1)
+                        triangle(x6, y6, x5, y5, x3, y3, depth + 1)
+                        triangle(x4, y4, x5, y5, x6, y6, depth + 1)
                     return
                 triangles.append([(x1, y1, v1), (x2, y2, v2), (x3, y3, v3)])
 

--- a/mathics/builtin/plot.py
+++ b/mathics/builtin/plot.py
@@ -743,6 +743,26 @@ class _Plot3D(Builtin):
             evaluation.message(self.get_name(), 'invpltpts', plotpoints)
             plotpoints = [7, 7]
 
+        # MaxRecursion Option
+        maxrec_option = self.get_option(options, 'MaxRecursion', evaluation)
+        max_depth = maxrec_option.to_python()
+        if isinstance(max_depth, int):
+            if max_depth < 0:
+                max_depth = 0
+                evaluation.message(self.get_name(), 'invmaxrec', max_depth, 15)
+            elif max_depth > 15:
+                max_depth = 15
+                evaluation.message(self.get_name(), 'invmaxrec', max_depth, 15)
+            else:
+                pass    # valid
+        elif max_depth == float('inf'):
+            max_depth = 15
+            evaluation.message(self.get_name(), 'invmaxrec', max_depth, 15)
+        else:
+            max_depth = 0
+            evaluation.message(self.get_name(), 'invmaxrec', max_depth, 15)
+
+        ## Plot the functions
         graphics = []
         for indx, f in enumerate(functions):
             stored = {}
@@ -765,14 +785,12 @@ class _Plot3D(Builtin):
 
             triangles = []
 
-            max_depth = 2   # recusion depth
-
             split_edges = set([])       # subdivided edges
 
             def triangle(x1, y1, x2, y2, x3, y3, depth=0):
                 v1, v2, v3 = eval_f(x1, y1), eval_f(x2, y2), eval_f(x3, y3)
 
-                if (v1 is v2 is v3 is None): # and (depth > max_depth / 2):
+                if (v1 is v2 is v3 is None) and (depth > max_depth / 2):
                     # fast finish because the entire region is undefined but
                     # recurse 'a little' to avoid missing well defined regions
                     return
@@ -1308,6 +1326,23 @@ class Plot3D(_Plot3D):
     #> Plot3D[z, {x, 1, 20}, {y, 1, 10}]
      = -Graphics3D-
 
+    ## MaxRecursion Option
+    #> Plot3D[0, {x, -2, 2}, {y, -2, 2}, MaxRecursion -> 0]
+     = -Graphics3D-
+    #> Plot3D[0, {x, -2, 2}, {y, -2, 2}, MaxRecursion -> 15]
+     = -Graphics3D-
+    #> Plot3D[0, {x, -2, 2}, {y, -2, 2}, MaxRecursion -> 16]
+     : MaxRecursion must be a non-negative integer; the recursion value is limited to 15. Using MaxRecursion -> 15.
+     = -Graphics3D-
+    #> Plot3D[0, {x, -2, 2}, {y, -2, 2}, MaxRecursion -> -1]
+     : MaxRecursion must be a non-negative integer; the recursion value is limited to 15. Using MaxRecursion -> 0.
+     = -Graphics3D-
+    #> Plot3D[0, {x, -2, 2}, {y, -2, 2}, MaxRecursion -> a]
+     : MaxRecursion must be a non-negative integer; the recursion value is limited to 15. Using MaxRecursion -> 0.
+     = -Graphics3D-
+    #> Plot3D[0, {x, -2, 2}, {y, -2, 2}, MaxRecursion -> Infinity]
+     : MaxRecursion must be a non-negative integer; the recursion value is limited to 15. Using MaxRecursion -> 15.
+     = -Graphics3D-
     """
 
     # FIXME: This test passes but the result is 511 lines long !
@@ -1326,6 +1361,7 @@ class Plot3D(_Plot3D):
         'Mesh': 'Full',
         'PlotPoints': 'None',
         'BoxRatios': '{1, 1, 0.4}',
+        'MaxRecursion': '2',
     })
 
     def get_functions_param(self, functions):

--- a/mathics/builtin/plot.py
+++ b/mathics/builtin/plot.py
@@ -1016,12 +1016,11 @@ class _Plot3D(Builtin):
                     mesh_points.extend([sorted(g) for k,g in itertools.groupby(mesh_line, lambda x: x[2] is None)])
                 mesh_points = [mesh_line for mesh_line in mesh_points if not any(x[2] is None for x in mesh_line)]
             elif mesh == 'System`All':
+                mesh_points = set([])
                 for t in triangles:
-                    mesh_points = set([])
-                    for t in triangles:
-                        mesh_points.add((t[0], t[1]) if t[1] > t[0] else (t[1], t[0]))
-                        mesh_points.add((t[1], t[2]) if t[2] > t[1] else (t[2], t[1]))
-                        mesh_points.add((t[0], t[2]) if t[2] > t[0] else (t[2], t[0]))
+                    mesh_points.add((t[0], t[1]) if t[1] > t[0] else (t[1], t[0]))
+                    mesh_points.add((t[1], t[2]) if t[2] > t[1] else (t[2], t[1]))
+                    mesh_points.add((t[0], t[2]) if t[2] > t[0] else (t[2], t[0]))
                 mesh_points = list(mesh_points)
 
             # find the max and min height

--- a/mathics/builtin/plot.py
+++ b/mathics/builtin/plot.py
@@ -782,7 +782,17 @@ class _Plot3D(Builtin):
                             v_borders[0] = v
                         if v_borders[1] is None or v > v_borders[1]:
                             v_borders[1] = v
-                if v1 is None or v2 is None or v3 is None:
+                if v1 is None and v2 is None and v3 is None:
+                    # fast finish: region is totally undefined
+                    return
+                elif v1 is None or v2 is None or v3 is None:
+                    # 'triforce' pattern recursion to find the edge of defined region
+                    #      (x1,y1)
+                    #         /\
+                    #        /__\
+                    #       /\  /\
+                    #      /__\/__\
+                    # (x2,y2)    (x3,y3)
                     if depth < 2:
                         triangle(x1, y1, (x1 + x2) / 2, (y1 + y2) / 2,
                                  (x1 + x3) / 2, (y1 + y3) / 2, depth + 1)

--- a/mathics/builtin/plot.py
+++ b/mathics/builtin/plot.py
@@ -837,54 +837,32 @@ class _Plot3D(Builtin):
                     if len(new_points) == 0:
                         continue
                     made_changes = True
-                    if len(new_points) == 1:
-                        # 'simple' subdivision
-                        #       1
-                        #      /|\
-                        #     / | \
-                        #    /__|__\
-                        #   2   4   3
-                        ni = new_points[0]
-                        t1 = [t[0], t[1], t[2]]
-                        t2 = [t[0], t[1], t[2]]
-                        x4  = 0.5 * (t[ni[0]][0] + t[ni[1]][0])
-                        y4  = 0.5 * (t[ni[0]][1] + t[ni[1]][1])
-                        v4 = stored[(x4, y4)]
-                        if v4 is not None:
-                            t1 = list(t)
-                            t2 = list(t)
-                            t1[ni[0]] = (x4, y4, v4)
-                            t2[ni[1]] = (x4, y4, v4)
-                            new_triangles.append(sorted(tuple(t1)))
-                            new_triangles.append(sorted(tuple(t2)))
-                        triangles[i] = None
-                    elif len(new_points) > 1:
-                        # 'triforce' subdivision
-                        #         1
-                        #         /\
-                        #      4 /__\ 6
-                        #       /\  /\
-                        #      /__\/__\
-                        #     2   5    3
-                        # if only two edges require subdivision bisect the
-                        # third edge but fake its value by averaging
-                        x4 = 0.5 * (t[0][0] + t[1][0])
-                        y4 = 0.5 * (t[0][1] + t[1][1])
-                        v4 = stored.get((x4, y4), 0.5*(t[0][2] + t[1][2]))
+                    # 'triforce' subdivision
+                    #         1
+                    #         /\
+                    #      4 /__\ 6
+                    #       /\  /\
+                    #      /__\/__\
+                    #     2   5    3
+                    # if less than three edges require subdivision bisect them
+                    # anyway but fake their values by averaging
+                    x4 = 0.5 * (t[0][0] + t[1][0])
+                    y4 = 0.5 * (t[0][1] + t[1][1])
+                    v4 = stored.get((x4, y4), 0.5*(t[0][2] + t[1][2]))
 
-                        x5 = 0.5 * (t[1][0] + t[2][0])
-                        y5 = 0.5 * (t[1][1] + t[2][1])
-                        v5 = stored.get((x5, y5), 0.5*(t[1][2] + t[2][2]))
+                    x5 = 0.5 * (t[1][0] + t[2][0])
+                    y5 = 0.5 * (t[1][1] + t[2][1])
+                    v5 = stored.get((x5, y5), 0.5*(t[1][2] + t[2][2]))
 
-                        x6 = 0.5 * (t[0][0] + t[2][0])
-                        y6 = 0.5 * (t[0][1] + t[2][1])
-                        v6 = stored.get((x6, y6), 0.5*(t[0][2] + t[2][2]))
+                    x6 = 0.5 * (t[0][0] + t[2][0])
+                    y6 = 0.5 * (t[0][1] + t[2][1])
+                    v6 = stored.get((x6, y6), 0.5*(t[0][2] + t[2][2]))
 
-                        new_triangles.append(sorted((t[0], (x4, y4, v4), (x6, y6, v6))))
-                        new_triangles.append(sorted((t[1], (x4, y4, v4), (x5, y5, v5))))
-                        new_triangles.append(sorted((t[2], (x5, y5, v5), (x6, y6, v6))))
-                        new_triangles.append(sorted(((x4, y4, v4), (x5, y5, v5), (x6, y6, v6))))
-                        triangles[i] = None
+                    new_triangles.append(sorted((t[0], (x4, y4, v4), (x6, y6, v6))))
+                    new_triangles.append(sorted((t[1], (x4, y4, v4), (x5, y5, v5))))
+                    new_triangles.append(sorted((t[2], (x5, y5, v5), (x6, y6, v6))))
+                    new_triangles.append(sorted(((x4, y4, v4), (x5, y5, v5), (x6, y6, v6))))
+                    triangles[i] = None
 
                 triangles.extend(new_triangles)
                 triangles = [t for t in triangles if t is not None]

--- a/mathics/builtin/plot.py
+++ b/mathics/builtin/plot.py
@@ -75,6 +75,12 @@ class Axis(Builtin):
     pass
 
 
+def extract_pyreal(value):
+    if isinstance(value, Real):
+        return chop(value).get_real_value()
+    return None
+
+
 def quiet_evaluate(expr, vars, evaluation, expect_list=False):
     """ Evaluates expr with given dynamic scoping values
     without producing arithmetic error messages. """
@@ -84,14 +90,14 @@ def quiet_evaluate(expr, vars, evaluation, expect_list=False):
     value = dynamic_scoping(quiet_expr.evaluate, vars, evaluation)
     if expect_list:
         if value.has_form('List', None):
-            value = [chop(item).get_real_value() for item in value.leaves]
+            value = (extract_pyreal(item) for item in value.leaves)
             if any(item is None for item in value):
                 return None
-            return value
+            return list(value)  # force generator evaluation
         else:
             return None
     else:
-        value = chop(value).get_real_value()
+        value = extract_pyreal(value)
         if value is None or isinf(value) or isnan(value):
             return None
         return value
@@ -1121,6 +1127,9 @@ class Plot3D(_Plot3D):
      = -Graphics3D-
 
     >> Plot3D[Sin[x y] /(x y), {x, -3, 3}, {y, -3, 3}, Mesh->All]
+     = -Graphics3D-
+
+    >> Plot3D[Log[x + y^2], {x, -1, 1}, {y, -1, 1}]
      = -Graphics3D-
 
     #> Plot3D[z, {x, 1, 20}, {y, 1, 10}]

--- a/mathics/builtin/plot.py
+++ b/mathics/builtin/plot.py
@@ -6,6 +6,7 @@ Plotting
 
 from math import sin, cos, pi, sqrt, isnan, isinf
 import numbers
+import itertools
 
 from mathics.core.expression import (Expression, Real, NumberError, Symbol,
                                      String, from_python)
@@ -928,10 +929,10 @@ class _Plot3D(Builtin):
                         i += 1
 
             # handle missing regions
-            # TODO
-
-            for mesh_line in mesh_points:
-                mesh_line.sort()
+            old_meshpoints, mesh_points = mesh_points, []
+            for mesh_line in old_meshpoints:
+                mesh_points.extend([sorted(g) for k,g in itertools.groupby(mesh_line, lambda x: x[2] is None)])
+            mesh_points = [mesh_line for mesh_line in mesh_points if not any(x[2] is None for x in mesh_line)]
 
             # find the max and min height
             v_min = v_max = None

--- a/mathics/builtin/plot.py
+++ b/mathics/builtin/plot.py
@@ -788,26 +788,6 @@ class _Plot3D(Builtin):
                                  (y2 + y3) / 2, (x1 + x3) / 2, (y1 + y3) / 2,
                                  depth + 1)
                     return
-                limit = (v_borders[1] - v_borders[0]) * eps
-                if depth < 2:
-                    if abs(v1 - v2) > limit:
-                        triangle(x1, y1, x3, y3, (x1 + x2) / 2, (y1 + y2) / 2,
-                                 depth + 1)
-                        triangle(x2, y2, x3, y3, (x1 + x2) / 2, (y1 + y2) / 2,
-                                 depth + 1)
-                        return
-                    if abs(v2 - v3) > limit:
-                        triangle(x1, y1, x2, y2, (
-                            x2 + x3) / 2, (y2 + y3) / 2, depth + 1)
-                        triangle(x1, y1, x3, y3, (
-                            x2 + x3) / 2, (y2 + y3) / 2, depth + 1)
-                        return
-                    if abs(v1 - v3) > limit:
-                        triangle(x2, y2, x1, y1, (
-                            x1 + x3) / 2, (y1 + y3) / 2, depth + 1)
-                        triangle(x2, y2, x3, y3, (
-                            x1 + x3) / 2, (y1 + y3) / 2, depth + 1)
-                        return
                 triangles.append([(x1, y1, v1), (x2, y2, v2), (x3, y3, v3)])
 
             numx = plotpoints[0] * 1.0

--- a/mathics/builtin/plot.py
+++ b/mathics/builtin/plot.py
@@ -1431,6 +1431,7 @@ class DensityPlot(_Plot3D):
         'ColorFunction': 'Automatic',
         'ColorFunctionScaling': 'True',
         'PlotPoints': 'None',
+        'MaxRecursion': '2',
     })
 
     def get_functions_param(self, functions):

--- a/mathics/builtin/plot.py
+++ b/mathics/builtin/plot.py
@@ -782,8 +782,9 @@ class _Plot3D(Builtin):
                             v_borders[0] = v
                         if v_borders[1] is None or v > v_borders[1]:
                             v_borders[1] = v
-                if v1 is None and v2 is None and v3 is None:
-                    # fast finish: region is totally undefined
+                if (v1 is v2 is v3 is None) and (depth < 1):
+                    # fast finish because the entire region is undefined but
+                    # recurse 'a little' to avoid missing well defined regions
                     return
                 elif v1 is None or v2 is None or v3 is None:
                     # 'triforce' pattern recursion to find the edge of defined region


### PR DESCRIPTION
Some improvements to the 3D plotting code:
- adaptive sampling in 3D
- better triangle subdivision algorithm (I've named it triforce)
- fix some 'tenting' effects (e.g. a grid square (1,2,3,4) was previously triangulated as (1,2,3), (1,3,4) when (1,2,4), (2,3,4) looks better
- fix some subdivision bugs which were causing gaps in the surfaces
- general code cleanup
- optimise Mesh
- basic (automatic) exclusion support
- implemented `MaxRecursion` option

Examples
--------
(all plotted with `Mesh->All` so the subdivision changes are more visible)
- `Plot3D[x ^ 2 + 1 / y, {x, -1, 1}, {y, 1, 4}]`
Before: 1.8s
![before1](https://cloud.githubusercontent.com/assets/1217643/5439474/307f6902-84d4-11e4-993c-076fb6b67a7f.png)
After: 1.3s
![after1](https://cloud.githubusercontent.com/assets/1217643/5439479/4106f038-84d4-11e4-87db-7d02ae55ed16.png)

- `Plot3D[x y / (x ^ 2 + y ^ 2 + 1), {x, -2, 2}, {y, -2, 2}]`
Before: 2.4s
![before2](https://cloud.githubusercontent.com/assets/1217643/5439475/3871c722-84d4-11e4-8d91-d34f65cab924.png)
After: 0.8s
![after2](https://cloud.githubusercontent.com/assets/1217643/5439482/44ec9298-84d4-11e4-8131-37caa45a1828.png)

- `Plot3D[Sin[x y] /(x y), {x, -3, 3}, {y, -3, 3}]`
Before: 2.3s
![before3](https://cloud.githubusercontent.com/assets/1217643/5439477/3b9a1350-84d4-11e4-9beb-53b350fee8bd.png)
After: 2.7s
![after3](https://cloud.githubusercontent.com/assets/1217643/5439485/4755f8ee-84d4-11e4-8eb0-c4ac62254f89.png)

- `Plot3D[Log[x^2 + y], {x, -1, 1}, {y, -1, 1}]`
Before: 1.9s (This plot is incorrect, it shows the magnitude when `Log` becomes complex valued).
![before4](https://cloud.githubusercontent.com/assets/1217643/5439478/3eda992c-84d4-11e4-8c2b-4698f30b7b11.png)
After: 2.4s
![after4](https://cloud.githubusercontent.com/assets/1217643/5439490/4d2115d8-84d4-11e4-9fce-a5d40ab4100d.png)

