### PR TITLE
Optimise BaseExpression creation

### DIFF
--- a/mathics/benchmark.py
+++ b/mathics/benchmark.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 import time
 from argparse import ArgumentParser
 import urllib.request
+import statistics
 
 import mathics
 from mathics.core.parser import parse, MultiLineFeeder, SingleLineFeeder
@@ -17,9 +18,9 @@ from mathics.core.evaluation import Evaluation
 from six.moves import map
 from six.moves import range
 
-
 # Default number of times to repeat each benchmark. None -> Automatic
 TESTS_PER_BENCHMARK = None
+
 
 # Mathics expressions to benchmark
 BENCHMARKS = {
@@ -98,18 +99,21 @@ def timeit(func, repeats=None):
         for i in range(repeats):
             times.append(time.clock())
             func()
-            if any(i == j for j in (5, 10, 100, 1000, 5000)):
+            if (i + 1) in (5, 10, 100, 1000, 5000):
                 if times[-1] > times[0] + 1:
-                    repeats = i
+                    repeats = i + 1
                     break
 
     times.append(time.clock())
 
-    average_time = format_time_units((times[-1] - times[0]) / repeats)
-    best_time = format_time_units(
-        min([times[i + 1] - times[i] for i in range(repeats)]))
-    print("    {0:5n} loops, avg: {1} per loop, best: {2} per loop".format(
-        repeats, average_time, best_time))
+    times = [times[i+1] - times[i] for i in range(repeats)]
+
+    average_time = format_time_units(statistics.mean(times))
+    best_time = format_time_units(min(times))
+    median_time = format_time_units(statistics.median(times))
+
+    print("    {0:5n} loops, avg: {1}, best: {2}, median: {3} per loop".format(
+        repeats, average_time, best_time, median_time))
 
 
 def truncate_line(string):

--- a/mathics/builtin/numeric.py
+++ b/mathics/builtin/numeric.py
@@ -23,9 +23,7 @@ from mathics.core.numbers import (dps, prec,
 from mathics.core.expression import (Integer, Rational, Real, Complex,
                                      Expression, Number, Symbol, from_python)
 from mathics.core.convert import from_sympy
-from mathics.settings import MACHINE_PRECISION
-
-machine_precision = MACHINE_PRECISION
+from mathics.core.numbers import machine_precision
 
 
 def get_precision(precision, evaluation):

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import
 import sympy
 import mpmath
 import re
+import abc
 
 from mathics.core.numbers import get_type, dps, prec, min_prec
 from mathics.core.convert import sympy_symbol_prefix, SympyExpression
@@ -111,12 +112,12 @@ def from_python(arg):
         raise NotImplementedError
 
 
-class KeyComparable(object):
-    '''
-    subclassing this requires implementing the get_sort_key method
-    '''
-    def __init__(self, *args, **kwargs):
-        pass
+class KeyComparable:
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
+    def get_sort_key(self):
+        return
 
     def __lt__(self, other):
         return self.get_sort_key() < other.get_sort_key()
@@ -139,12 +140,8 @@ class KeyComparable(object):
 
 class BaseExpression(KeyComparable):
     def __init__(self, *args, **kwargs):
-        super(BaseExpression, self).__init__()
-
         self.options = None
-
         self.pattern_sequence = False
-
         self.unformatted = self
 
     def get_attributes(self, definitions):
@@ -413,7 +410,6 @@ class BaseExpression(KeyComparable):
         return Expression('Power', self, other)
 
 
-# TODO subclass KeyComparable
 class Monomial(object):
     """
     An object to sort monomials, used in Expression.get_sort_key and

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -9,7 +9,7 @@ import mpmath
 import re
 import abc
 
-from mathics.core.numbers import get_type, dps, prec, min_prec
+from mathics.core.numbers import get_type, dps, prec, min_prec, machine_precision
 from mathics.core.convert import sympy_symbol_prefix, SympyExpression
 import six
 from six.moves import map
@@ -1599,7 +1599,6 @@ class Rational(Number):
             return [0, 0, sympy.Float(self.value), 0, 1]
 
     def get_real_value(self):
-        from mathics.builtin.numeric import machine_precision
         return self.value.n(machine_precision)
 
     def do_copy(self):

--- a/mathics/core/numbers.py
+++ b/mathics/core/numbers.py
@@ -12,6 +12,9 @@ from six.moves import range
 from mathics.core.util import unicode_superscript
 
 
+machine_precision = 64
+
+
 def get_type(value):
     if isinstance(value, sympy.Integer):
         return 'z'
@@ -36,7 +39,6 @@ def is_0(value):
 
 def sympy2mpmath(value, prec=None):
     if prec is None:
-        from mathics.builtin.numeric import machine_precision
         prec = machine_precision
     value = value.n(dps(prec))
     if value.is_real:

--- a/mathics/core/parser/convert.py
+++ b/mathics/core/parser/convert.py
@@ -9,8 +9,7 @@ from math import log10
 
 import mathics.core.expression as ma
 from mathics.core.parser.ast import Symbol, String, Number, Filename
-from mathics.core.numbers import dps
-from mathics.builtin.numeric import machine_precision
+from mathics.core.numbers import dps, machine_precision
 
 
 class Converter(object):

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -14,7 +14,6 @@ class StopGenerator_BaseRule(StopGenerator):
 
 class BaseRule(KeyComparable):
     def __init__(self, pattern, system=False):
-        super(BaseRule, self).__init__()
         self.pattern = Pattern.create(pattern)
         self.system = system
 

--- a/mathics/settings.py
+++ b/mathics/settings.py
@@ -27,9 +27,6 @@ TIMEOUT = None
 
 MAX_RECURSION_DEPTH = 512
 
-# number of bits of precision for inexact calculations
-MACHINE_PRECISION = 64
-
 ADMINS = (
     ('Admin', 'mail@test.com'),
 )


### PR DESCRIPTION
Some small changes to the core to speed up `BaseExpression` creation.

Also includes some enhancements to the benchmarking script.

### Before:
```
'Expand[(a1+a2+a3+a4+a5+a6+a7)^3]'
    10 loops, avg:  147 ms, best:  136 ms, median:  145 ms per loop
%timeit Integer(5)
    1000000 loops, best of 3: 1.52 µs per loop
%timeit Expression('Sin')
     100000 loops, best of 3: 4.03 µs per loop
```

### After:
```
'Expand[(a1+a2+a3+a4+a5+a6+a7)^3]'
      100 loops, avg: 98.3 ms, best: 93.1 ms, median: 95.5 ms per loop
%timeit Integer(5)
    1000000 loops, best of 3: 1.15 µs per loop
%timeit Expression('Sin')
     100000 loops, best of 3: 3.2  µs per loop
```

### After `lru_cache`:  **(deferred)**
```
'Expand[(a1+a2+a3+a4+a5+a6+a7)^3]'
    100 loops, avg: 87.8 ms, best: 82.4 ms, median: 86.2 ms per loop
%timeit Integer(5)
    10000000 loops, best of 3: 158 ns per loop
%timeit Expression('Sin')
    1000000 loops, best of 3: 1.99 µs per loop
```

The introduction of LRU cache caused some issues when copying and modifying expressions so I've removed them from this PR.