### PR TITLE
fixes Image[] import and export

### DIFF
--- a/mathics/autoload/formats/Image/Export.m
+++ b/mathics/autoload/formats/Image/Export.m
@@ -2,7 +2,7 @@
 
 Begin["System`Convert`Image`"]
 
-RegisterImageExport[type_] := RegisterExport[
+RegisterImageExport[type_] := ImportExport`RegisterExport[
     type,
 	System`ImageExport,
 	Options -> {},

--- a/mathics/autoload/formats/Image/Import.m
+++ b/mathics/autoload/formats/Image/Import.m
@@ -2,7 +2,7 @@
 
 Begin["System`Convert`Image`"]
 
-RegisterImageImport[type_] := RegisterImport[
+RegisterImageImport[type_] := ImportExport`RegisterImport[
     type,
     System`ImageImport,
     {},

--- a/mathics/builtin/importexport.py
+++ b/mathics/builtin/importexport.py
@@ -596,7 +596,7 @@ class Export(Builtin):
 
     def _infer_form(self, filename, evaluation):
         ext = Expression('FileExtension', filename).evaluate(evaluation)
-        ext = ext.get_string_value()
+        ext = ext.get_string_value().lower()
         return self._extdict.get(ext)
 
 


### PR DESCRIPTION
Somehow the context for `RegisterExport` was missing and so this didn't register properly and didn't work (it worked once). Also changed export file extension detection to case insensitive mode so we can now export to 'abc.PNG' as well.