### PR TITLE
RandomChoice[] and RandomSample[]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   global:
     - SYMPY_SRC=sympy-1.0
     - DOC="false"
+    - PYPY_NUMPY="false"
   matrix:
     - CYTHON="false"
     - CYTHON="true"
@@ -25,6 +26,8 @@ matrix:
       env: SYMPY_SRC=master CYTHON="false"
     - python: 3.5
       env: SYMPY_SRC=master CYTHON="false"
+    - python: pypy
+      env: PYPY_NUMPY="true"
   exclude:
     # PyPy is not compatible with Cython
     - python: pypy
@@ -32,12 +35,11 @@ matrix:
     - python: pypy3
       env: CYTHON="true"
   allow_failures:
-    - pypy
-      env: PYPY_NUMPY="true"
     - python: 3.2
     - python: pypy3
     - env: SYMPY_SRC=master CYTHON="false"
     - env: DOC="true" CYTHON="false"
+    - env: PYPY_NUMPY="true"
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
   - 3.3
   - 3.2
   - pypy3
-  - pypy4
 env:
   global:
     - SYMPY_SRC=sympy-1.0
@@ -32,12 +31,11 @@ matrix:
       env: CYTHON="true"
     - python: pypy3
       env: CYTHON="true"
-    # Travis currently does not support PyPy4
-    - python: pypy4
   allow_failures:
+    - pypy
+      env: PYPY_NUMPY="true"
     - python: 3.2
     - python: pypy3
-    - python: pypy4
     - env: SYMPY_SRC=master CYTHON="false"
     - env: DOC="true" CYTHON="false"
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - 3.3
   - 3.2
   - pypy3
+  - pypy4
 env:
   global:
     - SYMPY_SRC=sympy-1.0
@@ -34,6 +35,7 @@ matrix:
   allow_failures:
     - python: 3.2
     - python: pypy3
+    - python: pypy4
     - env: SYMPY_SRC=master CYTHON="false"
     - env: DOC="true" CYTHON="false"
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ matrix:
       env: CYTHON="true"
     - python: pypy3
       env: CYTHON="true"
+    # Travis currently does not support PyPy4
+    - python: pypy4
   allow_failures:
     - python: 3.2
     - python: pypy3

--- a/mathics/builtin/numpy_utils.py
+++ b/mathics/builtin/numpy_utils.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+A couple of helper functions for working with numpy (and a couple of fallbacks, if numpy is unavailable)
+"""
+
+from mathics.core.expression import Expression
+from itertools import chain
+
+try:
+    import numpy
+    _numpy = True
+except ImportError:  # no numpy?
+    _numpy = False
+
+def py_instantiate_elements(a, new_element, d=1):
+    # given a python array 'a' and a python element constructor 'new_element', generate a python array of the
+    # same shape as 'a' with python elements constructed through 'new_element'. 'new_element' will get called
+    # if an array of dimension 'd' is reached.
+
+    e = a[0]
+    depth = 1
+    while depth <= d and isinstance(e, list):
+        e = e[0]
+        depth += 1
+    if d == depth:
+        leaves = [new_element(x) for x in a]
+    else:
+        leaves = [py_instantiate_elements(e, new_element, d) for e in a]
+    return Expression('List', *leaves)
+
+
+def py_stack_along_inner_axis(a):
+    # explanation of functionality: see numpy version of _stack_array above
+
+    if not isinstance(a[0], list):
+        return list(chain(a))
+    else:
+        return [py_stack_along_inner_axis([x[i] for x in a]) for i in range(len(a[0]))]
+
+if _numpy:
+    def instantiate_elements(a, new_element, d=1):
+        # given a numpy array 'a' and a python element constructor 'new_element', generate a python array of the
+        # same shape as 'a' with python elements constructed through 'new_element'. 'new_element' will get called
+        # if an array of dimension 'd' is reached.
+
+        if len(a.shape) == d:
+            leaves = [new_element(x) for x in a]
+        else:
+            leaves = [instantiate_elements(e, new_element, d) for e in a]
+        return Expression('List', *leaves)
+
+    def stack_along_inner_axis(a):
+        # numpy.stack with axis=-1 stacks arrays along the most inner axis:
+
+        # e.g. numpy.stack([ [1, 2], [3, 4] ], axis=-1)
+        # gives: array([ [1, 3], [2, 4] ])
+
+        # e.g. numpy.stack([ [[1, 2], [3, 4]], [[4, 5], [6, 7]] ], axis=-1)
+        # gives: array([[[1, 4], [2, 5]], [[3, 6], [4, 7]]])
+
+        return numpy.stack(a, axis=-1)
+else:
+    # If numpy is not available, we define the following fallbacks that are useful for implementing a similar
+    # logic in pure python without numpy. They obviously work on regular python array though, not numpy arrays.
+
+    instantiate_elements = py_instantiate_elements
+    stack_along_inner_axis = py_stack_along_inner_axis
+
+

--- a/mathics/builtin/randomnumbers.py
+++ b/mathics/builtin/randomnumbers.py
@@ -673,3 +673,8 @@ class RandomSample(_RandomSelection):
      """
 
     _replace = False
