### PR TITLE
Fix for issue #375: avoid slots in rule handling D[{...}, ...]

### DIFF
--- a/mathics/builtin/calculus.py
+++ b/mathics/builtin/calculus.py
@@ -131,9 +131,9 @@ class D(SympyFunction):
         # 'Plus @@ MapIndexed[(D[f[Sequence@@ReplacePart[{args}, #2->t]], t] '
         # '/. t->#) * D[#, x]&, {args}]',
 
-        'D[{items___}, x_?NotListQ]':
+        'D[{items___}, x_?NotListQ]': (
             'Function[{System`Private`item}, D[System`Private`item, x]]'
-            ' /@ {items}',
+            ' /@ {items}'),
         'D[f_, {list_List}]': 'D[f, #]& /@ list',
         'D[f_, {list_List, n_Integer?Positive}]': (
             'D[f, Sequence @@ ConstantArray[{list}, n]]'),

--- a/mathics/builtin/calculus.py
+++ b/mathics/builtin/calculus.py
@@ -92,6 +92,10 @@ class D(SympyFunction):
 
     #> Attributes[f] = {}; Apart[f''[x + x]]
      = f''[2 x]
+
+    ## Issue #375
+    #> D[{#^2}, #]
+     = {2 #1}
     """
 
     # TODO
@@ -127,7 +131,9 @@ class D(SympyFunction):
         # 'Plus @@ MapIndexed[(D[f[Sequence@@ReplacePart[{args}, #2->t]], t] '
         # '/. t->#) * D[#, x]&, {args}]',
 
-        'D[{items___}, x_?NotListQ]': 'D[#, x]& /@ {items}',
+        'D[{items___}, x_?NotListQ]':
+            'Function[{System`Private`item}, D[System`Private`item, x]]'
+            ' /@ {items}',
         'D[f_, {list_List}]': 'D[f, #]& /@ list',
         'D[f_, {list_List, n_Integer?Positive}]': (
             'D[f, Sequence @@ ConstantArray[{list}, n]]'),


### PR DESCRIPTION
Use `Function` with named args, avoiding problems if the pattern variables contain slots