### PR TITLE
Graphics boxes for colors

### DIFF
--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -563,6 +563,10 @@ class Times(BinaryOperator, SympyFunction):
         'InputForm: Times[items__]'
         return self.format_times(items, evaluation, op='*')
 
+    def format_standardform(self, items, evaluation):
+        'StandardForm: Times[items__]'
+        return self.format_times(items, evaluation, op=' ')
+
     def format_outputform(self, items, evaluation):
         'OutputForm: Times[items__]'
         return self.format_times(items, evaluation, op=' ')

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -102,6 +102,7 @@ class Builtin(object):
                 if not isinstance(pattern, BaseExpression):
                     pattern = pattern % {'name': name}
                     pattern = parse_builtin_rule(pattern)
+                replace = replace % {'name': name}
                 formatvalues[form].append(Rule(
                     pattern, parse_builtin_rule(replace), system=True))
         for form, formatrules in formatvalues.items():

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -100,6 +100,7 @@ class Builtin(object):
                 if form not in formatvalues:
                     formatvalues[form] = []
                 if not isinstance(pattern, BaseExpression):
+                    pattern = pattern % {'name': name}
                     pattern = parse_builtin_rule(pattern)
                 formatvalues[form].append(Rule(
                     pattern, parse_builtin_rule(replace), system=True))

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -242,7 +242,7 @@ class _Color(_GraphicsElement):
         # way in the notebook, so we restrict the rule to StandardForm.
 
         (('StandardForm', ), '%(name)s[x__]'):
-            'Style[Graphics[{EdgeForm[Black], %(name)s[{x}], Rectangle[]}, ImageSize -> 16], ' +
+            'Style[Graphics[{EdgeForm[Black], %(name)s[x], Rectangle[]}, ImageSize -> 16], ' +
             'ImageSizeMultipliers -> {1, 1}]'
     }
 

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -241,7 +241,7 @@ class _Color(_GraphicsElement):
         # way in the notebook, so we restrict the rule to StandardForm.
 
         (('StandardForm', ), '%(name)s[x__]'):
-            'Style[Graphics[{EdgeForm[Black], x, Rectangle[]}, ImageSize -> 16], ' +
+            'Style[Graphics[{EdgeForm[Black], %(name)s[{x}], Rectangle[]}, ImageSize -> 16], ' +
             'ImageSizeMultipliers -> {1, 1}]'
     }
 

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -241,9 +241,13 @@ class _Color(_GraphicsElement):
         # diminish in size when they appear in lists or rows. we only want the display of colors this
         # way in the notebook, so we restrict the rule to StandardForm.
 
-        (('StandardForm', ), '%(name)s[x__]'):
+        (('StandardForm', ), '%(name)s[x__?NumericQ]'):
             'Style[Graphics[{EdgeForm[Black], %(name)s[x], Rectangle[]}, ImageSize -> 16], ' +
             'ImageSizeMultipliers -> {1, 1}]'
+    }
+
+    rules = {
+        '%(name)s[x_List]': 'Apply[%(name)s, x]',
     }
 
     components_sizes = []
@@ -252,10 +256,7 @@ class _Color(_GraphicsElement):
     def init(self, item=None, components=None):
         super(_Color, self).init(None, item)
         if item is not None:
-            if len(item.leaves) == 1 and item.leaves[0].has_form('List', None):
-                leaves = item.leaves[0].leaves
-            else:
-                leaves = item.leaves
+            leaves = item.leaves
             if len(leaves) in self.components_sizes:
                 components = [value.round_to_float() for value in leaves]
                 if None in components or not all(0 <= c <= 1 for c in components):

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -1274,24 +1274,23 @@ class GraphicsBox(BoxConstruct):
             aspect = aspect_ratio.round_to_float()
 
         image_size = graphics_options['System`ImageSize']
-        try:
-            if isinstance(image_size, Integer):
-                base_width = image_size.get_int_value()
-                base_height = None  # will be computed later in calc_dimensions
-            elif image_size.has_form('System`List', 2):
-                base_width, base_height = ([x.to_number() for x in image_size.leaves] + [0, 0])[:2]
-                aspect = base_height / base_width
-            else:
-                image_size = image_size.get_name()
-                base_width, base_height = {
-                    'System`Automatic': (400, 350),
-                    'System`Tiny': (100, 100),
-                    'System`Small': (200, 200),
-                    'System`Medium': (400, 350),
-                    'System`Large': (600, 500),
-                }.get(image_size, (None, None))
-        except NumberError:
-            raise BoxConstructError
+        if isinstance(image_size, Integer):
+            base_width = image_size.get_int_value()
+            base_height = None  # will be computed later in calc_dimensions
+        elif image_size.has_form('System`List', 2):
+            base_width, base_height = ([x.round_to_float() for x in image_size.leaves] + [0, 0])[:2]
+            if base_width is None or base_height is None:
+                raise BoxConstructError
+            aspect = base_height / base_width
+        else:
+            image_size = image_size.get_name()
+            base_width, base_height = {
+                'System`Automatic': (400, 350),
+                'System`Tiny': (100, 100),
+                'System`Small': (200, 200),
+                'System`Medium': (400, 350),
+                'System`Large': (600, 500),
+            }.get(image_size, (None, None))
         if base_width is None:
             raise BoxConstructError
         if max_width is not None and base_width > max_width:

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -214,8 +214,9 @@ class Graphics(Builtin):
             return content
 
         for option in options:
-            options[option] = Expression(
-                'N', options[option]).evaluate(evaluation)
+            if option not in ('System`ImageSize',):
+                options[option] = Expression(
+                    'N', options[option]).evaluate(evaluation)
         box_name = 'Graphics' + self.box_suffix
         return Expression(box_name, convert(content),
                           *options_to_rules(options))
