### PR TITLE
Faster $RecursionLimit

### DIFF
--- a/mathics/builtin/assignment.py
+++ b/mathics/builtin/assignment.py
@@ -172,6 +172,7 @@ class _SetOperator(object):
                 # TODO: Message
                 return False
             ignore_protection = True
+            evaluation.definitions.set_recursionlimit(rhs_int_value)
         elif lhs_name == 'System`$ModuleNumber':
             if not rhs_int_value or rhs_int_value <= 0:
                 evaluation.message('$ModuleNumber', 'set', rhs)

--- a/mathics/builtin/assignment.py
+++ b/mathics/builtin/assignment.py
@@ -172,7 +172,6 @@ class _SetOperator(object):
                 # TODO: Message
                 return False
             ignore_protection = True
-            evaluation.definitions.set_recursionlimit(rhs_int_value)
         elif lhs_name == 'System`$ModuleNumber':
             if not rhs_int_value or rhs_int_value <= 0:
                 evaluation.message('$ModuleNumber', 'set', rhs)

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -44,7 +44,7 @@ class Definitions(object):
         super(Definitions, self).__init__()
         self.builtin = {}
         self.user = {}
-        self.recursionlimit = settings.MAX_RECURSION_DEPTH
+        self.recursionlimit = None
 
         if add_builtin:
             from mathics.builtin import modules, contribute
@@ -326,10 +326,12 @@ class Definitions(object):
     def reset_user_definition(self, name):
         assert not isinstance(name, Symbol)
         del self.user[self.lookup_name(name)]
+        self.recursionlimit = None
 
     def add_user_definition(self, name, definition):
         assert not isinstance(name, Symbol)
         self.user[self.lookup_name(name)] = definition
+        self.recursionlimit = None
 
     def set_attribute(self, name, attribute):
         definition = self.get_user_definition(self.lookup_name(name))
@@ -347,9 +349,11 @@ class Definitions(object):
     def add_rule(self, name, rule, position=None):
         name = self.lookup_name(name)
         if position is None:
-            return self.get_user_definition(name).add_rule(rule)
+            result = self.get_user_definition(name).add_rule(rule)
         else:
-            return self.get_user_definition(name).add_rule_at(rule, position)
+            result = self.get_user_definition(name).add_rule_at(rule, position)
+        self.recursionlimit = None
+        return result
 
     def add_format(self, name, rule, form=''):
         definition = self.get_user_definition(self.lookup_name(name))
@@ -378,12 +382,14 @@ class Definitions(object):
         pos = valuesname(values)
         definition = self.get_user_definition(self.lookup_name(name))
         definition.set_values_list(pos, rules)
+        self.recursionlimit = None
 
     def get_options(self, name):
         return self.get_definition(self.lookup_name(name)).options
 
     def reset_user_definitions(self):
         self.user = {}
+        self.recursionlimit = None
 
     def get_user_definitions(self):
         if six.PY2:
@@ -399,6 +405,7 @@ class Definitions(object):
                 self.user = pickle.loads(base64.decodebytes(definitions.encode('ascii')))
         else:
             self.user = {}
+        self.recursionlimit = None
 
     def get_ownvalue(self, name):
         ownvalues = self.get_definition(self.lookup_name(name)).ownvalues
@@ -419,12 +426,13 @@ class Definitions(object):
 
     def unset(self, name, expr):
         definition = self.get_user_definition(self.lookup_name(name))
-        return definition.remove_rule(expr)
-
-    def set_recursionlimit(self, limit):
-        self.recursionlimit = limit
+        result = definition.remove_rule(expr)
+        self.recursionlimit = None
+        return result
 
     def get_recursionlimit(self):
+        if self.recursionlimit is None:
+            self.recursionlimit = self.get_config_value('$RecursionLimit', settings.MAX_RECURSION_DEPTH)
         return self.recursionlimit
 
     def get_config_value(self, name, default=None):

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -14,6 +14,7 @@ import bisect
 
 from mathics.core.expression import Expression, Symbol, String, fully_qualified_symbol_name
 from mathics.core.characters import letters, letterlikes
+from mathics import settings
 
 
 names_wildcards = "@*"
@@ -43,6 +44,7 @@ class Definitions(object):
         super(Definitions, self).__init__()
         self.builtin = {}
         self.user = {}
+        self.recursionlimit = settings.MAX_RECURSION_DEPTH
 
         if add_builtin:
             from mathics.builtin import modules, contribute
@@ -418,6 +420,12 @@ class Definitions(object):
     def unset(self, name, expr):
         definition = self.get_user_definition(self.lookup_name(name))
         return definition.remove_rule(expr)
+
+    def set_recursionlimit(self, limit):
+        self.recursionlimit = limit
+
+    def get_recursionlimit(self):
+        return self.recursionlimit
 
     def get_config_value(self, name, default=None):
         'Infinity -> None, otherwise returns integer.'

--- a/mathics/core/evaluation.py
+++ b/mathics/core/evaluation.py
@@ -444,8 +444,7 @@ class Evaluation(object):
 
     def inc_recursion_depth(self):
         self.check_stopped()
-        limit = self.definitions.get_config_value(
-            '$RecursionLimit', settings.MAX_RECURSION_DEPTH)
+        limit = self.definitions.get_recursionlimit()
         if limit is not None:
             if limit < 20:
                 limit = 20


### PR DESCRIPTION
The currrent check for `$RecursionLimit` is slow for functions with recursion. For these cases, this PR yields a 20% improvement in performance.


This PR caches `$RecursionLimit` in an attribute of `Definitions`, thus avoiding having to look it up in the symbol tables. ~~As the setting of `$RecursionLimit` already has special case in`assignment.py`, this change is easy.~~ __EDIT__ this turned out to be not true.

Before:
```
In[1]:= Timing[Length[#+1& /@ Range[10000]]]
Out[1]= {5.00666, 10000}
```

After:
```

In[2]:= Timing[Length[#+1& /@ Range[10000]]]
Out[2]= {4.08788, 10000}
```

Most other functions are not changed in their performance:

[before.txt](https://github.com/mathics/Mathics/files/436458/before.txt)

[after.txt](https://github.com/mathics/Mathics/files/436460/after.txt)
