### PR TITLE
AtomBuiltin and decentral Atom box handling

### DIFF
--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -236,6 +236,16 @@ class InstancableBuiltin(Builtin):
         pass
 
 
+class AtomBuiltin(Builtin):
+    # allows us to define apply functions, rules, messages, etc. for Atoms
+    # which are by default not in the definitions' contribution pipeline.
+    # see Image[] for an example of this.
+
+    def get_name(self):
+        name = super(AtomBuiltin, self).get_name()
+        return re.sub(r"Atom$", "", name)
+
+
 class Operator(Builtin):
     operator = None
     precedence = None
@@ -252,6 +262,7 @@ class Operator(Builtin):
             return self.operator_display
         else:
             return self.operator
+
 
 class Predefined(Builtin):
     def get_functions(self, prefix='apply'):

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -421,15 +421,7 @@ class MakeBoxes(Builtin):
             f:TraditionalForm|StandardForm|OutputForm|InputForm|FullForm]'''
 
         if expr.is_atom():
-            x = expr
-            if isinstance(x, Symbol):
-                return String(evaluation.definitions.shorten_name(x.name))
-            elif isinstance(x, String):
-                return String('"' + six.text_type(x.value) + '"')
-            elif isinstance(x, (Integer, Real)):
-                return x.make_boxes(f.get_name())
-            elif isinstance(x, (Rational, Complex)):
-                return x.format(evaluation, f.get_name())
+            return expr.atom_to_boxes(f, evaluation)
         else:
             head = expr.head
             leaves = expr.leaves
@@ -468,14 +460,7 @@ class MakeBoxes(Builtin):
         '''MakeBoxes[x_?AtomQ,
             f:TraditionalForm|StandardForm|OutputForm|InputForm|FullForm]'''
 
-        if isinstance(x, Symbol):
-            return String(evaluation.definitions.shorten_name(x.name))
-        elif isinstance(x, String):
-            return String('"' + x.value + '"')
-        elif isinstance(x, (Integer, Real)):
-            return x.make_boxes(f.get_name())
-        elif isinstance(x, (Rational, Complex)):
-            return x.format(evaluation, f.get_name())
+        return x.atom_to_boxes(f, evaluation)
 
     def apply_outerprecedenceform(self, expr, prec, f, evaluation):
         '''MakeBoxes[OuterPrecedenceForm[expr_, prec_],

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -1300,6 +1300,9 @@ class Atom(BaseExpression):
     def get_atoms(self, include_heads=True):
         return [self]
 
+    def atom_to_boxes(self, f, evaluation):
+        raise NotImplementedError
+
 
 class Symbol(Atom):
     def __init__(self, name, sympy_dummy=None, **kwargs):
@@ -1316,6 +1319,9 @@ class Symbol(Atom):
 
     def boxes_to_text(self, **options):
         return str(self.name)
+
+    def atom_to_boxes(self, f, evaluation):
+        return String(evaluation.definitions.shorten_name(self.name))
 
     def to_sympy(self, **kwargs):
         from mathics.builtin import mathics_to_sympy
@@ -1501,6 +1507,9 @@ class Integer(Number):
     def make_boxes(self, form):
         return String(str(self.value))
 
+    def atom_to_boxes(self, f, evaluation):
+        return self.make_boxes(f.get_name())
+
     def default_format(self, evaluation, form):
         return str(self.value)
 
@@ -1552,6 +1561,9 @@ class Rational(Number):
 
     def __setstate__(self, dict):
         self.value = sympy.Rational(dict['value'])
+
+    def atom_to_boxes(self, f, evaluation):
+        return self.format(evaluation, f.get_name())
 
     def to_sympy(self, **kwargs):
         return self.value
@@ -1670,6 +1682,9 @@ class Real(Number):
         _number_form_options['_Form'] = form    # passed to _NumberFormat
         return number_form(self, dps(self.prec), None, None, _number_form_options)
 
+    def atom_to_boxes(self, f, evaluation):
+        return self.make_boxes(f.get_name())
+
     def to_sympy(self, **kwargs):
         return self.value
 
@@ -1760,6 +1775,9 @@ class Complex(Number):
         self.sympy = self.real.to_sympy() + sympy.I * self.imag.to_sympy()
         self.value = (self.real, self.imag)
         self.prec = p
+
+    def atom_to_boxes(self, f, evaluation):
+        return self.format(evaluation, f.get_name())
 
     def to_sympy(self, **kwargs):
         return self.sympy
@@ -1979,6 +1997,9 @@ class String(Atom):
                 return r'\text{%s}' % encode_tex(text, in_text=True)
             else:
                 return encode_tex(text)
+
+    def atom_to_boxes(self, f, evaluation):
+        return String('"' + six.text_type(self.value) + '"')
 
     def do_copy(self):
         return String(self.value)


### PR DESCRIPTION
A cleaner version of the `Atom` implementation used in `Image[]`, that makes it easy to add new `Atom`s, such as `Image[]`, `Graph[]`,  etc. without having to change central code in `MakeBoxes`.

Two changes:

(1) new `AtomBuiltin` (from #378); needed as a mechanism to register a builtin-like symbol that is actually an `Atom` (declaring an `Atom` directly does not register a name that could be used for constructing it in an `Expression`, so there always has to be an accompanying `Builtin`).

(2) moved out logic from `class MakeBoxes(Builtin)` into a new `Atom.atom_to_boxes` method, so that new `Atom`s need not add their logic (and import their symbols) to `MakeBoxes` but must instead provide an implementation of `atom_to_boxes`.

In the current implementation, `MakeBoxes` returns `None` on unknown `Atom` types. This PR changes this to raising an `NotImplementedError` for `Atom`s not implementing `atom_to_boxes`. As implementations are provided for `Symbol`, `Integer`, `Rational`, `Real`, `Complex`, `String`, this might only happen if new `Atom`s are added that do not properly implement `atom_to_boxes`.