### PR TITLE
AngleVector[] and AnglePath[]

### DIFF
--- a/mathics/builtin/exptrig.py
+++ b/mathics/builtin/exptrig.py
@@ -1022,11 +1022,11 @@ class AnglePath(Builtin):
 
     def apply(self, steps, evaluation):
         'AnglePath[{steps___}]'
-        return AnglePath._compute(Integer(0), Integer(0), None, steps.get_sequence(), evaluation)
+        return AnglePath._compute(MachineReal(0), MachineReal(0), None, steps.get_sequence(), evaluation)
 
     def apply_phi0(self, phi0, steps, evaluation):
         'AnglePath[phi0_, {steps___}]'
-        return AnglePath._compute(Integer(0), Integer(0), phi0, steps.get_sequence(), evaluation)
+        return AnglePath._compute(MachineReal(0), MachineReal(0), phi0, steps.get_sequence(), evaluation)
 
     def apply_xy(self, x, y, steps, evaluation):
         'AnglePath[{x_, y_}, {steps___}]'

--- a/mathics/builtin/exptrig.py
+++ b/mathics/builtin/exptrig.py
@@ -1028,7 +1028,7 @@ class AnglePath(Builtin):
     >> AnglePath[{a, b}]
      = {{0, 0}, {Cos[a], Sin[a]}, {Cos[a] + Cos[a + b], Sin[a] + Sin[a + b]}}
 
-    >> Precision[Part[AnglePath[{N[1/3, 100], N[2/3, 100]}], 2, 1]
+    >> Precision[Part[AnglePath[{N[1/3, 100], N[2/3, 100]}], 2, 1]]
      = 100.
 
     >> Graphics[Line[AnglePath[Table[1.7, {50}]]]]

--- a/mathics/builtin/exptrig.py
+++ b/mathics/builtin/exptrig.py
@@ -925,7 +925,21 @@ class AnglePathFold(Fold):
     def __init__(self, parse):
         self._parse = parse
 
-    def _fold(self, state, steps, as_operand, math, at_least):
+    def _operands(self, state, steps):
+        expr_x, expr_y, expr_phi = state
+        yield expr_x
+        yield expr_y
+        if expr_phi is not None:
+            yield expr_phi
+
+        parse = self._parse
+        for step in steps:
+            expr_distance, expr_delta_phi = parse(step)
+            if expr_distance is not None:
+                yield expr_distance
+            yield expr_delta_phi
+
+    def _fold(self, state, steps, as_operand, out, math, at_least):
         sin = math.sin
         cos = math.cos
 
@@ -983,7 +997,7 @@ class AnglePathFold(Fold):
             x += dx
             y += dy
 
-            yield x, y, phi
+            yield out(x), out(y), out(phi)
 
 
 class AnglePath(Builtin):
@@ -1013,6 +1027,9 @@ class AnglePath(Builtin):
 
     >> AnglePath[{a, b}]
      = {{0, 0}, {Cos[a], Sin[a]}, {Cos[a] + Cos[a + b], Sin[a] + Sin[a + b]}}
+
+    >> Precision[Part[AnglePath[{N[1/3, 100], N[2/3, 100]}], 2, 1]
+     = 100.
 
     >> Graphics[Line[AnglePath[Table[1.7, {50}]]]]
      = -Graphics-

--- a/mathics/builtin/exptrig.py
+++ b/mathics/builtin/exptrig.py
@@ -1022,11 +1022,11 @@ class AnglePath(Builtin):
 
     def apply(self, steps, evaluation):
         'AnglePath[{steps___}]'
-        return AnglePath._compute(MachineReal(0), MachineReal(0), None, steps.get_sequence(), evaluation)
+        return AnglePath._compute(Integer(0), Integer(0), None, steps.get_sequence(), evaluation)
 
     def apply_phi0(self, phi0, steps, evaluation):
         'AnglePath[phi0_, {steps___}]'
-        return AnglePath._compute(MachineReal(0), MachineReal(0), phi0, steps.get_sequence(), evaluation)
+        return AnglePath._compute(Integer(0), Integer(0), phi0, steps.get_sequence(), evaluation)
 
     def apply_xy(self, x, y, steps, evaluation):
         'AnglePath[{x_, y_}, {steps___}]'

--- a/mathics/builtin/numeric.py
+++ b/mathics/builtin/numeric.py
@@ -21,6 +21,7 @@ import zlib
 import math
 from six.moves import range
 from collections import namedtuple
+import sys
 
 
 from mathics.builtin.base import Builtin, Predefined
@@ -904,6 +905,16 @@ class SymbolicEvaluation(Exception):
     pass
 
 
+def _is_machine_precision_or_int(x):
+    if x.is_machine_precision():
+        return True
+
+    if isinstance(x, Integer) and x.get_int_value().bit_length() < sys.float_info.mant_dig:
+        return True
+
+    return False
+
+
 class Fold(object):
     # allows inherited classes to specify a single algorithm implementation that
     # can be called with machine precision, arbitrary precision or symbolically.
@@ -929,7 +940,7 @@ class Fold(object):
     def converter(self, mode):
         if mode == 'machine':
             def number(x):
-                if not x.is_machine_precision():
+                if not _is_machine_precision_or_int(x):
                     raise PrecisionExhausted
                 return x.to_python()
         elif mode == 'precision':


### PR DESCRIPTION
Seemed so simple, but is now quite elaborate since a special case for numerical evaluation seems important to me, as speed is an issue here.

One thing that vexes me is that numerical evaluation does not automatically get triggered when using this in `Graphics`, which means that a very slow symbolic evaluation is triggered inside `Graphics` if one does not specify numerical quantities. More specifically:

```
Timing[Graphics[Line[AnglePath[Table[90 Degree, {20}]]]]]
{3.6392160000000002, -Graphics-}

Timing[Graphics[Line[AnglePath[Table[1.57, {20}]]]]]
{0.013397999999999577, -Graphics-}
```

As you can see, the numerical evaluation (due to the special case in `AnglePath`) is about two magnitudes faster. I really wonder how we could get `Graphics` to do a recursive `N` on all its sub expressions before these get evaluated...