### PR TITLE
String expression

### DIFF
--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -443,6 +443,13 @@ class Except(PatternObject):
 
     >> Cases[{a, 0, b, 1, c, 2, 3}, Except[1, _Integer]]
      = {0, 2, 3}
+
+    Except can also be used for string expressions:
+    >> StringReplace["Hello world!", Except[LetterCharacter] -> ""]
+     = Helloworld
+
+    #> StringReplace["abc DEF 123!", Except[LetterCharacter, WordCharacter] -> "0"]
+     = abc DEF 000!
     """
 
     arg_counts = [1, 2]

--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -389,6 +389,13 @@ class Alternatives(BinaryOperator, PatternObject):
 
     >> a+b+c+d/.(a|b)->t
      = c + d + 2 t
+
+    Alternatives can also be used for string expressions
+    >> StringReplace["0123 3210", "1" | "2" -> "X"]
+     = 0XX3 3XX0
+
+    #> StringReplace["h1d9a f483", DigitCharacter | WhitespaceCharacter -> ""]
+     = hdaf
     """
 
     operator = '|'
@@ -971,6 +978,11 @@ class Repeated(PostfixOperator, PatternObject):
      = Repeated[1]
     #> 8^^1.. // FullForm   (* Mathematica gets this wrong *)
      = Repeated[1]
+
+    #> StringReplace["010110110001010", "01".. -> "a"]
+     = a1a100a0
+    #> StringMatchQ[#, "a" ~~ ("b"..) ~~ "a"] &/@ {"aa", "aba", "abba"}
+     = {False, True, True}
     """
 
     messages = {
@@ -1045,6 +1057,9 @@ class RepeatedNull(Repeated):
      = RepeatedNull[1]
     #> 8^^1... // FullForm   (* Mathematica gets this wrong *)
      = RepeatedNull[1]
+
+    #> StringMatchQ[#, "a" ~~ ("b"...) ~~ "a"] &/@ {"aa", "aba", "abba"}
+     = {True, True, True}
     """
 
     operator = '...'

--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -835,6 +835,9 @@ class Blank(_Blank):
     'Blank' only matches a single expression:
     >> MatchQ[f[1, 2], f[_]]
      = False
