### PR TITLE
TakeSmallest[] and related

### DIFF
--- a/mathics/builtin/algebra.py
+++ b/mathics/builtin/algebra.py
@@ -486,3 +486,14 @@ class Variables(Builtin):
         variables = Expression('List', *variables)
         variables.sort()        # MMA doesn't do this
         return variables
+
+
+class UpTo(Builtin):
+    messages = {
+        'innf': 'Expected non-negative integer or infinity at position 1 in ``.',
+        'argx': 'UpTo expects 1 argument, `1` arguments were given.'
+    }
+
+
+class Missing(Builtin):
+    pass

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -2929,7 +2929,7 @@ class TakeLargest(_RankedTakeLargest):
 
 class TakeLargestBy(_RankedTakeLargest):
     def apply(self, l, f, n, evaluation, options):
-        'TakeLargest[l_List, f_, n_, OptionsPattern[TakeLargestBy]]'
+        'TakeLargestBy[l_List, f_, n_, OptionsPattern[TakeLargestBy]]'
         return self._compute(l, n, evaluation, options, f=f)
 
 

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -2887,7 +2887,6 @@ class _RankedTake(Builtin):
             if py_n == 1:
                 result = [self._get_1(heap)]
             else:
-                heapq.heapify(heap)
                 result = self._get_n(py_n, heap)
 
             return Expression('List', *[x[leaf_pos] for x in result])

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -16,6 +16,7 @@ from mathics.builtin.base import (
     Builtin, Test, InvalidLevelspecError,
     PartError, PartDepthError, PartRangeError, Predefined, SympyFunction)
 from mathics.builtin.scoping import dynamic_scoping
+from mathics.builtin.base import MessageException, NegativeIntegerException, TakeInteger
 from mathics.core.expression import Expression, String, Symbol, Integer, Number
 from mathics.core.evaluation import BreakInterrupt, ContinueInterrupt
 from mathics.core.rules import Pattern
@@ -23,6 +24,7 @@ from mathics.core.convert import from_sympy
 from mathics.builtin.algebra import cancel
 
 import sympy
+import heapq
 
 from collections import defaultdict
 import functools
