### PR TITLE
Global system bug

### DIFF
--- a/mathics/builtin/assignment.py
+++ b/mathics/builtin/assignment.py
@@ -213,11 +213,11 @@ class _SetOperator(object):
             ignore_protection = True
             return True
         elif lhs_name == 'System`$ContextPath':
-            if rhs.has_form('List', None) and all(
-                    valid_context_name(s.get_string_value()) for s in rhs.leaves):
-                evaluation.definitions.context_path = [
-                    s.get_string_value() for s in rhs.leaves]
+            context_path = [s.get_string_value() for s in rhs.get_leaves()]
+            if rhs.has_form('List', None) and all(valid_context_name(s) for s in context_path):
+                evaluation.definitions.set_context_path(context_path)
                 ignore_protection = True
+                return True
             else:
                 evaluation.message(lhs_name, 'cxlist', rhs)
                 return False

--- a/mathics/builtin/assignment.py
+++ b/mathics/builtin/assignment.py
@@ -211,6 +211,7 @@ class _SetOperator(object):
 
             evaluation.definitions.set_current_context(new_context)
             ignore_protection = True
+            return True
         elif lhs_name == 'System`$ContextPath':
             if rhs.has_form('List', None) and all(
                     valid_context_name(s.get_string_value()) for s in rhs.leaves):

--- a/mathics/builtin/scoping.py
+++ b/mathics/builtin/scoping.py
@@ -315,6 +315,19 @@ class ContextPath(Predefined):
 
     >> $ContextPath // InputForm
      = {"Global`", "System`"}
+
+    #> $ContextPath = Sin[2]
+     : Sin[2] is not a list of valid context names ending in `.
+     = Sin[2]
+
+    #> x`x = 1; x
+     = x
+    #> $ContextPath = {"x`"};
+    #> x
+     = 1
+    #> System`$ContextPath
+     = {x`}
+    #> $ContextPath = {"Global`", "System`"};
     """
 
     name = '$ContextPath'

--- a/mathics/builtin/scoping.py
+++ b/mathics/builtin/scoping.py
@@ -347,10 +347,12 @@ class Begin(Builtin):
      : No previous context defined.
      = Global`
 
-    #> Begin["`System`"]
-     = Global`System`
+    #> Begin["`test`"]
+     = Global`test`
+    #> Context[]
+     = Global`test`
     #> End[]
-     = Global`System`
+     = Global`test`
     """
 
     rules = {
@@ -358,7 +360,8 @@ class Begin(Builtin):
              Unprotect[System`Private`$ContextStack];
              System`Private`$ContextStack = Append[System`Private`$ContextStack, $Context];
              Protect[System`Private`$ContextStack];
-             $Context = context
+             $Context = context;
+             $Context
         ''',
     }
 

--- a/mathics/builtin/scoping.py
+++ b/mathics/builtin/scoping.py
@@ -346,6 +346,11 @@ class Begin(Builtin):
     >> End[]
      : No previous context defined.
      = Global`
+
+    #> Begin["`System`"]
+     = Global`System`
+    #> End[]
+     = Global`System`
     """
 
     rules = {


### PR DESCRIPTION
Hit this trying to get the ```KnotTheory` ``` package working in Mathics.

```mathematica
Begin["`System`"]
```
was returning ``` `System` ```, not the fully qualified ```Global`System```. It turns out `$Context` was being set first correctly to ```Global`System` ``` and reset then to ``` `System` ```.

@bnjones does this fix look right to you?