### PR TITLE
support for 'requires' attribute

### DIFF
--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -1340,6 +1340,8 @@ class General(Builtin):
         'invalidargs': "Invalid arguments.",
 
         'notboxes': "`1` is not a valid box structure.",
+
+        'pyimport': "`1`[] is not available. Your Python installation misses the \"`2`\" module.",
     }
 
 


### PR DESCRIPTION
This is a precursor to a larger package (https://github.com/poke1024/Mathics/tree/nlp).

It allows `Builtin`s to define a `requires` attribute that lists Python modules that are needed for this Builtin. If not available, all `apply` methods in this `Builtin` will be automatically deactivated, an error will be output if the methods are called. Also, no test cases from these `Builtin`s are run, if the packages in `requires` are not installed in the test environment.

Here's an example how it works. First, define a some Builtin `DrSeuss`: 

```
class DrSeuss(Builtin):
    requires = (
        'drseuss',
    )

    def apply(self, x, evaluation):
        'DrSeuss[x_]'
        return x
```

Calling it will produce this:

`In[1]:= DrSeuss[1]
 : DrSeuss[] is not available. Your Python installation misses the "drseuss" module
`
