### PR TITLE
avoid unwanted reevaluations

### DIFF
--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -1103,6 +1103,9 @@ class Expression(BaseExpression):
                     leaves = [Expression('List', *func_params), body] + \
                         self.leaves[2:]
 
+        if len(vars) == 0:  # might just be a symbol set via Set[] we looked up here
+            return self
+
         return Expression(
             self.head.replace_vars(
                 vars, options=options, in_scoping=in_scoping),


### PR DESCRIPTION
Mathics currently reevaluates variable values (i.e. values of symbols set via Set[]) every time they're accessed.

This can lead to worrisome performance:

`x=Range[10000]; Timing[First[x]]`
`{0.2507470000000005,1}`

This PR fixes this by not rebuilding expressions if no var is replaced. That way, the original expression's `is_evaluated` attribute does not get reset, and the expression is thus not reevaluated when `Expression.evaluate()` gets called for it later on. With change in PR:

`x=Range[10000]; Timing[First[x]]`
`{0.08305200000000035,1}`
