### PR TITLE
cleanup Factorial

### DIFF
--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -1414,18 +1414,7 @@ class Factorial(PostfixOperator, _MPMathFunction):
 
     operator = '!'
     precedence = 610
-
-    def apply_int(self, n, evaluation):
-        'Factorial[n_Integer]'
-
-        n = n.to_sympy()
-        if n < 0:
-            return Symbol('ComplexInfinity')
-        else:
-            return Integer(sympy.factorial(n))
-
-    def eval(self, z):
-        return mpmath.factorial(z)
+    mpmath_name = 'factorial'
 
 
 class Gamma(_MPMathFunction):


### PR DESCRIPTION
This code dates back to the original version of Mathics in 2011 (a77c08e66e6103d28af3c09e69e0d857600c10da),  but it's no longer needed.