### PR TITLE
some small improvements to Piecewise[]

### DIFF
--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -1715,15 +1715,13 @@ class Piecewise(SympyFunction):
     >> Piecewise[{{0, x <= 0}}, 1]
      = Piecewise[{{0, x <= 0}}, 1]
 
-    >> D[%, x]
-     = 0
+    ## D[%, x]
+    ## Piecewise({{0, Or[x < 0, x > 0]}}, Indeterminate).
 
-    In MMA, D[%, x] = Piecewise({{0, Or[x < 0, x > 0]}}, Indeterminate).
+    >> Integrate[Piecewise[{{1, x <= 0}, {-1, x > 0}}], x]
+     = Piecewise[{{x, x <= 0}, {-x, x > 0}}]
 
-    >> Integrate[Piecewise[{{1, x < 0}, {-1, x > 0}}], x]
-     = Piecewise[{{x, x < 0}, {-x, x > 0}}]
-
-    >> Integrate[Piecewise[{{1, x < 0}, {-1, x > 0}}], {x, -1, 2}]
+    >> Integrate[Piecewise[{{1, x <= 0}, {-1, x > 0}}], {x, -1, 2}]
      = -1
 
     Piecewise defaults to 0 if no other case is matching.

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -1718,6 +1718,9 @@ class Piecewise(SympyFunction):
     #> D[%, x]
      = Piecewise({{0, Or[x < 0, x > 0]}}, Indeterminate)
 
+    #> Integrate[Piecewise[{{1, x < 0}, {-1, x > 0}}], x]
+     = Piecewise[{{x, x <= 0}, {-x, x > 0}}]
+
     >> Integrate[Piecewise[{{1, x < 0}, {-1, x > 0}}], {x, -1, 2}]
      = -1
 
@@ -1745,6 +1748,7 @@ class Piecewise(SympyFunction):
             return
 
         sympy_cases = []
+        no_true_seen = True
         for case in leaves[0].leaves:
             if case.get_head_name() != 'System`List':
                 return
@@ -1757,6 +1761,7 @@ class Piecewise(SympyFunction):
                 cond_name = cond.get_name()
                 if cond_name == 'System`True':
                     sympy_cond = True
+                    no_true_seen = False
                 elif cond_name == 'System`False':
                     sympy_cond = False
             if sympy_cond is None:
@@ -1766,7 +1771,7 @@ class Piecewise(SympyFunction):
 
         if len(leaves) == 2:  # default case
             sympy_cases.append((leaves[1].to_sympy(**kwargs), True))
-        else:
+        elif no_true_seen:
             sympy_cases.append((Integer(0), True))
 
         return sympy.Piecewise(*sympy_cases)

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -1748,7 +1748,6 @@ class Piecewise(SympyFunction):
             return
 
         sympy_cases = []
-        no_true_seen = True
         for case in leaves[0].leaves:
             if case.get_head_name() != 'System`List':
                 return
@@ -1761,7 +1760,6 @@ class Piecewise(SympyFunction):
                 cond_name = cond.get_name()
                 if cond_name == 'System`True':
                     sympy_cond = True
-                    no_true_seen = False
                 elif cond_name == 'System`False':
                     sympy_cond = False
             if sympy_cond is None:
@@ -1771,7 +1769,7 @@ class Piecewise(SympyFunction):
 
         if len(leaves) == 2:  # default case
             sympy_cases.append((leaves[1].to_sympy(**kwargs), True))
-        elif no_true_seen:
+        else:
             sympy_cases.append((Integer(0), True))
 
         return sympy.Piecewise(*sympy_cases)

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -1589,7 +1589,7 @@ class Sum(_IterationFunction, SympyFunction):
      = 0
 
     >> (-1 + a^n) Sum[a^(k n), {k, 0, m-1}] // Simplify
-     = Piecewise[{{m, a ^ n == 1}, {(1 - (a ^ n) ^ m) / (1 - a ^ n), True}}] (-1 + a ^ n)
+     = Piecewise[{{m (-1 + a ^ n), a ^ n == 1}}, -1 + (a ^ n) ^ m]
 
     Infinite sums:
     >> Sum[1 / 2 ^ i, {i, 1, Infinity}]
@@ -1715,11 +1715,13 @@ class Piecewise(SympyFunction):
     >> Piecewise[{{0, x <= 0}}, 1]
      = Piecewise[{{0, x <= 0}}, 1]
 
-    #> D[%, x]
-     = Piecewise({{0, Or[x < 0, x > 0]}}, Indeterminate)
+    >> D[%, x]
+     = 0
 
-    #> Integrate[Piecewise[{{1, x < 0}, {-1, x > 0}}], x]
-     = Piecewise[{{x, x <= 0}, {-x, x > 0}}]
+    In MMA, D[%, x] = Piecewise({{0, Or[x < 0, x > 0]}}, Indeterminate).
+
+    >> Integrate[Piecewise[{{1, x < 0}, {-1, x > 0}}], x]
+     = Piecewise[{{x, x < 0}, {-x, x > 0}}]
 
     >> Integrate[Piecewise[{{1, x < 0}, {-1, x > 0}}], {x, -1, 2}]
      = -1

--- a/mathics/builtin/calculus.py
+++ b/mathics/builtin/calculus.py
@@ -143,6 +143,28 @@ class D(SympyFunction):
             'Nest[Function[{t}, D[t, x]], expr, n]'),
     }
 
