### PR TITLE
The Quit/Quit[] issue was fixed.

### DIFF
--- a/mathics/builtin/assignment.py
+++ b/mathics/builtin/assignment.py
@@ -999,11 +999,15 @@ class Quit(Builtin):
      = x
     """
 
-    rules = {
-        'Quit[]': 'Quit',
-        }
+    
     def apply(self, evaluation):
         'Quit'
+
+        evaluation.definitions.set_user_definitions({})
+        return Symbol('Null')
+
+    def apply2(self, evaluation):
+        'Quit[]'
 
         evaluation.definitions.set_user_definitions({})
         return Symbol('Null')


### PR DESCRIPTION
I just replace the rule by  a new definition. It is not so elegant, but works. By the way, both raise an error if we call from the kernel.

