### PR TITLE
load unevaluated cells

### DIFF
--- a/mathics/web/media/js/inout.js
+++ b/mathics/web/media/js/inout.js
@@ -117,8 +117,10 @@ function setContent(content) {
 	queries.each(function(item) {
 		var li = createQuery(null, true, true);
 		li.textarea.value = item.request;
-		setResult(li.ul, item.results);
-		li.textarea.results = item.results;
+		if( item.results != undefined ) {
+			setResult(li.ul, item.results);
+			li.textarea.results = item.results;
+		}
 	});
 	
 	createSortable();


### PR DESCRIPTION
in the web interface i had trouble loading a worksheet that contained unevaluated cells.
the sheet up to and including the first unevaluated cell would load, the remainder would be
missing.

the save command saves unevaluated cells ok, the load command should also load them. 

the small change within this pull request fixes this.

but i'm not a javascript expert!  checking against undefined may not be the best way
of doing the check.

