### PR TITLE
Hash[]

### DIFF
--- a/mathics/builtin/files.py
+++ b/mathics/builtin/files.py
@@ -13,7 +13,6 @@ from __future__ import division
 import os
 import io
 import shutil
-import hashlib
 import zlib
 import base64
 import tempfile
@@ -3697,36 +3696,15 @@ class FileHash(Builtin):
 
     def apply(self, filename, hashtype, evaluation):
         'FileHash[filename_String, hashtype_String]'
-        py_hashtype = hashtype.to_python()
-        py_filename = filename.to_python()
-
-        # TODO: MD2?
-        supported_hashes = {
-            'Adler32': zlib.adler32,
-            'CRC32': zlib.crc32,
-            'MD5': lambda s: int(hashlib.md5(s).hexdigest(), 16),
-            'SHA': lambda s: int(hashlib.sha1(s).hexdigest(), 16),
-            'SHA224': lambda s: int(hashlib.sha224(s).hexdigest(), 16),
-            'SHA256': lambda s: int(hashlib.sha256(s).hexdigest(), 16),
-            'SHA384': lambda s: int(hashlib.sha384(s).hexdigest(), 16),
-            'SHA512': lambda s: int(hashlib.sha512(s).hexdigest(), 16),
-        }
-
-        py_hashtype = py_hashtype[1:-1]
-        py_filename = py_filename[1:-1]
-
-        hash_func = supported_hashes.get(py_hashtype)
-        if hash_func is None:
-            return
+        py_filename = filename.get_string_value()
 
         try:
             with mathics_open(py_filename, 'rb') as f:
                 dump = f.read()
         except IOError:
-            evaluation.message('General', 'noopen', filename)
-            return
+            return evaluation.message('General', 'noopen', filename)
 
-        return from_python(hash_func(dump))
+        return evaluation.evaluate(Expression('Hash', String(dump), hashtype))
 
 
 class FileDate(Builtin):

--- a/mathics/builtin/files.py
+++ b/mathics/builtin/files.py
@@ -27,7 +27,7 @@ from six.moves import range
 from six import unichr
 
 from mathics.core.expression import (Expression, Real, Complex, String, Symbol,
-                                     from_python, Integer, BoxError,
+                                     from_python, Integer, BoxError, ByteArray,
                                      valid_context_name)
 from mathics.builtin.base import (Builtin, Predefined, BinaryOperator,
                                   PrefixOperator)
@@ -3704,7 +3704,7 @@ class FileHash(Builtin):
         except IOError:
             return evaluation.message('General', 'noopen', filename)
 
-        return evaluation.evaluate(Expression('Hash', String(dump), hashtype))
+        return Expression('Hash', ByteArray(dump), hashtype).evaluate(evaluation)
 
 
 class FileDate(Builtin):

--- a/mathics/builtin/files.py
+++ b/mathics/builtin/files.py
@@ -27,10 +27,11 @@ from six.moves import range
 from six import unichr
 
 from mathics.core.expression import (Expression, Real, Complex, String, Symbol,
-                                     from_python, Integer, BoxError, ByteArray,
+                                     from_python, Integer, BoxError,
                                      valid_context_name)
 from mathics.builtin.base import (Builtin, Predefined, BinaryOperator,
                                   PrefixOperator)
+from mathics.builtin.numeric import Hash
 from mathics.settings import ROOT_DIR
 
 
@@ -3704,7 +3705,7 @@ class FileHash(Builtin):
         except IOError:
             return evaluation.message('General', 'noopen', filename)
 
-        return Expression('Hash', ByteArray(dump), hashtype).evaluate(evaluation)
+        return Hash.compute(lambda update: update(dump), hashtype.get_string_value())
 
 
 class FileDate(Builtin):

--- a/mathics/builtin/numeric.py
+++ b/mathics/builtin/numeric.py
@@ -579,6 +579,9 @@ class Hash(Builtin):
 
     > Hash[SomeHead[3.1415]]
     = 58042316473471877315442015469706095084
