### PR TITLE
Speedups for Position[], Cases[], DeleteCases[]

### DIFF
--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -572,19 +572,26 @@ class Except(PatternObject):
             self.p.match(yield_func, expression, vars, evaluation)
 
 
+class Matcher(object):
+    def __init__(self, form):
+        self.form = Pattern.create(form)
+
+    def match(self, expr, evaluation):
+        class StopGenerator_MatchQ(StopGenerator):
+            pass
+
+        def yield_func(vars, rest):
+            raise StopGenerator_MatchQ(Symbol("True"))
+
+        try:
+            self.form.match(yield_func, expr, {}, evaluation)
+        except StopGenerator_MatchQ:
+            return True
+        return False
+
+
 def match(expr, form, evaluation):
-    class StopGenerator_MatchQ(StopGenerator):
-        pass
-
-    form = Pattern.create(form)
-
-    def yield_func(vars, rest):
-        raise StopGenerator_MatchQ(Symbol("True"))
-    try:
-        form.match(yield_func, expr, {}, evaluation)
-    except StopGenerator_MatchQ:
-        return True
-    return False
+    return Matcher(form).match(expr, evaluation)
 
 
 class MatchQ(Builtin):


### PR DESCRIPTION
BEFORE:

```
In[3]:= Timing[Position[Range[10000], 100]]
Out[3]= {2.08852, {{100}}}

In[2]:= Timing[Cases[Range[10000], Real]]
Out[2]= {4.01146, {}}

In[4]:= Timing[Length[DeleteCases[Range[10000], 100]]]
Out[4]= {5.31249, 9999}
```

AFTER:

```
In[3]:= Timing[Position[Range[10000], 100]]
Out[3]= {0.448546, {{100}}}

In[2]:= Timing[Cases[Range[10000], Real]]
Out[2]= {0.43542, {}}

In[4]:= Timing[Length[DeleteCases[Range[10000], 100]]]
Out[4]= {0.665926, 9999}
```

If you're dealing with 100 000 elements, this really makes a difference.