### PR TITLE
Improve support for gamma functions

### DIFF
--- a/mathics/builtin/__init__.py
+++ b/mathics/builtin/__init__.py
@@ -71,8 +71,8 @@ def add_builtins(new_builtins):
         name = builtin.get_name()
         if isinstance(builtin, SympyObject):
             mathics_to_sympy[name] = builtin
-            if builtin.sympy_name:
-                sympy_to_mathics[builtin.sympy_name] = builtin
+            for sympy_name in builtin.get_sympy_names():
+                sympy_to_mathics[sympy_name] = builtin
         if isinstance(builtin, BoxConstruct):
             box_constructs[name] = builtin
         if isinstance(builtin, Operator):

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -41,12 +41,15 @@ class _MPMathFunction(SympyFunction):
         mpmath_function = getattr(mpmath, self.mpmath_name)
         return mpmath_function(*args)
 
+    def check_nargs(self, nargs):
+        return nargs == self.nargs
+
     def apply(self, z, evaluation):
         '%(name)s[z__]'
 
         args = z.get_sequence()
 
-        if len(args) != self.nargs:
+        if not self.check_nargs(len(args)):
             return
 
         # if no arguments are inexact attempt to use sympy
@@ -1507,6 +1510,7 @@ class Gamma(_MPMathFunction):
     """
 
     mpmath_name = 'gamma'
+    nargs = (1, 2)
 
     rules = {
         'Gamma[z_, x0_, x1_]': 'Gamma[z, x0] - Gamma[z, x1]',
@@ -1514,6 +1518,9 @@ class Gamma(_MPMathFunction):
 
     def get_sympy_names(self):
         return ['gamma', 'uppergamma']
+
+    def check_nargs(self, nargs):
+        return self.nargs[0] <= nargs <= self.nargs[1]
 
     def to_sympy(self, expr, **kwargs):
         try:

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -1718,11 +1718,11 @@ class Piecewise(SympyFunction):
             return leaves[0].leaves + [
                 Expression('List', leaves[1], Symbol('True'))]
 
-    def from_sympy(self, args):
+    def from_sympy(self, sympy_name, args):
         # Hack to get around weird sympy.Piecewise 'otherwise' behaviour
         if str(args[-1].leaves[1]).startswith('System`_True__Dummy_'):
             args[-1].leaves[1] = Symbol('True')
-        return [args]
+        return Expression(self.get_name(), args)
 
 
 class Boole(Builtin):

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -1485,11 +1485,15 @@ class Factorial(PostfixOperator, _MPMathFunction):
         return mpmath.factorial(z)
 
 
-class Gamma(SympyFunction):
+class Gamma(_MPMathFunction):
     """
     <dl>
     <dt>'Gamma[$z$]'
-        <dd>is the Gamma function on the complex number $z$.
+        <dd>is the gamma function on the complex number $z$.
+    <dt>'Gamma[$z$, $x$]'
+        <dd>is the upper incomplete gamma function.
+    <dt>'Gamma[$z$, $x0$, $x1$]'
+        <dd>is equivalent to 'Gamma[$z$, $x0$] - Gamma[$z$, $x1$]'.
     </dl>
 
     >> Gamma[8]
