### PR TITLE
Replace[]

### DIFF
--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -483,6 +483,8 @@ def python_levelspec(levelspec):
             return values[0], values[1]
         else:
             raise InvalidLevelspecError
+    elif isinstance(levelspec, Symbol) and levelspec.get_name() == 'System`All':
+        return 0, None
     else:
         return 1, value_to_level(levelspec)
 

--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -149,14 +149,22 @@ class Replace(Builtin):
     >> Replace[x, {x -> 2}]
      = 2
 
-    By default, only the top level gets replaced.
+    By default, only the top level is searched for matches
     >> Replace[1 + x, {x -> 2}]
      = 1 + x
 
     >> Replace[x, {{x -> 1}, {x -> 2}}]
      = {1, 2}
 
-    You can use Replace as an operator:
+    Replace stops after the first replacement
+    >> Replace[x, {x -> {}, _List -> y}]
+     = {}
+
+    Replace replaces the deepest levels first
+    >> Replace[x[1], {x[1] -> y, 1 -> 2}, All]
+     = x[2]
+
+    You can use Replace as an operator
     >> Replace[{x_ -> x + 1}][10]
      = 11
     """
@@ -176,7 +184,7 @@ class Replace(Builtin):
             return rules
 
         result, applied = expr.apply_rules(
-            rules, evaluation, level=0, levelspec=levelspec)
+            rules, evaluation, level=0, options={'levelspec': levelspec})
         return result
 
     def apply(self, expr, rules, evaluation):
@@ -221,6 +229,10 @@ class ReplaceAll(BinaryOperator):
 
     #> a + b /. x_ + y_ -> {x, y}
      = {a, b}
+
+    ReplaceAll replaces the shallowest levels first:
+    >> ReplaceAll[x[1], {x[1] -> y, 1 -> 2}]
+     = y
     """
 
     operator = '/.'

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -1110,23 +1110,15 @@ class Expression(BaseExpression):
             new_applied[0] = applied
             return descend(Expression(head, *self.leaves)), new_applied[0]
         else:  # Replace mode; replace depth first
-            l1, l2 = options['levelspec']
-            if level < l1:
-                apply_this_level = False
-            elif l2 is not None and level > l2:
-                return self, False
-            else:
-                apply_this_level = True
-
             expr = descend(self)
-            if apply_this_level:
-                expr, applied = super(
-                    Expression, expr).apply_rules(rules, evaluation, level, options)
+            expr, applied = super(
+                Expression, expr).apply_rules(rules, evaluation, level, options)
+            new_applied[0] = new_applied[0] or applied
+            if not applied and options['heads']:
+                # heads in Replace are treated at the level of the arguments, i.e. level + 1
+                head, applied = expr.head.apply_rules(rules, evaluation, level + 1, options)
                 new_applied[0] = new_applied[0] or applied
-                if not applied:
-                    head, applied = expr.head.apply_rules(rules, evaluation, level, options)
-                    new_applied[0] = new_applied[0] or applied
-                    expr = Expression(head, *expr.leaves)
+                expr = Expression(head, *expr.leaves)
             return expr, new_applied[0]
 
 


### PR DESCRIPTION
An implementation for `Replace[]`.

The changes in `apply_rules` were necessary since `Replace` replaces depth first, whereas `ReplaceAll` replaces breadth first.