### PR TITLE
FilledCurve[], BezierCurve[], BezierFunction[]

### DIFF
--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -1797,9 +1797,16 @@ class Piecewise(SympyFunction):
 
     >> Plot[Piecewise[{{Log[x], x > 0}, {x*-0.5, x < 0}}], {x, -1, 1}]
      = -Graphics-
+
+    >> Piecewise[{{0 ^ 0, False}}, -1]
+     = -1
     """
 
     sympy_name = 'Piecewise'
+
+    attributes = (
+        'HoldAll',
+    )
 
     def apply(self, items, evaluation):
         'Piecewise[items__]'

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -1810,8 +1810,7 @@ class Piecewise(SympyFunction):
 
     def apply(self, items, evaluation):
         'Piecewise[items__]'
-        result = self.to_sympy(
-            Expression('Piecewise', *items.get_sequence()), evaluation=evaluation)
+        result = self.to_sympy(Expression('Piecewise', *items.get_sequence()))
         if result is None:
             return
         if not isinstance(result, sympy.Piecewise):
@@ -1823,8 +1822,6 @@ class Piecewise(SympyFunction):
         if len(leaves) not in (1, 2):
             return
 
-        evaluation = kwargs['evaluation']
-
         sympy_cases = []
         for case in leaves[0].leaves:
             if case.get_head_name() != 'System`List':
@@ -1832,7 +1829,6 @@ class Piecewise(SympyFunction):
             if len(case.leaves) != 2:
                 return
             then, cond = case.leaves
-            cond = cond.evaluate(evaluation)
 
             sympy_cond = None
             if isinstance(cond, Symbol):

--- a/mathics/builtin/comparison.py
+++ b/mathics/builtin/comparison.py
@@ -318,7 +318,21 @@ def do_cmp(x1, x2):
         return None
 
 
-class Equal(_EqualityOperator, SympyFunction):
+class SympyComparison(SympyFunction):
+    def to_sympy(self, expr, **kwargs):
+        to_sympy = super(SympyComparison, self).to_sympy
+        if len(expr.leaves) > 2:
+            def pairs(items):
+                yield Expression(expr.get_head_name(), *items[:2])
+                items = items[1:]
+                while len(items) >= 2:
+                    yield Expression(expr.get_head_name(), *items[:2])
+                    items = items[1:]
+            return sympy.And(*[to_sympy(p, **kwargs) for p in pairs(expr.leaves)])
+        return to_sympy(expr, **kwargs)
+
+
+class Equal(_EqualityOperator, SympyComparison):
     """
     <dl>
     <dt>'Equal[$x$, $y$]'
@@ -408,7 +422,7 @@ class Equal(_EqualityOperator, SympyFunction):
         return x
 
 
-class Unequal(_EqualityOperator, SympyFunction):
+class Unequal(_EqualityOperator, SympyComparison):
     """
     <dl>
     <dt>'Unequal[$x$, $y$]'
@@ -463,7 +477,7 @@ class Unequal(_EqualityOperator, SympyFunction):
         return not x
 
 
-class Less(_ComparisonOperator, SympyFunction):
+class Less(_ComparisonOperator, SympyComparison):
     """
     <dl>
     <dt>'Less[$x$, $y$]'
@@ -481,7 +495,7 @@ class Less(_ComparisonOperator, SympyFunction):
     sympy_name = 'StrictLessThan'
 
 
-class LessEqual(_ComparisonOperator, SympyFunction):
+class LessEqual(_ComparisonOperator, SympyComparison):
     """
     <dl>
     <dt>'LessEqual[$x$, $y$]'
@@ -495,7 +509,7 @@ class LessEqual(_ComparisonOperator, SympyFunction):
     sympy_name = 'LessThan'
 
 
-class Greater(_ComparisonOperator, SympyFunction):
+class Greater(_ComparisonOperator, SympyComparison):
     """
     <dl>
     <dt>'Greater[$x$, $y$]'
@@ -514,7 +528,7 @@ class Greater(_ComparisonOperator, SympyFunction):
     sympy_name = 'StrictGreaterThan'
 
 
-class GreaterEqual(_ComparisonOperator, SympyFunction):
+class GreaterEqual(_ComparisonOperator, SympyComparison):
     """
     <dl>
     <dt>'GreaterEqual[$x$, $y$]'

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -911,9 +911,14 @@ def _svg_bezier(*segments):
 
 class BernsteinBasis(Builtin):
     rules = {
-        'BernsteinBasis[d_, n_, x_]': 'Piecewise[{{Binomial[d, n] * x ^ n * (1 - x) ^ (d - n), 0 < x < 1}}, 0]'
+        'BernsteinBasis[d_, n_, x_]': 'Piecewise[{{Binomial[d, n] * x ^ n * (1 - x) ^ (d - n), 0 < x < 1}}, 0]',
     }
 
+
+class BezierFunction(Builtin):
+    rules = {
+        'BezierFunction[p_]': 'Function[x, Total[p * BernsteinBasis[Length[p] - 1, Range[0, Length[p] - 1], x]]]',
+    }
 
 class BezierCurve(Builtin):
     """

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -1439,6 +1439,13 @@ class _GraphicsElements(object):
         self.evaluation = evaluation
         self.elements = []
 
+        builtins = evaluation.definitions.builtin
+        def get_options(name):
+            builtin = builtins.get(name)
+            if builtin is None:
+                return None
+            return builtin.options
+
         def convert(content, style):
             if content.has_form('List', None):
                 items = content.leaves
@@ -1463,7 +1470,7 @@ class _GraphicsElements(object):
                 elif head[-3:] == 'Box':  # and head[:-3] in element_heads:
                     element_class = get_class(head)
                     if element_class is not None:
-                        options = evaluation.definitions.builtin[head[:-3]].options
+                        options = get_options(head[:-3])
                         if options:
                             data, options = _data_and_options(item.leaves, options)
                             new_item = Expression(head, *data)

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -920,7 +920,7 @@ def _asy_bezier(*segments):
         return
 
     def cubic(p0, p1, p2, p3):
-        return '..controls(%.5g,%.5g) and (%.5g,%.5g)..(%.5g,%.5g)' % (*p1, *p2, *p3)
+        return '..controls(%.5g,%.5g) and (%.5g,%.5g)..(%.5g,%.5g)' % tuple(list(chain(p1, p2, p3)))
 
     def quadratric(qp0, qp1, qp2):
         # asymptote only supports cubic beziers, so we convert this quadratic


### PR DESCRIPTION
These work with svg and asy (I've tested both with the accompanying test cases). One test case specifically demonstrates that the points generated by `BezierFunction` match the curve which defined through the svg/asy commands.

There are two changes to `Piecewise` in here needed for `BernsteinBasis` (and because I was too confused and committed this to this PR instead of a new one). `Piecewise` now holds all expressions, as some might not be evaluable, and only evaluates conditions.