@@ -1502,11 +1506,28 @@ class Gamma(SympyFunction):
      = -Graphics-
     """
 
-    # TODO implement the incomplete Gamma functions
+    mpmath_name = 'gamma'
 
     rules = {
-        'Gamma[x_]': '(x - 1)!',
+        'Gamma[z_, x0_, x1_]': 'Gamma[z, x0] - Gamma[z, x1]',
     }
+
+    def get_sympy_names(self):
+        return ['gamma', 'uppergamma']
+
+    def to_sympy(self, expr, **kwargs):
+        try:
+            sympy_function = {
+                1: sympy.gamma,
+                2: sympy.uppergamma,
+            }[len(expr.leaves)]
+            leaves = self.prepare_sympy(expr.leaves)
+            return sympy_function(*(
+                    leaf.to_sympy(**kwargs) for leaf in leaves))
+        except KeyError:
+            return None
+        except TypeError:
+            pass
 
 
 class Pochhammer(SympyFunction):

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -1499,8 +1499,21 @@ class Gamma(_MPMathFunction):
         <dd>is equivalent to 'Gamma[$z$, $x0$] - Gamma[$z$, $x1$]'.
     </dl>
 
+    'Gamma[$z$]' is equivalent to '($z$ - 1)!':
+    >> Simplify[Gamma[z] - (z - 1)!]
+     = 0
+
+    Exact arguments:
     >> Gamma[8]
      = 5040
+    >> Gamma[1/2]
+     = Sqrt[Pi]
+    >> Gamma[1, x]
+     = E ^ (-x)
+
+    Numeric arguments:
+    >> Gamma[1.*^20]
+     = 1.93284951431009771*^1956570551809674817225
     >> Gamma[1. + I]
      = 0.498015668118356043 - 0.154949828301810685 I
 

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -1527,6 +1527,7 @@ class Gamma(_MPMathFunction):
 
     rules = {
         'Gamma[z_, x0_, x1_]': 'Gamma[z, x0] - Gamma[z, x1]',
+        'Gamma[1 + z_]': 'z!',
     }
 
     def get_sympy_names(self):

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -347,6 +347,11 @@ class SympyObject(Builtin):
     def is_constant(self):
         return False
 
+    def get_sympy_names(self):
+        if self.sympy_name:
+            return [self.sympy_name]
+        return []
+
 
 class SympyFunction(SympyObject):
     def prepare_sympy(self, leaves):
@@ -361,8 +366,8 @@ class SympyFunction(SympyObject):
         except TypeError:
             pass
 
-    def from_sympy(self, leaves):
-        return leaves
+    def from_sympy(self, sympy_name, leaves):
+        return Expression(self.get_name(), *leaves)
 
     def prepare_mathics(self, sympy_expr):
         return sympy_expr
@@ -376,8 +381,11 @@ class SympyConstant(SympyObject, Predefined):
         return True
 
     def to_sympy(self, expr, **kwargs):
-        # there is no "native" SymPy expression for e.g. E[x]
-        return None
+        if expr.is_atom():
+            return getattr(sympy, self.sympy_name)
+        else:
+            # there is no "native" SymPy expression for e.g. E[x]
+            return None
 
 
 class InvalidLevelspecError(Exception):

--- a/mathics/builtin/calculus.py
+++ b/mathics/builtin/calculus.py
@@ -450,7 +450,7 @@ class Integrate(SympyFunction):
                 return [leaves[0]] + x.leaves
         return leaves
 
-    def from_sympy(self, leaves):
+    def from_sympy(self, sympy_name, leaves):
         args = []
         for leaf in leaves[1:]:
             if leaf.has_form('List', 1):
@@ -458,7 +458,8 @@ class Integrate(SympyFunction):
                 args.append(leaf.leaves[0])
             else:
                 args.append(leaf)
-        return [leaves[0]] + args
+        new_leaves = [leaves[0]] + args
+        return Expression(self.get_name(), *new_leaves)
 
     def apply(self, f, xs, evaluation):
         'Integrate[f_, xs__]'

--- a/mathics/core/convert.py
+++ b/mathics/core/convert.py
@@ -242,8 +242,7 @@ def from_sympy(expr):
         args = [from_sympy(arg) for arg in expr.args]
         builtin = sympy_to_mathics.get(name)
         if builtin is not None:
-            name = builtin.get_name()
-            args = builtin.from_sympy(args)
+            return builtin.from_sympy(name, args)
         return Expression(Symbol(name), *args)
 
     elif isinstance(expr, sympy.Tuple):

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -1341,7 +1341,7 @@ class Symbol(Atom):
             not builtin.is_constant()):
             return sympy.Symbol(sympy_symbol_prefix + self.name)
         else:
-            return getattr(sympy, builtin.sympy_name)
+            return builtin.to_sympy(self)
 
     def to_python(self, *args, **kwargs):
         if self.name == 'System`True':

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -94,6 +94,19 @@ class SympyConvert(unittest.TestCase):
             mathics.Symbol('System`Pi'),
             sympy.pi)
 
+    def testGamma(self):
+        self.compare(
+            mathics.Expression('Gamma', mathics.Symbol('Global`z')),
+            sympy.gamma(sympy.Symbol('_Mathics_User_Global`z')))
+        self.compare(
+            mathics.Expression(
+                'Gamma',
+                mathics.Symbol('Global`z'),
+                mathics.Symbol('Global`x')),
+            sympy.uppergamma(
+                sympy.Symbol('_Mathics_User_Global`z'),
+                sympy.Symbol('_Mathics_User_Global`x')))
+
 
 class PythonConvert(unittest.TestCase):
     def compare(self, mathics_expr, python_expr):

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -86,6 +86,14 @@ class SympyConvert(unittest.TestCase):
             mathics.Expression('Sin', mathics.Symbol('Global`x')),
             sympy.sin(sympy.Symbol('_Mathics_User_Global`x')))
 
+    def testConstant(self):
+        self.compare(
+            mathics.Symbol('System`E'),
+            sympy.E)
+        self.compare(
+            mathics.Symbol('System`Pi'),
+            sympy.pi)
+
 
 class PythonConvert(unittest.TestCase):
     def compare(self, mathics_expr, python_expr):


### PR DESCRIPTION
SymPy exposes separate `gamma()` and `uppergamma()` functions, whereas in Mathematica `Gamma[z]` is the gamma function and `Gamma[z, x]` is the upper incomplete gamma function.

Add support for `Gamma[z, x]` plus plumbing for mapping multiple SymPy functions onto one builtin. Right now I think it's just this one function that needs this kind of treatment, but it'd easy to factor out if there are more.