+
+if not _numpy:  # hide symbols from non-numpy envs
+    _RandomSelection = None
+    RandomChoice = None
+    RandomSample = None

--- a/mathics/builtin/randomnumbers.py
+++ b/mathics/builtin/randomnumbers.py
@@ -16,6 +16,8 @@ import six.moves.cPickle as pickle
 import binascii
 import hashlib
 import numpy
+import time
+import os
 
 from mathics.builtin.base import Builtin
 from mathics.core.expression import (Integer, String, Symbol, Real, Expression,
@@ -75,7 +77,8 @@ class RandomEnv:
         return numpy.random.choice(n, size=size, replace=replace, p=p)
 
     def seed(self, x=None):
-        # numpy implementation might be different from the old python impl.
+        if x is None:  # numpy does not know to seed itself randomly
+            x = int(time.time() * 1000) ^ hash(os.urandom(16))
         # for numpy, seed must be convertible to 32 bit unsigned integer.
         numpy.random.seed(abs(x) & 0xffffffff)
 
@@ -138,6 +141,12 @@ class SeedRandom(Builtin):
 
     String seeds are supported as well:
     >> SeedRandom["Mathics"]
+    >> RandomInteger[100]
+     = ...
+
+    Calling 'SeedRandom' without arguments will seed the random
+    number generator to a random state:
+    >> SeedRandom[]
     >> RandomInteger[100]
      = ...
 
@@ -536,10 +545,10 @@ class RandomChoice(_RandomSelection):
      = {c, a, c, c, a, a, c, b, c, c, c, c, a, c, b, a, b, b, b, b}
     >> SeedRandom[42]
     >> RandomChoice[{"a", {1, 2}, x, {}}, 10]
-     = {x, {}, a, x, x, {}, a, a, x, {1,2}}
+     = {x, {}, a, x, x, {}, a, a, x, {1, 2}}
     >> SeedRandom[42]
     >> RandomChoice[{a, b, c}, {5, 2}]
-     = {{c, b}, {a, b}, {b, b}, {b, a}, {a, b}}
+     = {{c, a}, {c, c}, {a, a}, {c, b}, {c, c}}
     >> SeedRandom[42]
     >> RandomChoice[{1, 100, 5} -> {a, b, c}, 20]
      = {b, b, b, b, b, b, b, b, b, b, b, c, b, b, b, b, b, b, b, b}
@@ -584,7 +593,7 @@ class RandomSample(_RandomSelection):
      = {{1, 2}, {}, a}
     >> SeedRandom[42]
     >> RandomSample[Range[100], {2, 3}]
-     = {84, 54, 71}, {46, 45, 40}}
+     = {{84, 54, 71}, {46, 45, 40}}
     >> SeedRandom[42]
     >> RandomSample[Range[100] -> Range[100], 5]
      = {62, 98, 86, 78, 40}

--- a/mathics/builtin/randomnumbers.py
+++ b/mathics/builtin/randomnumbers.py
@@ -582,7 +582,7 @@ class _RandomSelection(_RandomBase):
                 return evaluation.message(self.get_name(), 'wghtv', weights), None
             weights = norm_weights
 
-        py_weights = weights.to_python() if is_proper_spec else None
+        py_weights = weights.to_python(n_evaluation=evaluation) if is_proper_spec else None
         if (py_weights is None) or (not all(isinstance(w, (int, float)) and w >= 0 for w in py_weights)):
             return evaluation.message(self.get_name(), 'wghtv', weights), None
 

--- a/mathics/builtin/randomnumbers.py
+++ b/mathics/builtin/randomnumbers.py
@@ -506,8 +506,86 @@ class _RandomSelection(_RandomBase):
 
 
 class RandomChoice(_RandomSelection):