+
+    >> Hash[{a, b, c}, "xyzstr"]
+     = Hash[{a, b, c}, xyzstr]
     """
 
     rules = {

--- a/mathics/builtin/numeric.py
+++ b/mathics/builtin/numeric.py
@@ -565,11 +565,11 @@ class Hash(Builtin):
       <dd>The types supported are "MD5", "Adler32", "CRC32", "SHA", "SHA224", "SHA256", "SHA384", and "SHA512".</dd>
     </dl>
 
-    > Hash["That book was made by Mr. Mark Twain, and he told the truth, mainly."]
-    = 124728405849036592016661111124271805877
+    > Hash["The Adventures of Huckleberry Finn"]
+    = 213425047836523694663619736686226550816
 
-    > Hash["That book was made by Mr. Mark Twain, and he told the truth, mainly.", "SHA256"]
-    = 80205187535742766793368712314651197079792629272387688364300850280559660013913
+    > Hash["The Adventures of Huckleberry Finn", "SHA256"]
+    = 95092649594590384288057183408609254918934351811669818342876362244564858646638
 
     > Hash[1/3]
     = 56073172797010645108327809727054836008

--- a/mathics/builtin/numeric.py
+++ b/mathics/builtin/numeric.py
@@ -14,6 +14,8 @@ from __future__ import absolute_import
 
 import sympy
 import mpmath
+import hashlib
+import zlib
 from six.moves import range
 
 from mathics.builtin.base import Builtin, Predefined
@@ -539,3 +541,70 @@ class IntegerDigits(Builtin):
                 digits = [0] * (nr_elements - len(digits)) + digits
 
         return Expression('List', *digits)
+
+
+class _ZLibHash:  # make zlib hashes behave as if they were from hashlib
+    def __init__(self, fn):
+        self._bytes = b''
+        self._fn = fn
+
+    def update(self, bytes):
+        self._bytes += bytes
+
+    def hexdigest(self):
+        return format(self._fn(self._bytes), 'x')
+
+
+class Hash(Builtin):
+    """
+    <dl>
+    <dt>'Hash[$expr$]'
+      <dd>returns an integer hash for the given $expr$.
+    <dt>'Hash[$expr$, $type$]'
+      <dd>returns an integer hash of the specified $type$ for the given $expr$.</dd>
+      <dd>The types supported are "MD5", "Adler32", "CRC32", "SHA", "SHA224", "SHA256", "SHA384", and "SHA512".</dd>
+    </dl>
+
+    > Hash["That book was made by Mr. Mark Twain, and he told the truth, mainly."]
+    = 124728405849036592016661111124271805877
+
+    > Hash["That book was made by Mr. Mark Twain, and he told the truth, mainly.", "SHA256"]
+    = 80205187535742766793368712314651197079792629272387688364300850280559660013913
+
+    > Hash[1/3]
+    = 56073172797010645108327809727054836008
+
+    > Hash[{a, b, {c, {d, e, f}}}]
+    = 135682164776235407777080772547528225284
+
+    > Hash[SomeHead[3.1415]]
+    = 58042316473471877315442015469706095084
+    """
+
+    rules = {
+        'Hash[expr_]': 'Hash[expr, "MD5"]',
+    }
+
+    attributes = ('Protected', 'ReadProtected')
+
+    # FIXME md2
+    _supported_hashes = {
+        'Adler32': lambda: _ZLibHash(zlib.adler32),
+        'CRC32': lambda: _ZLibHash(zlib.crc32),
+        'MD5': hashlib.md5,
+        'SHA': hashlib.sha1,
+        'SHA224': hashlib.sha224,
+        'SHA256': hashlib.sha256,
+        'SHA384': hashlib.sha384,
+        'SHA512': hashlib.sha512,
+    }
+
+    def apply(self, expr, hashtype, evaluation):
+        'Hash[expr_, hashtype_String]'
+        py_hashtype = hashtype.get_string_value()
+        hash_func = Hash._supported_hashes.get(py_hashtype)
+        if hash_func is None:  # unknown hash function?
+            return  # return Expression
+        h = hash_func()
+        expr.user_hash(h.update)
+        return from_python(int(h.hexdigest(), 16))

--- a/mathics/builtin/numeric.py
+++ b/mathics/builtin/numeric.py
@@ -602,12 +602,15 @@ class Hash(Builtin):
         'SHA512': hashlib.sha512,
     }
 
-    def apply(self, expr, hashtype, evaluation):
-        'Hash[expr_, hashtype_String]'
-        py_hashtype = hashtype.get_string_value()
+    @staticmethod
+    def compute(user_hash, py_hashtype):
         hash_func = Hash._supported_hashes.get(py_hashtype)
         if hash_func is None:  # unknown hash function?
-            return  # return Expression
+            return  # in order to return original Expression
         h = hash_func()
-        expr.user_hash(h.update)
+        user_hash(h.update)
         return from_python(int(h.hexdigest(), 16))
+
+    def apply(self, expr, hashtype, evaluation):
+        'Hash[expr_, hashtype_String]'
+        return Hash.compute(expr.user_hash, hashtype.get_string_value())

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -212,6 +212,13 @@ class BaseExpression(KeyComparable):
         """
         raise NotImplementedError
 
+    def user_hash(self, update):
+        # whereas __hash__ is for internal Mathics purposes like using Expressions as dictionary keys and fast
+        # comparison of elements, user_hash is called for Hash[]. user_hash should strive to give stable results
+        # across versions, whereas __hash__ must not. user_hash should try to hash all the data available, whereas
+        # __hash__ might only hash a sample of the data available.
+        raise NotImplementedError
+
     def same(self, other):
         pass
 