@@ -1273,10 +1274,10 @@ class GraphicsBox(BoxConstruct):
 
         image_size = graphics_options['System`ImageSize']
         try:
-            if image_size.is_numeric():
-                base_width = int(image_size.to_number())
+            if isinstance(image_size, Integer):
+                base_width = image_size.get_int_value()
                 base_height = None  # will be computed later in calc_dimensions
-            elif image_size.get_head_name() == 'System`List':
+            elif image_size.has_form('System`List', 2):
                 base_width, base_height = ([x.to_number() for x in image_size.leaves] + [0, 0])[:2]
                 aspect = base_height / base_width
             else:

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -2046,3 +2046,4 @@ GRAPHICS_SYMBOLS = frozenset(
     list(element_heads) +
     [element + 'Box' for element in element_heads] +
     list(style_heads))
+

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -1827,8 +1827,8 @@ class _ColorObject(Builtin):
             >> Graphics[{EdgeForm[Black], %(name)s, Disk[]}, ImageSize->Small]
              = -Graphics-
 
-            >> %(name)s // StandardForm
-             = -Graphics-
+            >> %(name)s // ToBoxes
+             = StyleBox[GraphicsBox[...], ...]
         """ % {'name': strip_context(self.get_name()), 'text_name': text_name}
         if self.__doc__ is None:
             self.__doc__ = doc

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -241,7 +241,7 @@ class _Color(_GraphicsElement):
         # diminish in size when they appear in lists or rows. we only want the display of colors this
         # way in the notebook, so we restrict the rule to StandardForm.
 
-        (('StandardForm', ), '%(name)s[x__?NumericQ]'):
+        (('StandardForm', ), '%(name)s[x__?(NumericQ[#] && 0 <= # <= 1&)]'):
             'Style[Graphics[{EdgeForm[Black], %(name)s[x], Rectangle[]}, ImageSize -> 16], ' +
             'ImageSizeMultipliers -> {1, 1}]'
     }

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -314,8 +314,8 @@ class RGBColor(_Color):
     >> RGBColor[0, 1, 0]
      = RGBColor[0, 1, 0]
 
-    >> RGBColor[0, 1, 0] // StandardForm
-     = -Graphics-
+    >> RGBColor[0, 1, 0] // ToBoxes
+     = StyleBox[GraphicsBox[...], ...]
     """
 
     components_sizes = [3, 4]

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -559,7 +559,7 @@ class ToBoxes(Builtin):
 
     Unlike 'MakeBoxes', 'ToBoxes' evaluates its argument:
     >> ToBoxes[a + a]
-     = RowBox[{2, \u2062, a}]
+     = RowBox[{2,  , a}]
 
     >> ToBoxes[a + b]
      = RowBox[{a, +, b}]
@@ -820,7 +820,7 @@ class TableForm(Builtin):
      . -Graphics-   -Graphics-   -Graphics-
 
     #> TableForm[{}]
-     = 
+     =
     """
 
     options = {

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -820,7 +820,7 @@ class TableForm(Builtin):
      . -Graphics-   -Graphics-   -Graphics-
 
     #> TableForm[{}]
-     =
+     = 
     """
 
     options = {

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -247,7 +247,8 @@ class BaseExpression(KeyComparable):
             include_form = False
             if head in formats and len(self.get_leaves()) == 1:
                 expr = self.leaves[0]
-                if not (form == 'System`OutputForm' and head == 'System`StandardForm'):
+                # removing 'True' below breaks the 'RGBColor[1,0,0]//StandardForm' test cases.
+                if True or not (form == 'System`OutputForm' and head == 'System`StandardForm'):
                     form = head
 
                     include_form = True

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -247,8 +247,7 @@ class BaseExpression(KeyComparable):
             include_form = False
             if head in formats and len(self.get_leaves()) == 1:
                 expr = self.leaves[0]
-                # removing 'True' below breaks the 'RGBColor[1,0,0]//StandardForm' test cases.
-                if True or not (form == 'System`OutputForm' and head == 'System`StandardForm'):
+                if not (form == 'System`OutputForm' and head == 'System`StandardForm'):
                     form = head
 
                     include_form = True


### PR DESCRIPTION
Adds little color boxes to colors (i.e. classes derived from `_Color`) like `RGBColor[0, 1, 1]` in `StandardForm`.

This should have been a fairly simple format change, but I ran into obstacles with my new unit test, that should be testing that `RGBColor[0, 1, 0] // StandardForm` is now `-Graphics-`.

The test case didn't work, it just ignored my `//StandardForm` direction. And this was due to some special case handling in `mathics/core/expression.py` involving `OutputForm` and `StandardForm` (that I don't understand). Disabling it (as below) fixes my new test case, but breaks two old test cases, namely: `ToBoxes[a + a]` and `StandardForm[a + b * c]`. Both of these test `StandardForm` expressions (`ToBoxes` defaults to `StandardForm` if no second parameter is given), and they failed, because their test cases expected the `Times` unicode dot symbol. I checked with MMA and I don't think `StandardForm` should have a `Times` dot symbol anywhere. So I changed these test cases to map `Times` to space in `StandardForm` which seems to be the right thing to me. On the other hand, I don't understand what's going on here with this special case I disabled.

I extended `ImageSize` for `Graphics` to allow a width or a {width, height} specification, which was not possible before. The whole `xmax, xmin` handling in `mathics/builtin/graphics.py` seems quite sloppy in regard to `None` values (looks to me like they subtract None values and then return it as int), so I added an `if` there.

The change in `mathics/builtin/base.py` is just about allowing `%(name)s` in format patterns.


