### PR TITLE
Faster insert_rule

### DIFF
--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -10,6 +10,7 @@ import six.moves.cPickle as pickle
 import os
 import base64
 import re
+import bisect
 
 from mathics.core.expression import Expression, Symbol, String, fully_qualified_symbol_name
 from mathics.core.characters import letters, letterlikes
@@ -475,8 +476,7 @@ def insert_rule(values, rule):
         if existing.pattern.same(rule.pattern):
             del values[index]
             break
-    values.insert(0, rule)
-    values.sort()
+    bisect.insort(values, rule)
 
 
 class Definition(object):

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -476,7 +476,9 @@ def insert_rule(values, rule):
         if existing.pattern.same(rule.pattern):
             del values[index]
             break
-    bisect.insort(values, rule)
+    # use insort_left to guarantee that if equal rules exist, newer rules will
+    # get higher precedence by being inserted before them. see DownValues[].
+    bisect.insort_left(values, rule)
 
 
 class Definition(object):


### PR DESCRIPTION
Makes Mathics startup faster, by making the time in `contribute` in the `Definitions` constructor go to roughly 50% (from 2.5 to 1.1 s).