### PR TITLE
add MAX_STORED_SIZE setting

### DIFF
--- a/mathics/core/evaluation.py
+++ b/mathics/core/evaluation.py
@@ -302,9 +302,10 @@ class Evaluation(object):
 
         # Prevent too large results from being stored, as this can exceed the
         # DB's max_allowed_packet size
-        data = pickle.dumps(result)
-        if len(data) > 10000:
-            return Symbol('Null')
+        if settings.MAX_STORED_SIZE is not None:
+            data = pickle.dumps(result)
+            if len(data) > settings.MAX_STORED_SIZE:
+                return Symbol('Null')
         return result
 
     def stop(self):

--- a/mathics/settings.py
+++ b/mathics/settings.py
@@ -30,6 +30,10 @@ MAX_RECURSION_DEPTH = 512
 # number of bits of precision for inexact calculations
 MACHINE_PRECISION = 64
 
+# max pickle.dumps() size for storing results in DB
+# historically 10000 was used on public mathics servers
+MAX_STORED_SIZE = None
+
 ADMINS = (
     ('Admin', 'mail@test.com'),
 )


### PR DESCRIPTION
Images in particular are too large to store in the DB (on public web servers), but locally it's probably okay to store them.