### PR TITLE
Only numerify if the result is numeric

### DIFF
--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -125,7 +125,7 @@ class Plus(BinaryOperator, SympyFunction):
     >> a + a + 3 * a
      = 5 a
     >> a + b + 4.5 + a + b + a + 2 + 1.5 b
-     = 6.5 + 3. a + 3.5 b
+     = 6.5 + 3 a + 3.5 b
 
     Apply 'Plus' on a list to sum up its elements:
     >> Plus @@ {2, 4, 6}

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -1222,7 +1222,9 @@ class Expression(BaseExpression):
                 # and we don't want to lose exactness in e.g. 1.0+I.
                 if not isinstance(leaf, Number):
                     n_expr = Expression('N', leaf, Integer(dps(_prec)))
-                    new_leaves[index] = n_expr.evaluate(evaluation)
+                    n_result = n_expr.evaluate(evaluation)
+                    if isinstance(n_result, Number):
+                        new_leaves[index] = n_result
             return Expression(self.head, *new_leaves)
         else:
             return self


### PR DESCRIPTION
Avoids downgrading exact expressions to inexact ones when they don't
evaluate to a numeric result.

Before:
```
In[1]:= 1. + Sqrt[x]
Out[1]= 1. + x ^ 0.5
```
After:
```
In[1]:= 1. + Sqrt[x]
Out[1]= 1. + Sqrt[x]
```