+    """
+    <dl>
+    <dt>'RandomChoice[$items$]'
+        <dd>randomly picks one item from $items$.
+    <dt>'RandomChoice[$items$, $n$]'
+        <dd>randomly picks $n$ items from $items$. Each pick in the $n$ picks happens from the
+        given set of $items$, so each item can be picked any number of times.
+    <dt>'RandomChoice[$items$, {$n1$, $n2$, ...}]'
+        <dd>randomly picks items from $items$ and arranges the picked items in the nested list
+        structure described by {$n1$, $n2$, ...}.
+    <dt>'RandomChoice[$weights$ -> $items$, $n$]'
+        <dd>randomly picks $n$ items from $items$ and uses the corresponding numeric values in
+        $weights$ to determine how probable it is for each item in $items$ to get picked (in the
+        long run, items with higher weights will get picked more often than ones with lower weight).
+    <dt>'RandomChoice[$weights$ -> $items$]'
+        <dd>randomly picks one items from $items$ using weights $weights$.
+    <dt>'RandomChoice[$weights$ -> $items$, {$n1$, $n2$, ...}]'
+        <dd>randomly picks a structured list of items from $items$ using weights $weights$.
+    </dl>
+
+    >> SeedRandom[42]
+    >> RandomChoice[{a, b, c}]
+     = {c}
+    >> SeedRandom[42]
+    >> RandomChoice[{a, b, c}, 20]
+     = {c, a, c, c, a, a, c, b, c, c, c, c, a, c, b, a, b, b, b, b}
+    >> SeedRandom[42]
+    >> RandomChoice[{"a", {1, 2}, x, {}}, 10]
+     = {x, {}, a, x, x, {}, a, a, x, {1,2}}
+    >> SeedRandom[42]
+    >> RandomChoice[{a, b, c}, {5, 2}]
+     = {{c, b}, {a, b}, {b, b}, {b, a}, {a, b}}
+    >> SeedRandom[42]
+    >> RandomChoice[{1, 100, 5} -> {a, b, c}, 20]
+     = {b, b, b, b, b, b, b, b, b, b, b, c, b, b, b, b, b, b, b, b}
+     """
+
     _replace = True
 
 
 class RandomSample(_RandomSelection):
+    """
+    <dl>
+    <dt>'RandomSample[$items$]'
+        <dd>randomly picks one item from $items$.
+    <dt>'RandomSample[$items$, $n$]'
+        <dd>randomly picks $n$ items from $items$. Each pick in the $n$ picks happens after the
+        previous items picked have been removed from $items$, so each item can be picked at most
+        once.
+    <dt>'RandomSample[$items$, {$n1$, $n2$, ...}]'
+        <dd>randomly picks items from $items$ and arranges the picked items in the nested list
+        structure described by {$n1$, $n2$, ...}. Each item gets picked at most once.
+    <dt>'RandomSample[$weights$ -> $items$, $n$]'
+        <dd>randomly picks $n$ items from $items$ and uses the corresponding numeric values in
+        $weights$ to determine how probable it is for each item in $items$ to get picked (in the
+        long run, items with higher weights will get picked more often than ones with lower weight).
+        Each item gets picked at most once.
+    <dt>'RandomSample[$weights$ -> $items$]'
+        <dd>randomly picks one items from $items$ using weights $weights$. Each item gets picked
+        at most once.
+    <dt>'RandomSample[$weights$ -> $items$, {$n1$, $n2$, ...}]'
+        <dd>randomly picks a structured list of items from $items$ using weights $weights$. Each
+        item gets picked at most once.
+    </dl>
+
+    >> SeedRandom[42]
+    >> RandomSample[{a, b, c}]
+     = {a}
+    >> SeedRandom[42]
+    >> RandomSample[{a, b, c, d, e, f, g, h}, 7]
+     = {b, f, a, h, c, e, d}
+    >> SeedRandom[42]
+    >> RandomSample[{"a", {1, 2}, x, {}}, 3]
+     = {{1, 2}, {}, a}
+    >> SeedRandom[42]
+    >> RandomSample[Range[100], {2, 3}]
+     = {84, 54, 71}, {46, 45, 40}}
+    >> SeedRandom[42]
+    >> RandomSample[Range[100] -> Range[100], 5]
+     = {62, 98, 86, 78, 40}
+     """
+
     _replace = False

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,15 @@ exec(compile(open('mathics/version.py').read(), 'mathics/version.py', 'exec'))
 
 is_PyPy = (platform.python_implementation() == 'PyPy')
 
