### PR TITLE
PointSize[]

### DIFF
--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -498,11 +498,11 @@ class PointSize(_Size):
     """
     <dl>
     <dt>'PointSize[$t$]'
-        <dd>sets the diameter of points to $t$.
+        <dd>sets the diameter of points to $t$, which is relative to the overall width.
     </dl>
     """
     def get_size(self):
-        return self.graphics.extent_width * self.value
+        return self.graphics.view_width * self.value
 
 
 class Offset(Builtin):
@@ -1435,6 +1435,9 @@ class GraphicsBox(BoxConstruct):
         elements, calc_dimensions = self._prepare_elements(
             leaves, options, max_width=450)
 
+        xmin, xmax, ymin, ymax, w, h, width, height = calc_dimensions()
+        elements.view_width = w
+
         asy_completely_visible = '\n'.join(
             element.to_asy() for element in elements.elements
             if element.is_completely_visible)
@@ -1442,8 +1445,6 @@ class GraphicsBox(BoxConstruct):
         asy_regular = '\n'.join(
             element.to_asy() for element in elements.elements
             if not element.is_completely_visible)
-
-        xmin, xmax, ymin, ymax, w, h, width, height = calc_dimensions()
 
         tex = r"""
 \begin{asy}
@@ -1464,9 +1465,10 @@ clip(box((%s,%s), (%s,%s)));
         elements, calc_dimensions = self._prepare_elements(
             leaves, options, neg_y=True)
 
-        svg = elements.to_svg()
-
         xmin, xmax, ymin, ymax, w, h, width, height = calc_dimensions()
+        elements.view_width = w
+
+        svg = elements.to_svg()
 
         xmin -= 1
         ymin -= 1

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -423,9 +423,9 @@ class GrayLevel(_Color):
         return (g, g, g, self.components[1])
 
 
-class _Thickness(_GraphicsElement):
+class _Size(_GraphicsElement):
     def init(self, graphics, item=None, value=None):
-        super(_Thickness, self).init(graphics, item)
+        super(_Size, self).init(graphics, item)
         if item is not None:
             self.value = item.leaves[0].round_to_float()
         elif value is not None:
@@ -434,6 +434,10 @@ class _Thickness(_GraphicsElement):
             raise BoxConstructError
         if self.value < 0:
             raise BoxConstructError
+
+
+class _Thickness(_Size):
+    pass
 
 
 class AbsoluteThickness(_Thickness):
@@ -488,6 +492,17 @@ class Thick(Builtin):
     rules = {
         'Thick': 'AbsoluteThickness[2]',
     }
+
+
+class PointSize(_Size):
+    """
+    <dl>
+    <dt>'PointSize[$t$]'
+        <dd>sets the diameter of points to $t$.
+    </dl>
+    """
+    def get_size(self):
+        return self.graphics.extent_width * self.value
 
 
 class Offset(Builtin):
@@ -763,14 +778,18 @@ class PointBox(_Polyline):
             raise BoxConstructError
 
     def to_svg(self):
-        l = self.style.get_line_width(face_element=False)
+        point_size, _ = self.style.get_style(PointSize, face_element=False)
+        if point_size is None:
+            point_size = PointSize(self.graphics, value=0.005)
+        size = point_size.get_size()
+
         style = create_css(edge_color=self.edge_color,
-                           stroke_width=l, face_color=self.face_color)
+                           stroke_width=0, face_color=self.face_color)
         svg = ''
         for line in self.lines:
             for coords in line:
-                svg += '<circle cx="%f" cy="%f" r="1" style="%s" />' % (
-                    coords.pos()[0], coords.pos()[1], style)
+                svg += '<circle cx="%f" cy="%f" r="%f" style="%s" />' % (
+                    coords.pos()[0], coords.pos()[1], size, style)
         return svg
 
     def to_asy(self):
@@ -1992,6 +2011,7 @@ styles = system_symbols_dict({
     'AbsoluteThickness': AbsoluteThickness,
     'Thick': Thick,
     'Thin': Thin,
+    'PointSize': PointSize,
 })
 
 style_heads = frozenset(styles.keys())


### PR DESCRIPTION
This adds `PointSize[]` and boosts the standard point size to something more like MMA.

Attached are two `ListPlot[{1, 10, 5, 3}]` pictures (before and after) to see the difference.

<img width="429" alt="before" src="https://cloud.githubusercontent.com/assets/11859538/17892687/ddfca8ca-6942-11e6-95b0-c1c56aa45a8d.png">

<img width="427" alt="after" src="https://cloud.githubusercontent.com/assets/11859538/17892697/e3c241a2-6942-11e6-89e3-367bd9090600.png">

In order for the `PointSize[]` parameter to really scale with the actual width, I had to introduce `view_width`, since neither `extent_width` nor `pixel_width` measure the final, clipped area. This is important if something like `Graphics[{PointSize[0.3], Point[{0, 0}]}]` should work (which it does now). This is the same approach used in https://github.com/mathics/Mathics/pull/470, which works well there.
