### PR TITLE
No reevaluation of evaluated values

### DIFF
--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -1113,7 +1113,7 @@ class Expression(BaseExpression):
                     leaves = [Expression('List', *func_params), body] + \
                         self.leaves[2:]
 
-        if len(vars) == 0:  # might just be a symbol set via Set[] we looked up here
+        if not vars:  # might just be a symbol set via Set[] we looked up here
             return self.shallow_copy()
 
         return Expression(

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -492,6 +492,16 @@ class Expression(BaseExpression):
         result.original = self
         return result
 
+    def shallow_copy(self):
+        # this is a minimal, shallow copy: head, leaves are shared with
+        # the original, only the Expression instance is new. we transfer
+        # the is_evaluated state, so we don't reevaluate evaluated stuff.
+        expr = Expression(self.head)
+        expr.leaves = self.leaves
+        expr.options = self.options
+        expr.is_evaluated = self.is_evaluated
+        return expr
+
     def set_positions(self, position=None):
         self.position = position
         self.head.set_positions(ExpressionPointer(self, 0))
@@ -1104,7 +1114,7 @@ class Expression(BaseExpression):
                         self.leaves[2:]
 
         if len(vars) == 0:  # might just be a symbol set via Set[] we looked up here
-            return self
+            return self.shallow_copy()
 
         return Expression(
             self.head.replace_vars(

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -1103,6 +1103,9 @@ class Expression(BaseExpression):
                     leaves = [Expression('List', *func_params), body] + \
                         self.leaves[2:]
 
+        if len(vars) == 0:  # might just be a symbol set via Set[] we looked up here
+            return self
+
         return Expression(
             self.head.replace_vars(
                 vars, options=options, in_scoping=in_scoping),

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -94,6 +94,8 @@ class Rule(BaseRule):
     def do_replace(self, vars, options, evaluation):
         new = self.replace.replace_vars(vars)
         new.options = options
+        if len(options) > 0:  # need to trigger (re)evaluation?
+            new = new.copy()  # clear is_evaluated for whole tree
         return new
 
     def __repr__(self):


### PR DESCRIPTION
Mathics currently reevaluates variable values (i.e. values of symbols set via Set[]) every time they're accessed.

This can lead to some worrisome performance (and it gets worse for even longer lists):

`x=Range[10000]; Timing[First[x]]`
`{0.2507470000000005,1}`

This PR fixes this by not rebuilding expressions if no var is replaced. That way, the original expression's is_evaluated attribute does not get reset, and the expression is thus not reevaluated when Expression.evaluate() gets called for it later on. With change in PR:

`x=Range[10000]; Timing[First[x]]`
`{0.08288399999999996,1}`