+INSTALL_REQUIRES = []
+DEPENDENCY_LINKS = []
+
+if is_PyPy:
+    DEPENDENCY_LINKS += ['git+https://bitbucket.org/pypy/numpy.git#egg=pypy_numpy-1.8']
+    INSTALL_REQUIRES += ['pypy_numpy>=1.8']
+else:
+    INSTALL_REQUIRES += ['numpy>=1.8']
+
 try:
     if is_PyPy:
         raise ImportError
@@ -49,7 +58,6 @@ try:
 except ImportError:
     EXTENSIONS = []
     CMDCLASS = {}
-    INSTALL_REQUIRES = []
 else:
     EXTENSIONS = {
         'core': ['expression', 'numbers', 'rules', 'pattern'],
@@ -60,10 +68,10 @@ else:
                   ['mathics/%s/%s.py' % (parent, module)])
         for parent, modules in EXTENSIONS.items() for module in modules]
     CMDCLASS = {'build_ext': build_ext}
-    INSTALL_REQUIRES = ['cython>=0.15.1']
+    INSTALL_REQUIRES += ['cython>=0.15.1']
 
 # General Requirements
-INSTALL_REQUIRES += ['sympy==1.0', 'numpy>=1.8', 'django >= 1.8, < 1.9', 'ply==3.8',
+INSTALL_REQUIRES += ['sympy==1.0', 'django >= 1.8, < 1.9', 'ply==3.8',
                      'mpmath>=0.19', 'python-dateutil', 'colorama', 'six>=1.10']
 
 
@@ -160,6 +168,7 @@ setup(
     ],
 
     install_requires=INSTALL_REQUIRES,
+    dependency_links=DEPENDENCY_LINKS,
 
     package_data={
         'mathics': [

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ mathics-users@googlegroups.com and ask for help.
 
 import sys
 import platform
+import os
 from setuptools import setup, Command, Extension
 
 # Ensure user has the correct Python version
@@ -46,7 +47,7 @@ INSTALL_REQUIRES = []
 DEPENDENCY_LINKS = []
 
 if is_PyPy:
-    if False:  # FIXME check for >= PyPy4
+    if os.environ.get('PYPY_NUMPY') == 'true':
         DEPENDENCY_LINKS += ['git+https://bitbucket.org/pypy/numpy.git#egg=pypy_numpy-1.8']
         INSTALL_REQUIRES += ['pypy_numpy>=1.8']
 else:

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ else:
     INSTALL_REQUIRES = ['cython>=0.15.1']
 
 # General Requirements
-INSTALL_REQUIRES += ['sympy==1.0', 'django >= 1.8, < 1.9', 'ply==3.8',
+INSTALL_REQUIRES += ['sympy==1.0', 'numpy>=1.8', 'django >= 1.8, < 1.9', 'ply==3.8',
                      'mpmath>=0.19', 'python-dateutil', 'colorama', 'six>=1.10']
 
 

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,9 @@ INSTALL_REQUIRES = []
 DEPENDENCY_LINKS = []
 
 if is_PyPy:
-    DEPENDENCY_LINKS += ['git+https://bitbucket.org/pypy/numpy.git#egg=pypy_numpy-1.8']
-    INSTALL_REQUIRES += ['pypy_numpy>=1.8']
+    if False:  # FIXME check for >= PyPy4
+        DEPENDENCY_LINKS += ['git+https://bitbucket.org/pypy/numpy.git#egg=pypy_numpy-1.8']
+        INSTALL_REQUIRES += ['pypy_numpy>=1.8']
 else:
     INSTALL_REQUIRES += ['numpy>=1.8']
 


### PR DESCRIPTION
Adds RandomChoice[] and RandomSample[]. These two need numpy installed.

I rewired RandomInteger[] et al. to numpy (if it's installed), as there should be one consistent random number provider for the system that attaches to one random generator state, which can be set, reset, etc.. Starting to have different random generator states for e.g. RandomInteger[] and RandomChoice[] (and ImageRandom[] and others in the future for that matter) would surely spell disaster. So if numpy is available, everything is based on the numpy generator now.

If numpy is not installed (e.g. for PyPy) the implementation falls back and is equivalent in its results to the old implementation. Then, however, RandomChoice[] and RandomSample[] are not available. They could be added through adding a python only implementation in NoNumPyRandomEnv.randchoice().

I adjusted setup.py to pull the PyPy-numpy package for PyPy (https://bitbucket.org/pypy/numpy). The install works and downloads the package, but this then says that it needs PyPy4 to run, which is currently not supported by TravisCI. So I commented it out for now. It might be an option for the future though.