+
+    #> StringReplace["hello world!", _ -> "x"]
+     = xxxxxxxxxxxx
     """
     rules = {
         'MakeBoxes[Verbatim[Blank][], f:StandardForm|TraditionalForm|OutputForm|InputForm]': '"_"',
@@ -884,6 +887,9 @@ class BlankSequence(_Blank):
      = {{a, b}, {d}}
     #> a + b + c + d /. Plus[x__, c] -> {x}
      = {a, b, d}
+
+    #> StringReplace[{"ab", "abc", "abcd"}, "b" ~~ __ -> "x"]
+     = {ab, ax, ax}
     """
     rules = {
         'MakeBoxes[Verbatim[BlankSequence][], f:StandardForm|TraditionalForm|OutputForm|InputForm]': '"__"',
@@ -934,6 +940,9 @@ class BlankNullSequence(_Blank):
      = ___symbol
     #> ___symbol //FullForm
      = BlankNullSequence[symbol]
+
+    #> StringReplace[{"ab", "abc", "abcd"}, "b" ~~ ___ -> "x"]
+     = {ax, ax, ax}
     """
 
     rules = {

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -420,8 +420,10 @@ class StringSplit(Builtin):
             re_patts.append(py_p)
 
         result = [py_string]
+        # Python's re.split includes the text of groups if they are capturing.
+        # To handle this difference ignore strings that match the pattern.
         for re_patt in re_patts:
-            result = [t for s in result for t in re.split(re_patt, s)]
+            result = [t for s in result for t in re.split(re_patt, s) if not re.match(re_patt, t)]
         return from_python([x for x in result if x != ''])
 
 

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -36,7 +36,7 @@ def to_regex(expr):
             # further e.g. StringExpression["abc", RegularExpression[regex2]].
             return regex
         except re.error:
-            return None # invalid regex
+            return None     # invalid regex
 
     if isinstance(expr, Symbol):
         return {
@@ -120,11 +120,11 @@ def mathics_split(patt, string, flags):
     For these reasons we implement our own split.
     '''
     # (start, end) indices of splits
-    indices =  list((m.start(), m.end()) for m in re.finditer(patt, string, flags))
+    indices = list((m.start(), m.end()) for m in re.finditer(patt, string, flags))
 
     # (start, end) indices of stuff to keep
     indices = [(None, 0)] + indices + [(len(string), None)]
-    indices = [(indices[i][1], indices[i+1][0]) for i in range(len(indices) - 1)]
+    indices = [(indices[i][1], indices[i + 1][0]) for i in range(len(indices) - 1)]
 
     # slice up the string
     return [string[start:stop] for start, stop in indices]

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -65,10 +65,14 @@ def to_regex(expr):
         return r'(.|\n)+'
     if expr.has_form('BlankNullSequence', 0):
         return r'(.|\n)*'
-    if expr.has_form('Except', 1):
-        leaf = to_regex(expr.leaves[0])
-        if leaf is not None:
-            return '^{0}'.format(leaf)
+    if expr.has_form('Except', 1, 2):
+        if len(expr.leaves) == 1:
+            leaves = [expr.leaves[0], Expression('Blank')]
+        else:
+            leaves = [expr.leaves[0], expr.leaves[1]]
+        leaves = [to_regex(leaf) for leaf in leaves]
+        if all(leaf is not None for leaf in leaves):
+            return '(?!{0}){1}'.format(*leaves)
     if expr.has_form('Characters', 1):
         leaf = expr.leaves[0].get_string_value()
         if leaf is not None:

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -438,6 +438,11 @@ class StringMatchQ(Builtin):
     ## Words containing nonword characters
     #> StringMatchQ[{"monkey", "don't", "AAA", "S&P"}, ___ ~~ Except[WordCharacter] ~~ ___]
      = {False, True, False, True}
+
+    ## Try to match a literal number
+    #> StringMatchQ[1.5, NumberString]
+     : String or list of strings expected at position 1 in StringMatchQ[1.5, NumberString].
+     = StringMatchQ[1.5, NumberString]
     """
 
     attributes = ('Listable',)
@@ -445,6 +450,10 @@ class StringMatchQ(Builtin):
     options = {
         'IgnoreCase': 'False',
         'SpellingCorrections': 'None',
+    }
+
+    messages = {
+        'strse': 'String or list of strings expected at position `1` in `2`.',
     }
 
     def apply(self, string, patt, evaluation, options):

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -9,12 +9,12 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 
 import sys
+import re
 
 import six
 from six.moves import range
 from six import unichr
 
-import re
 from mathics.builtin.base import BinaryOperator, Builtin, Test
 from mathics.core.expression import (Expression, Symbol, String, Integer,
                                      from_python)
@@ -92,7 +92,7 @@ def to_regex(expr):
     return None
 
 
-class StringExpression(Builtin):
+class StringExpression(BinaryOperator):
     """
     <dl>
     <dt>'StringExpression[s_1, s_2, ...]'

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -349,7 +349,15 @@ class EndOfLine(Builtin):
 
 
 class WordBoundary(Builtin):
-    pass
+    """
+    <dl>
+    <dt>'WordBoundary'
+      <dd>represents the boundary between words.
+    </dl>
+
+    >> StringReplace["apple banana orange artichoke", "e" ~~ WordBoundary -> "E"]
+     = applE banana orangE artichokE
+    """
 
 
 class LetterCharacter(Builtin):

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -44,7 +44,7 @@ def to_regex(expr):
             'System`Whitespace': r'\s+',
             'System`DigitCharacter': r'\d',
             'System`WhitespaceCharacter': r'\s',
-            'System`WordCharacter': r'\s',
+            'System`WordCharacter': r'[0-9a-zA-Z]',
             'System`StartOfLine': r'^',
             'System`EndOfLine': r'$',
             'System`StartOfString': r'\A',
@@ -255,7 +255,21 @@ class WhitespaceCharacter(Builtin):
 
 
 class WordCharacter(Builtin):
-    pass
+    r"""
+    <dl>
+    <dt>'WordCharacter'
+      <dd>represents a single letter or digit character.
+    </dl>
+
+    >> StringMatchQ[#, WordCharacter] &/@ {"1", "a", "A", ",", " "}
+     = {True, True, True, False, False}
+
+    Test whether a string is alphanumeric:
+    >> StringMatchQ["abc123DEF", WordCharacter..]
+     = True
+    >> StringMatchQ["$b;123", WordCharacter..]
+     = False
+    """
 
 
 class StartOfString(Builtin):

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -216,7 +216,18 @@ class DigitCharacter(Builtin):
 
 
 class Whitespace(Builtin):
-    pass
+    r"""
+    <dl>
+    <dt>'Whitespace'
+      <dd>represents a sequence of whitespace characters.
+    </dl>
+
+    >> StringSplit["a  \n b \r\n c d", Whitespace]
+     = {a, b, c, d}
+
+    >> StringReplace[" this has leading and trailing whitespace \n ", (StartOfString ~~ Whitespace) | (Whitespace ~~ EndOfString) -> ""] <> " removed" // FullForm
+     = "this has leading and trailing whitespace removed"
+    """
 
 
 class WhitespaceCharacter(Builtin):

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -138,7 +138,6 @@ class RegularExpression(Builtin):
 
     #> RegularExpression["[abc]"]
      = RegularExpression[[abc]]
-
     """
 
 
@@ -258,6 +257,7 @@ class HexidecimalCharacter(Builtin):
      = {True, True, True, False, False, False, False}
     """
 
+
 class StringMatchQ(Builtin):
     """
     >> StringMatchQ["abc", "abc"]
@@ -279,8 +279,8 @@ class StringMatchQ(Builtin):
 
         re_patt = to_regex(patt)
         if re_patt is None:
-                return evaluation.message('StringExpression', 'invld', patt,
-                                          Expression ('StringExpression', patt))
+            return evaluation.message('StringExpression', 'invld', patt,
+                                      Expression('StringExpression', patt))
         # force matching whole of string
         re_patt = '(?:' + re_patt + ')'
         if not re_patt.endswith(r'\Z'):
@@ -507,7 +507,6 @@ class StringReplace(Builtin):
     #> StringReplace["  Have a nice day.  ", (StartOfString ~~ Whitespace) | (Whitespace ~~ EndOfString) -> ""] // FullForm
      = "Have a nice day."
     """
-
 
     # TODO Special Characters
     """

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -150,7 +150,25 @@ class NumberString(Builtin):
 
 
 class DigitCharacter(Builtin):
-    pass
+    """
+    <dl>
+    <dt>'DigitCharacter'
+      <dd>represents the digits 0-9.
+    </dl>
+
+    >> StringMatchQ["1", DigitCharacter]
+     = True
+    >> StringMatchQ["a", DigitCharacter]
+     = False
+    >> StringMatchQ["12", DigitCharacter]
+     = False
+
+    >> StringMatchQ["123245", DigitCharacter..]
+     = True
+
+    #> StringMatchQ["123245a6", DigitCharacter..]
+     = False
+    """
 
 
 class Whitespace(Builtin):

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -93,9 +93,37 @@ def to_regex(expr):
 
 
 class StringExpression(Builtin):
+    """
+    <dl>
+    <dt>'StringExpression[s_1, s_2, ...]'
+      <dd>represents a sequence of strings and symbolic string objects $s_i$.
+    </dl>
+
+    >> "a" ~~ "b" // FullForm
+     = "ab"
+
+    #> "a" ~~ "b" ~~ "c" // FullForm
+     = "abc"
+
+    #> a ~~ b
+     = a ~~ b
+    """
+
+    operator = '~~'
+    precedence = 135
+    attributes = ('Flat', 'OneIdentity', 'Protected')
+
     messages = {
         'invld': 'Element `1` is not a valid string or pattern element in `2`.',
     }
+
+    def apply(self, args, evaluation):
+        'StringExpression[args__String]'
+        args = args.get_sequence()
+        args = [arg.get_string_value() for arg in args]
+        if None in args:
+            return
+        return String(''.join(args))
 
 
 class RegularExpression(Builtin):

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -434,7 +434,13 @@ class StringMatchQ(Builtin):
      = False
     #> StringMatchQ["abc", "ABC", IgnoreCase -> True]
      = True
+
+    ## Words containing nonword characters
+    #> StringMatchQ[{"monkey", "don't", "AAA", "S&P"}, ___ ~~ Except[WordCharacter] ~~ ___]
+     = {False, True, False, True}
     """
+
+    attributes = ('Listable',)
 
     options = {
         'IgnoreCase': 'False',

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -204,7 +204,19 @@ class WordBoundary(Builtin):
 
 
 class LetterCharacter(Builtin):
-    pass
+    """
+    <dl>
+    <dt>'LetterCharacter'
+      <dd>represents the letters a-z and A-Z.
+    </dl>
+
+    >> StringMatchQ[#, LetterCharacter] & /@ {"a", "1", "A", " ", "."}
+     = {True, False, True, False, False}
+
+    LetterCharacter does not match unicode characters.
+    >> StringMatchQ["\[Lambda]", LetterCharacter]
+     = False
+    """
 
 
 class HexidecimalCharacter(Builtin):

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -22,7 +22,7 @@ from mathics.core.expression import (Expression, Symbol, String, Integer,
 
 def string_expression_to_regex(expr):
     if isinstance(expr, String):
-        return re.escape(expr.get_string_value())
+        return '(' + re.escape(expr.get_string_value()) + ')'
     if expr.has_form('RegularExpression', 1):
         return expr.leaves[0].get_string_value()
     if expr.has_symbol('Whitespace'):
@@ -349,9 +349,8 @@ class StringReplace(Builtin):
             py_n = 0
         else:
             py_n = n.get_int_value()
-            if py_n is None py_n < 0:
-                return evaluation.message(
-                    'StringReplace', 'innf', Integer(3), expr)
+            if py_n is None or py_n < 0:
+                return evaluation.message('StringReplace', 'innf', Integer(3), expr)
 
         def do_subs(py_stri):
             for py_s, py_sp in py_rules:

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -100,6 +100,17 @@ def to_regex(expr):
     return None
 
 
+def anchor_pattern(patt):
+    '''
+    anchors a regex in order to force matching against an entire string.
+    '''
+    if not patt.endswith(r'\Z'):
+        patt = patt + r'\Z'
+    if not patt.startswith(r'\A'):
+        patt = r'\A' + patt
+    return patt
+
+
 class StringExpression(BinaryOperator):
     """
     <dl>
@@ -415,11 +426,7 @@ class StringMatchQ(Builtin):
             return evaluation.message('StringExpression', 'invld', patt,
                                       Expression('StringExpression', patt))
 
-        # force matching of the entire string
-        if not re_patt.endswith(r'\Z'):
-            re_patt = re_patt + r'\Z'
-        if not re_patt.startswith(r'\A'):
-            re_patt = r'\A' + re_patt
+        re_patt = anchor_pattern(re_patt)
 
         # TODO
         flags = re.MULTILINE
@@ -547,8 +554,9 @@ class StringSplit(Builtin):
         # Python's re.split includes the text of groups if they are capturing.
         # To handle this difference ignore strings that match the pattern.
         for re_patt in re_patts:
+            anchored_patt = anchor_pattern(re_patt)
             try:
-                result = [t for s in result for t in re.split(re_patt, s, flags=flags) if not re.match(re_patt, t, flags=flags)]
+                result = [t for s in result for t in re.split(re_patt, s, flags=flags) if not re.match(anchored_patt, t, flags=flags)]
             except ValueError as exc:
                 if exc.args != ('split() requires a non-empty pattern match.',):
                     raise exc

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -28,7 +28,11 @@ def to_regex(expr):
     if isinstance(expr, String):
         return re.escape(expr.get_string_value())
     if expr.has_form('RegularExpression', 1):
-        return expr.leaves[0].get_string_value()
+        regex = expr.leaves[0].get_string_value()
+        try:
+            return re.compile(regex)
+        except re.error:
+            return None # invalid regex
 
     if isinstance(expr, Symbol):
         return {
@@ -138,6 +142,11 @@ class RegularExpression(Builtin):
 
     #> RegularExpression["[abc]"]
      = RegularExpression[[abc]]
+
+    ## Mathematica doesn't seem to verify the correctness of regex
+    #> StringSplit["ab23c", RegularExpression["[0-9]++"]]
+     : Element RegularExpression[[0-9]++] is not a valid string or pattern element in RegularExpression[[0-9]++].
+     = StringSplit[ab23c, RegularExpression[[0-9]++]]
     """
 
 

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -248,7 +248,15 @@ class LetterCharacter(Builtin):
 
 
 class HexidecimalCharacter(Builtin):
-    pass
+    """
+    <dl>
+    <dt>'HexidecimalCharacter'
+      <dd>represents the characters 0-9, a-f and A-F.
+    </dl>
+
+    >> StringMatchQ[#, HexidecimalCharacter] & /@ {"a", "1", "A", "x", "H", " ", "."}
+     = {True, True, True, False, False, False, False}
+    """
 
 class StringMatchQ(Builtin):
     """

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -217,6 +217,9 @@ class StringMatchQ(Builtin):
 
     >> StringMatchQ["abc", "abd"]
      = False
+
+    >> StringMatchQ["15a94xcZ6", (DigitCharacter | LetterCharacter)..]
+     = True
     """
 
     def apply(self, string, patt, evaluation):

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -273,7 +273,16 @@ class WordCharacter(Builtin):
 
 
 class StartOfString(Builtin):
-    pass
+    """
+    <dl>
+    <dt>'StartOfString'
+      <dd>represents the start of a string.
+    </dl>
+
+    Test whether strings start with "a":
+    >> StringMatchQ[#, StartOfString ~~ "a" ~~ __] &/@ {"apple", "banana", "artichoke"}
+     = {True, False, True}
+    """
 
 
 class EndOfString(Builtin):

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -286,7 +286,16 @@ class StartOfString(Builtin):
 
 
 class EndOfString(Builtin):
-    pass
+    """
+    <dl>
+    <dt>'EndOfString'
+      <dd>represents the end of a string.
+    </dl>
+
+    Test whether strings end with "e":
+    >> StringMatchQ[#, __ ~~ "e" ~~ EndOfString] &/@ {"apple", "banana", "artichoke"}
+     = {True, False, True}
+    """
 
 
 class StartOfLine(Builtin):

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -222,6 +222,9 @@ class Whitespace(Builtin):
       <dd>represents a sequence of whitespace characters.
     </dl>
 
+    >> StringMatchQ["\r \n", Whitespace]
+     = True
+
     >> StringSplit["a  \n b \r\n c d", Whitespace]
      = {a, b, c, d}
 
@@ -231,7 +234,24 @@ class Whitespace(Builtin):
 
 
 class WhitespaceCharacter(Builtin):
-    pass
+    r"""
+    <dl>
+    <dt>'WhitespaceCharacter'
+      <dd>represents a single whitespace character.
+    </dl>
+
+    >> StringMatchQ["\n", WhitespaceCharacter]
+     = True
+
+    >> StringSplit["a\nb\r\nc\rd", WhitespaceCharacter]
+     = {a, b, c, d}
+
+    For sequences of whitespace characters use 'Whitespace':
+    >> StringMatchQ[" \n", WhitespaceCharacter]
+     = False
+    >> StringMatchQ[" \n", Whitespace]
+     = True
+    """
 
 
 class WordCharacter(Builtin):

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -29,6 +29,8 @@ def to_regex(expr):
         return re.escape(expr.get_string_value())
     if expr.has_form('RegularExpression', 1):
         regex = expr.leaves[0].get_string_value()
+        if regex is None:
+            return regex
         try:
             return re.compile(regex)
         except re.error:
@@ -147,6 +149,10 @@ class RegularExpression(Builtin):
     #> StringSplit["ab23c", RegularExpression["[0-9]++"]]
      : Element RegularExpression[[0-9]++] is not a valid string or pattern element in RegularExpression[[0-9]++].
      = StringSplit[ab23c, RegularExpression[[0-9]++]]
+
+    #> StringSplit["ab23c", RegularExpression[2]]
+     : Element RegularExpression[2] is not a valid string or pattern element in RegularExpression[2].
+     = StringSplit[ab23c, RegularExpression[2]]
     """
 
 

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -78,13 +78,6 @@ def to_regex(expr):
         if None in leaves:
             return None
         return "".join(leaves)
-    if expr.has_form('Longest', 1):
-        return to_regex(expr.leaves[0])
-    if expr.has_form('Shortest', 1):
-        leaf = to_regex(expr.leaves[0])
-        if leaf is not None:
-            return '{0}*?'.format(leaf)
-            # p*?|p+?|p??
     if expr.has_form('Repeated', 1):
         leaf = to_regex(expr.leaves[0])
         if leaf is not None:


### PR DESCRIPTION
Implements some string expression enhancements.

The main idea here is to represent the various string expression components as regex or combinations of regex; see `to_regex`.

I initially tried to workaround some strange behaviour in `re.split` but ended up rewriting it; see `mathics_split`.

TODO:
- [x] `IgnoreCase` option
- [x] figure out multiline mode (on by default)?

Tests/docs for:
- [x] `Alternatives`
- [x] `Repeated` and `RepeatedNull`
- [x] `Blank*`
- [x] `Except`, blocked by #353 

Not implemented:
- `Shortest` and `Longest`
- `StringCases`