### PR TITLE
Disable spellchecking on query fields

### DIFF
--- a/mathics/web/media/js/mathics.js
+++ b/mathics/web/media/js/mathics.js
@@ -501,7 +501,7 @@ function createQuery(before, noFocus, updatingAll) {
 	var li = $E('li', {'id': 'query_' + queryIndex++, 'class': 'query'},
 		ul = $E('ul', {'class': 'query'},
 			$E('li', {'class': 'request'},
-				textarea = $E('textarea', {'class': 'request'}),
+				textarea = $E('textarea', {'class': 'request', 'spellcheck': 'false'}),
 				$E('span', {'class': 'submitbutton', 'title': "Submit [Shift+Return]"},
 					submitButton = $E('span', $T('='))
 				)


### PR DESCRIPTION
This PR just disables spellchecking by setting the [HTML5 spellcheck attribute](https://www.w3.org/TR/html5/editing.html#attr-spellcheck) - doesn't seem like this buys us much, it doesn't help me spell `LaguerreL`