@@ -1198,6 +1205,11 @@ class Expression(BaseExpression):
     def __hash__(self):
         return hash(('Expression', self.head) + tuple(self.leaves))
 
+    def user_hash(self, update):
+        update(("%s>%d>" % (self.get_head_name(), len(self.leaves))).encode('utf8'))
+        for leaf in self.leaves:
+            leaf.user_hash(update)
+
 
 class Atom(BaseExpression):
 
@@ -1351,6 +1363,9 @@ class Symbol(Atom):
     def __hash__(self):
         return hash(('Symbol', self.name))  # to distinguish from String
 
+    def user_hash(self, update):
+        update(b'System`Symbol>' + self.name.encode('utf8'))
+
 
 class Number(Atom):
     def __str__(self):
@@ -1468,6 +1483,8 @@ class Integer(Number):
     def __hash__(self):
         return hash(('Integer', self.value))
 
+    def user_hash(self, update):
+        update(b'System`Integer>' + str(self.value).encode('utf8'))
 
 class Rational(Number):
     def __init__(self, numerator, denominator=None, **kwargs):
@@ -1538,6 +1555,9 @@ class Rational(Number):
 
     def __hash__(self):
         return hash(("Rational", self.value))
+
+    def user_hash(self, update):
+        update(b'System`Rational>' + ('%s>%s' % self.value.as_numer_denom()).encode('utf8'))
 
 
 class Real(Number):
@@ -1671,6 +1691,11 @@ class Real(Number):
         _prec = self.get_precision()
         return hash(("Real", self.to_sympy().n(dps(_prec))))
 
+    def user_hash(self, update):
+        # ignore last 7 binary digits when hashing
+        _prec = self.get_precision()
+        update(b'System`Real>' + str(self.to_sympy().n(dps(_prec))).encode('utf8'))
+
 
 class Complex(Number):
     def __init__(self, real, imag, p=None, **kwargs):
@@ -1766,6 +1791,10 @@ class Complex(Number):
     def __hash__(self):
         return hash(('Complex', self.real, self.imag))
 
+    def user_hash(self, update):
+        update(b'System`Complex>')
+        update(self.real)
+        update(self.imag)
 
 def encode_mathml(text):
     text = text.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
@@ -1943,6 +1972,11 @@ class String(Atom):
 
     def __hash__(self):
         return hash(("String", self.value))
+
+    def user_hash(self, update):
+        # hashing a String is the one case where the user gets the untampered
+        # hash value of the string's text. this corresponds to MMA behavior.
+        update(self.value.encode('utf8'))
 
 
 def get_default_value(name, evaluation, k=None, n=None):

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -1980,24 +1980,6 @@ class String(Atom):
         update(self.value.encode('utf8'))
 
 
-class ByteArray(Atom):
-    def __init__(self, bytes, **kwargs):
-        super(ByteArray, self).__init__(**kwargs)
-        self.bytes = bytearray(bytes)
-
-    def __str__(self):
-        return '(' + ', '.join('%d' % x for x in self.bytes) + ')'
-
-    def same(self, other):
-        return isinstance(other, ByteArray) and self.bytes == other.bytes
-
-    def __hash__(self):
-        return hash(("ByteArray", hashlib.sha1(self.bytes).hexdigest()))
-
-    def user_hash(self, update):
-        update(self.bytes)
-
-
 def get_default_value(name, evaluation, k=None, n=None):
     pos = []
     if k is not None:

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import
 import sympy
 import mpmath
 import re
+import hashlib
 
 from mathics.core.numbers import get_type, dps, prec, min_prec
 from mathics.core.convert import sympy_symbol_prefix, SympyExpression
@@ -1977,6 +1978,24 @@ class String(Atom):
         # hashing a String is the one case where the user gets the untampered
         # hash value of the string's text. this corresponds to MMA behavior.
         update(self.value.encode('utf8'))
+
+
+class ByteArray(Atom):
+    def __init__(self, bytes, **kwargs):
+        super(ByteArray, self).__init__(**kwargs)
+        self.bytes = bytearray(bytes)
+
+    def __str__(self):
+        return '(' + ', '.join('%d' % x for x in self.bytes) + ')'
+
+    def same(self, other):
+        return isinstance(other, ByteArray) and self.bytes == other.bytes
+
+    def __hash__(self):
+        return hash(("ByteArray", hashlib.sha1(self.bytes).hexdigest()))
+
+    def user_hash(self, update):
+        update(self.bytes)
 
 
 def get_default_value(name, evaluation, k=None, n=None):


### PR DESCRIPTION
Mathics currently has FileHash[], but no Hash[]. This PR moves the functionality in FileHash[] to Hash[] and adds a user_hash to all BaseExpression derived classes so they know how to hash themselves with various hash algorithms. Hashing a string produces the original untampered hash, as it does in MMA.