### PR TITLE
Proposal to fix Plus and Times functionality

### DIFF
--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -246,8 +246,8 @@ def power(evaluation, *items_sequence):
             evaluation.message('Power', 'infy')
             return Symbol('ComplexInfinity')
     else:
-        numerified_items = [item.numerify(evaluation) for item in items_sequence]
-        return Expression('Power', *numerified_items)
+        numerified_items = Expression('System`Sequence', *items_sequence).numerify(evaluation)
+        return Expression('Power', *numerified_items.get_sequence())
 
 
 def divide(x, y, evaluation):

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -338,6 +338,10 @@ class Definitions(object):
         definition.attributes = set(attributes)
 
     def clear_attribute(self, name, attribute):
+        if attribute == 'System`Protected':
+            if name in ('System`Plus', 'System`Times'):
+                # mathics.built.arithmetic.plus() assumes std behavior
+                return
         definition = self.get_user_definition(self.lookup_name(name))
         if attribute in definition.attributes:
             definition.attributes.remove(attribute)


### PR DESCRIPTION
This is a proposal to assume that `Plus[]` and `Times[]` always work the same and cannot be overriden by users. The advantage would be that Python code doing basic calculations wouldn't need to go through the whole pattern lookup engine each time an addition or multiplication (or subtraction for that matter) is done.

I'm currently doing some experiments on implementing `FindClusters[]` and calling `Expression('Plus', ...)` each time an addition is done feels like overkill. Directly calling a plus function as proposed in this PR (see `mathics.builtin.arithmetic.plus()`) would seem so much more efficient.

Investigating this, I found that MMA seems to protect Plus and Times no matter what, i.e. calling `Unprotect[Plus]` or `Unprotect[Times]` has no effect, and each attempt to define new rules will be rejected. In these cases, `Unprotect` is a noop. I mimicked this with this PR (see change in `definitions.py`).

Regarding the changes in `arithmetic.py`: I just pulled out the code from `apply` into separate functions.

Python code could now import `plus` and do something like `plus(evaluation, a, b, Integer(1))`.

