### PR TITLE
Avoid computing x^y in PowerMod[x, y, m]

### DIFF
--- a/mathics/builtin/numbertheory.py
+++ b/mathics/builtin/numbertheory.py
@@ -52,11 +52,12 @@ class PowerMod(Builtin):
             return
         if b < 0:
             b = -b
-            if a == 0:
+            try:
+                a = int(sympy.invert(a, m))
+            except sympy.polys.polyerrors.NotInvertible:
                 evaluation.message('PowerMod', 'ninv', a_int, m_int)
                 return
-            a = sympy.invert(a, m)
-        return Integer(sympy.Mod(a ** b, m))
+        return Integer(pow(a, b, m))
 
 
 class Mod(Builtin):


### PR DESCRIPTION
Python's built-in `pow` function can already do modular exponentiation, so we don't need to compute the power and reduce. The only extra part here is to handle errors SymPy raises if it can't find the multiplicative inverse.