+    def apply_piecewise(self, p, x, evaluation):
+        'D[Piecewise[p___], x_]'
+
+        p = p.get_sequence()
+        if len(p) not in (1, 2):
+            return
+        if p[0].get_head_name() != 'System`List':
+            return
+        cases = []
+        for leaf in p[0].leaves:
+            if leaf.get_head_name() != 'System`List':
+                return
+            if len(leaf.leaves) != 2:
+                return
+            expr, cond = leaf.leaves
+            cases.append(Expression('List', Expression('D', expr, x), cond))
+        if len(p) == 2:
+            default = [Expression('D', p[1], x)]
+        else:
+            default = []
+        return Expression('Piecewise', Expression('List', *cases), *default)
+
     def apply(self, f, x, evaluation):
         'D[f_, x_?NotListQ]'
 

--- a/mathics/builtin/calculus.py
+++ b/mathics/builtin/calculus.py
@@ -143,28 +143,6 @@ class D(SympyFunction):
             'Nest[Function[{t}, D[t, x]], expr, n]'),
     }
 
-    def apply_piecewise(self, p, x, evaluation):
-        'D[Piecewise[p___], x_]'
-
-        p = p.get_sequence()
-        if len(p) not in (1, 2):
-            return
-        if p[0].get_head_name() != 'System`List':
-            return
-        cases = []
-        for leaf in p[0].leaves:
-            if leaf.get_head_name() != 'System`List':
-                return
-            if len(leaf.leaves) != 2:
-                return
-            expr, cond = leaf.leaves
-            cases.append(Expression('List', Expression('D', expr, x), cond))
-        if len(p) == 2:
-            default = [Expression('D', p[1], x)]
-        else:
-            default = []
-        return Expression('Piecewise', Expression('List', *cases), *default)
-
     def apply(self, f, x, evaluation):
         'D[f_, x_?NotListQ]'
 

--- a/mathics/core/convert.py
+++ b/mathics/core/convert.py
@@ -182,6 +182,9 @@ def from_sympy(expr):
     elif isinstance(expr, SympyExpression):
         return expr.expr
 
+    elif isinstance(expr, sympy.Piecewise):
+        return Expression('Piecewise', Expression(
+            'List', *[Expression('List', from_sympy(case), from_sympy(cond)) for case, cond in expr.args]))
     elif isinstance(expr, sympy.RootSum):
         return Expression('RootSum', from_sympy(expr.poly),
                           from_sympy(expr.fun))
@@ -236,22 +239,22 @@ def from_sympy(expr):
 
     elif isinstance(expr, sympy.LessThan):
         return Expression('LessEqual',
-                          [from_sympy(arg) for arg in expr.args])
+                          *[from_sympy(arg) for arg in expr.args])
     elif isinstance(expr, sympy.StrictLessThan):
         return Expression('Less',
-                          [from_sympy(arg) for arg in expr.args])
+                          *[from_sympy(arg) for arg in expr.args])
     elif isinstance(expr, sympy.GreaterThan):
         return Expression('GreaterEqual',
-                          [from_sympy(arg) for arg in expr.args])
+                          *[from_sympy(arg) for arg in expr.args])
     elif isinstance(expr, sympy.StrictGreaterThan):
         return Expression('Greater',
-                          [from_sympy(arg) for arg in expr.args])
+                          *[from_sympy(arg) for arg in expr.args])
     elif isinstance(expr, sympy.Unequality):
         return Expression('Unequal',
-                          [from_sympy(arg) for arg in expr.args])
+                          *[from_sympy(arg) for arg in expr.args])
     elif isinstance(expr, sympy.Equality):
         return Expression('Equal',
-                          [from_sympy(arg) for arg in expr.args])
+                          *[from_sympy(arg) for arg in expr.args])
     elif expr is sympy.true:
         return Symbol('True')
     elif expr is sympy.false:

--- a/mathics/core/convert.py
+++ b/mathics/core/convert.py
@@ -183,8 +183,19 @@ def from_sympy(expr):
         return expr.expr
 
     elif isinstance(expr, sympy.Piecewise):
-        return Expression('Piecewise', Expression(
-            'List', *[Expression('List', from_sympy(case), from_sympy(cond)) for case, cond in expr.args]))
+        args = expr.args
+        default = []
+        if len(args) > 0:
+            default_case, default_cond = args[-1]
+            if default_cond == sympy.true:
+                args = args[:-1]
+                if isinstance(default_case, sympy.Integer) and int(default_case) == 0:
+                    pass  # ignore
+                else:
+                    default = [from_sympy(default_case)]
+        return Expression('Piecewise', Expression('List', *[Expression(
+            'List', from_sympy(case), from_sympy(cond)) for case, cond in args]), *default)
+
     elif isinstance(expr, sympy.RootSum):
         return Expression('RootSum', from_sympy(expr.poly),
                           from_sympy(expr.fun))

--- a/mathics/core/convert.py
+++ b/mathics/core/convert.py
@@ -190,7 +190,7 @@ def from_sympy(expr):
             if default_cond == sympy.true:
                 args = args[:-1]
                 if isinstance(default_case, sympy.Integer) and int(default_case) == 0:
-                    pass  # ignore
+                    pass  # ignore, as 0 default case is always implicit in Piecewise[]
                 else:
                     default = [from_sympy(default_case)]
         return Expression('Piecewise', Expression('List', *[Expression(


### PR DESCRIPTION
These are some small improvements to `Piecewise[]`,  which improve things in my opinion, as `Piecewise[]` can now be used and is evaluated as soon as it gets into the regular Sympy pipeline.

`D` and `Derivative` still do not work as they don't use the Sympy pipeline and someone understanding `D`'s logic might want to look at this (I tried and failed).

adding `*` in the comparison (e.g. `LessEqual`) cases in `convert.py` is actually a bug fix; without it, `from_sympy` produces stuff like `LessEqual(List(a), List(b))`.

 