### PR TITLE
Faster StringSplit[]

### DIFF
--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -617,7 +617,7 @@ class StringSplit(Builtin):
         for re_patt in re_patts:
             result = [t for s in result for t in mathics_split(re_patt, s, flags=flags)]
 
-        return from_python([x for x in result if x != ''])
+        return Expression('List', *[String(x) for x in result if x != ''])
 
 
 class StringPosition(Builtin):


### PR DESCRIPTION
Avoids the use of `from_python` and thus gains 10% speed.