@@ -2809,3 +2811,154 @@ class RotateRight(_Rotate):
     """
 
     _sign = -1
+
+
+class _RankedTake(Builtin):
+    messages = {
+        'intpm': 'Expected non-negative integer at position `1` in `2`.',
+        'rank': 'The specified rank `1` is not between 1 and `2`.',
+    }
+
+    options = {
+        'ExcludedForms': 'Automatic',
+    }
+
+    def _compute(self, l, n, evaluation, options, f=None):
+        try:
+            limit = TakeInteger.from_expression(n)
+        except MessageException as e:
+            e.message(evaluation)
+            return
+        except NegativeIntegerException:
+            if f:
+                args = (3, Expression(self.get_name(), l, f, n))
+            else:
+                args = (2, Expression(self.get_name(), l, n))
+            evaluation.message(self.get_name(), 'intpm', *args)
+            return
+
+        if limit is None:
+            return
+
+        if limit == 0:
+            return Expression('List')
+        else:
+            excluded = self.get_option(options, 'ExcludedForms', evaluation)
+            if excluded:
+                if isinstance(excluded, Symbol) and excluded.get_name() == 'System`Automatic':
+                    def exclude(item):
+                        if isinstance(item, Symbol) and item.get_name() in ('System`None',
+                                                                            'System`Null',
+                                                                            'System`Indeterminate'):
+                            return True
+                        elif item.get_head_name() == 'System`Missing':
+                            return True
+                        else:
+                            return False
+                else:
+                    excluded = Expression('Alternatives', *excluded.leaves)
+
+                    def exclude(item):
+                        return Expression('MatchQ', item, excluded).evaluate(evaluation).is_true()
+
+                filtered = [leaf for leaf in l.leaves if not exclude(leaf)]
+            else:
+                filtered = l.leaves
+
+            if limit > len(filtered):
+                if not limit.is_upper_limit():
+                    evaluation.message(self.get_name(), 'rank', limit.integer(), len(filtered))
+                    return
+                else:
+                    py_n = len(filtered)
+            else:
+                py_n = limit.integer()
+
+            if py_n < 1:
+                return Expression('List')
+
+            if f:
+                heap = [(Expression(f, leaf).evaluate(evaluation), leaf, i) for i, leaf in enumerate(filtered)]
+                leaf_pos = 1  # in tuple above
+            else:
+                heap = [(leaf, i) for i, leaf in enumerate(filtered)]
+                leaf_pos = 0  # in tuple above
+
+            if py_n == 1:
+                result = [self._get_1(heap)]
+            else:
+                heapq.heapify(heap)
+                result = self._get_n(py_n, heap)
+
+            return Expression('List', *[x[leaf_pos] for x in result])
+
+
+class _RankedTakeSmallest(_RankedTake):
+    def _get_1(self, a):
+        return min(a)
+
+    def _get_n(self, n, heap):
+        return heapq.nsmallest(n, heap)
+
+
+class _RankedTakeLargest(_RankedTake):
+    def _get_1(self, a):
+        return max(a)
+
+    def _get_n(self, n, heap):
+        return heapq.nlargest(n, heap)
+
+
+class TakeLargest(_RankedTakeLargest):
+    """
+    <dl>
+    <dt>'TakeSmallest[$list$, $f$, $n$]'
+        <dd>returns the a sorted list of the n smallest items in $list$.
+    </dl>
+
+    >> TakeLargest[{-8, 150, Missing[abc]}, 2]
+     = {150, -8}
+
+    >> TakeLargest[{-8, 150, Missing[abc]}, 2, ExcludedForms -> {}]
+     = {Missing[abc], 150}
+    """
+
+    def apply(self, l, n, evaluation, options):
+        'TakeLargest[l_List, n_, OptionsPattern[TakeLargest]]'
+        return self._compute(l, n, evaluation, options)
+
+
+class TakeLargestBy(_RankedTakeLargest):
+    def apply(self, l, f, n, evaluation, options):
+        'TakeLargest[l_List, f_, n_, OptionsPattern[TakeLargestBy]]'
+        return self._compute(l, n, evaluation, options, f=f)
+
+
+class TakeSmallest(_RankedTakeSmallest):
+    """
+    <dl>
+    <dt>'TakeSmallest[$list$, $f$, $n$]'
+        <dd>returns the a sorted list of the n smallest items in $list$.
+    </dl>
+    """
+
+    def apply(self, l, n, evaluation, options):
+        'TakeSmallest[l_List, n_, OptionsPattern[TakeSmallest]]'
+        return self._compute(l, n, evaluation, options)
+
+
+class TakeSmallestBy(_RankedTakeSmallest):
+    """
+    <dl>
+    <dt>'TakeSmallestBy[$list$, $f$, $n$]'
+        <dd>returns the a sorted list of the n smallest items in $list$ using $f$ to retrieve the items' keys to
+        compare them.
+    </dl>
+
+    >> TakeSmallestBy[{"abc", "ab", "x"}, StringLength, 1]
+     = {'x'}
+    """
+
+    def apply(self, l, f, n, evaluation, options):
+        'TakeSmallestBy[l_List, f_, n_, OptionsPattern[TakeSmallestBy]]'
+        return self._compute(l, n, evaluation, options, f=f)


### PR DESCRIPTION
An implementation for `TakeSmallest`, `TakeSmallestBy`, `TakeLargest`, `TakeLargestBy` based on Python's `heapq.nsmallest` and `heapq.nlargest`.

This also introduces upper limits when taking things using `UpTo`, which is a very recent MMA addition (http://reference.wolfram.com/language/ref/UpTo.html).

My idea would be to wrap `UpTo` and the regular integer take counts in a class `CountableInteger` as done here.