### PR TITLE
fix #302

### DIFF
--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -1594,6 +1594,12 @@ class Sum(_IterationFunction, SympyFunction):
     ## Issue431
     #> Sum[2^(-i), {i, 1, \[Infinity]}]
      = 1
+
+    ## Issue302
+    #> Sum[i / Log[i], {i, 1, Infinity}]
+     = Sum[i / Log[i], {i, 1, Infinity}]
+    #> Sum[Cos[Pi i], {i, 1, Infinity}]
+     = Sum[Cos[Pi i], {i, 1, Infinity}]
     """
 
     # Do not throw warning message for symbolic iteration bounds

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -1434,11 +1434,6 @@ class _IterationFunction(Builtin):
     """
 
     attributes = ('HoldAll',)
-    rules = {
-        '%(name)s[expr_, {i_Symbol, imin_, imax_}]': (
-            '%(name)s[expr, {i, imin, imax, 1}]'),
-    }
-
     allow_loopcontrol = False
     throw_iterb = True
 
@@ -1482,6 +1477,10 @@ class _IterationFunction(Builtin):
             index += 1
         return self.get_result(result)
 
+    def apply_iter_nostep(self, expr, i, imin, imax, evaluation):
+        '%(name)s[expr_, {i_Symbol, imin_, imax_}]'
+        return self.apply_iter(expr, i, imin, imax, Integer(1), evaluation)
+
     def apply_iter(self, expr, i, imin, imax, di, evaluation):
         '%(name)s[expr_, {i_Symbol, imin_, imax_, di_}]'
 
@@ -1499,6 +1498,7 @@ class _IterationFunction(Builtin):
 
             if not result.same(whole_expr):
                 return result
+            return
 
         index = imin.evaluate(evaluation)
         imax = imax.evaluate(evaluation)


### PR DESCRIPTION
Partial fix for #302. Returns the expression unevaluated (correctly) but no error message.