### PR TITLE
Cleanup of Style definitions

### DIFF
--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -1144,8 +1144,7 @@ class _GraphicsElements(object):
                 if item.get_name() == 'System`Null':
                     continue
                 head = item.get_head_name()
-                if (head in style_heads or  # noqa
-                    head in ('System`EdgeForm', 'System`FaceForm')):
+                if head in style_heads or head in ('System`EdgeForm', 'System`FaceForm'):
                     style.append(item)
                 elif head[-3:] == 'Box':  # and head[:-3] in element_heads:
                     element_class = get_class(head)

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -31,17 +31,12 @@ class ColorError(BoxConstructError):
     pass
 
 
-element_heads = system_symbols('Rectangle', 'Disk', 'Line', 'Point',
-                               'Circle', 'Polygon', 'Inset', 'Text', 'Sphere')
-color_heads = system_symbols('RGBColor', 'CMYKColor', 'Hue', 'GrayLevel')
-thickness_heads = system_symbols('Thickness', 'AbsoluteThickness', 'Thick',
-                                 'Thin')
+element_heads = set(system_symbols(
+    'Rectangle', 'Disk', 'Line', 'Point', 'Circle', 'Polygon', 'Inset', 'Text', 'Sphere'))
 
-GRAPHICS_SYMBOLS = set(['System`List', 'System`Rule', 'System`VertexColors'] +
-                       list(element_heads) +
-                       [element + 'Box' for element in element_heads] +
-                       list(color_heads) + list(thickness_heads))
-
+# the following variables are declared here but initialized only at the end of this file.
+style_heads = None
+GRAPHICS_SYMBOLS = None
 
 def get_class(name):
     from mathics.builtin.graphics3d import GLOBALS3D
@@ -241,6 +236,10 @@ class _GraphicsElement(InstancableBuiltin):
         self.style = style
         self.is_completely_visible = False  # True for axis elements
 
+    @staticmethod
+    def create_as_style(klass, graphics, item):
+        return klass(graphics, item)
+
 
 class _Color(_GraphicsElement):
     components_sizes = []
@@ -275,6 +274,10 @@ class _Color(_GraphicsElement):
         if cls is None:
             raise ColorError
         return cls(expr)
+
+    @staticmethod
+    def create_as_style(klass, graphics, item):
+        return klass(item)
 
     def to_css(self):
         rgba = self.to_rgba()
@@ -1048,10 +1051,9 @@ class Style(object):
 
     def append(self, item, allow_forms=True):
         head = item.get_head_name()
-        if head in color_heads:
-            style = get_class(head)(item)
-        elif head in thickness_heads:
-            style = get_class(head)(self.graphics, item)
+        if head in style_heads:
+            klass = get_class(head)
+            style = klass.create_as_style(klass, self.graphics, item)
         elif head in ('System`EdgeForm', 'System`FaceForm'):
             style = self.klass(self.graphics, edge=head == 'System`EdgeForm',
                                face=head == 'System`FaceForm')
@@ -1142,7 +1144,7 @@ class _GraphicsElements(object):
                 if item.get_name() == 'System`Null':
                     continue
                 head = item.get_head_name()
-                if (head in color_heads or head in thickness_heads or   # noqa
+                if (head in style_heads or  # noqa
                     head in ('System`EdgeForm', 'System`FaceForm')):
                     style.append(item)
                 elif head[-3:] == 'Box':  # and head[:-3] in element_heads:
@@ -1996,7 +1998,9 @@ GLOBALS = system_symbols_dict({
     'PolygonBox': PolygonBox,
     'PointBox': PointBox,
     'InsetBox': InsetBox,
+})
 
+styles = system_symbols_dict({
     'RGBColor': RGBColor,
     'CMYKColor': CMYKColor,
     'Hue': Hue,
@@ -2007,3 +2011,12 @@ GLOBALS = system_symbols_dict({
     'Thick': Thick,
     'Thin': Thin,
 })
+
+GLOBALS.update(styles)
+
+style_heads = styles.keys()
+
+GRAPHICS_SYMBOLS = set(['System`List', 'System`Rule', 'System`VertexColors'] +
+                       list(element_heads) +
+                       [element + 'Box' for element in element_heads] +
+                       list(style_heads))

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -31,13 +31,6 @@ class ColorError(BoxConstructError):
     pass
 
 
-element_heads = set(system_symbols(
-    'Rectangle', 'Disk', 'Line', 'Point', 'Circle', 'Polygon', 'Inset', 'Text', 'Sphere'))
-
-# the following variables are declared here but initialized only at the end of this file.
-style_heads = None
-GRAPHICS_SYMBOLS = None
-
 def get_class(name):
     from mathics.builtin.graphics3d import GLOBALS3D
 
@@ -1983,6 +1976,23 @@ class Large(Builtin):
     '''
 
 
+element_heads = frozenset(system_symbols(
+    'Rectangle', 'Disk', 'Line', 'Point', 'Circle', 'Polygon', 'Inset', 'Text', 'Sphere'))
+
+styles = system_symbols_dict({
+    'RGBColor': RGBColor,
+    'CMYKColor': CMYKColor,
+    'Hue': Hue,
+    'GrayLevel': GrayLevel,
+
+    'Thickness': Thickness,
+    'AbsoluteThickness': AbsoluteThickness,
+    'Thick': Thick,
+    'Thin': Thin,
+})
+
+style_heads = frozenset(styles.keys())
+
 GLOBALS = system_symbols_dict({
     'Rectangle': Rectangle,
     'Disk': Disk,
@@ -1999,23 +2009,10 @@ GLOBALS = system_symbols_dict({
     'InsetBox': InsetBox,
 })
 
-styles = system_symbols_dict({
-    'RGBColor': RGBColor,
-    'CMYKColor': CMYKColor,
-    'Hue': Hue,
-    'GrayLevel': GrayLevel,
-
-    'Thickness': Thickness,
-    'AbsoluteThickness': AbsoluteThickness,
-    'Thick': Thick,
-    'Thin': Thin,
-})
-
 GLOBALS.update(styles)
 
-style_heads = styles.keys()
-
-GRAPHICS_SYMBOLS = set(['System`List', 'System`Rule', 'System`VertexColors'] +
-                       list(element_heads) +
-                       [element + 'Box' for element in element_heads] +
-                       list(style_heads))
+GRAPHICS_SYMBOLS = frozenset(
+    ['System`List', 'System`Rule', 'System`VertexColors'] +
+    list(element_heads) +
+    [element + 'Box' for element in element_heads] +
+    list(style_heads))


### PR DESCRIPTION
This is in preparation of adding `Arrowheads` and `FontSize` soon.

The current code makes adding new `Style` directives cumbersome, as several places of definition and reference in the code need to be changed.

This PR reorganizes and unifies the places where style heads are declared into one central place, such that adding a new style means adding a new entry to `styles` at the end of the file and nowhere else.

I didn't reorganize `element_heads` (apart from making it a `set`) as some funky mixing of `Graphics` and `Graphics3D` objects is going on there, that I didn't understand.

I'm not sure what the `# noqa` comment in `_GraphicsElements.__init__` means, so I just left it. Is it 'no QA'?


