### PR TITLE
Added correct indexing for negative steps and check for 0-index

### DIFF
--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -276,10 +276,18 @@ def walk_parts(list_of_list, indices, evaluation, assign_list=None):
                         return False
             if len(index.leaves) > 2:
                 step = index.leaves[2].get_int_value()
+
+            if start == 0 or stop == 0:
+                # index 0 is undefined
+                evaluation.message('Part', 'span', 0)
+                return False
+
             if start is None or step is None:
                 evaluation.message('Part', 'span', index)
                 return False
-            start, stop = python_seq(start, stop)
+
+            start, stop = python_seq(start, stop, step)
+
             for inner in inner_list:
                 if inner.is_atom():
                     evaluation.message('Part', 'partd')
@@ -533,14 +541,31 @@ class LevelQ(Test):
             return False
 
 
-def python_seq(start, stop):
-    if start > 0:
-        start -= 1
-    if stop is not None and stop < 0:
-        stop += 1
-        if stop == 0:
+def python_seq(start, stop, step=+1):
+    if not step: step = +1
+    if step == +1:
+        if start > 0:
+            start -= 1
+        if stop is not None and stop < 0:
+            stop += 1
+            if stop == 0:
+                stop = None
+        return start, stop
+    else:
+        if stop and stop > 0:
+            stop -= 2
+        elif stop and stop < 0:
+            stop -= 1
+        if start and start > 0:
+            start -= 1
+        if not start:
+            start = None
+        if stop == -1:
             stop = None
-    return start, stop
+        elif stop == None:
+            # No stop equals len(list)!
+            stop = -1
+        return start, stop
 
 
 def convert_seq(seq):
@@ -972,7 +997,7 @@ class Take(Builtin):
                 evaluation.message('Take', 'seqs', seq)
                 return
             start, stop, step = seq_tuple
-            py_start, py_stop = python_seq(start, stop)
+            py_start, py_stop = python_seq(start, stop, step)
             for inner in inner_list:
                 if (inner.is_atom() or      # noqa
                     abs(start) > len(inner.leaves) or
@@ -1023,7 +1048,7 @@ class Drop(Builtin):
                 evaluation.message('Drop', 'seqs', seq)
                 return
             start, stop, step = seq_tuple
-            py_start, py_stop = python_seq(start, stop)
+            py_start, py_stop = python_seq(start, stop, step)
             for inner in inner_list:
                 if (inner.is_atom() or  # noqa
                     abs(start) > len(inner.leaves) or


### PR DESCRIPTION
This fixes stuff like 
a = {1,2,3,4,5}
a[[3;;1;;-1]] == {3,2,1}

which previously resulted in {2}.

This should fix #196 