### PR TITLE
Fix gh-pages index repo link

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <!-- HEADER -->
     <div id="header_wrap" class="outer">
         <header class="inner">
-          <a id="forkme_banner" href="https://github.com/sn6uv/Mathics">View on GitHub</a>
+          <a id="forkme_banner" href="https://github.com/mathics/Mathics">View on GitHub</a>
 
           <h1 id="project_title">Mathics</h1>
           <h2 id="project_tagline">A free, light-weight alternative to Mathematica</h2>


### PR DESCRIPTION
Maybe you guys should find a way to make use of mathics.github.io rather than mathics.github.io/Mathics too?