### PR TITLE
Cache for Definitions

### DIFF
--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -43,6 +43,7 @@ class Definitions(object):
         super(Definitions, self).__init__()
         self.builtin = {}
         self.user = {}
+        self.cache = {}
 
         if add_builtin:
             from mathics.builtin import modules, contribute
@@ -102,6 +103,7 @@ class Definitions(object):
     def set_current_context(self, context):
         assert isinstance(context, six.string_types)
         self.set_ownvalue('System`$Context', String(context))
+        self.cache = {}
 
     def set_context_path(self, context_path):
         assert isinstance(context_path, list)
@@ -109,6 +111,7 @@ class Definitions(object):
         self.set_ownvalue('System`$ContextPath',
                           Expression('System`List',
                                      *[String(c) for c in context_path]))
+        self.cache = {}
 
     def get_builtin_names(self):
         return set(self.builtin)
@@ -224,49 +227,59 @@ class Definitions(object):
         return self.get_definition(name, only_if_exists=True) is not None
 
     def get_definition(self, name, only_if_exists=False):
+        if not only_if_exists:
+            definition = self.cache.get(name, None)
+            if definition is not None:
+                return definition
+
         name = self.lookup_name(name)
         user = self.user.get(name, None)
         builtin = self.builtin.get(name, None)
 
         if user is None and builtin is None:
-            return None if only_if_exists else Definition(name=name)
-        if builtin is None:
-            return user
-        if user is None:
-            return builtin
-
-        if user:
-            attributes = user.attributes
-        elif builtin:
-            attributes = builtin.attributes
+            definition = None if only_if_exists else Definition(name=name)
+        elif builtin is None:
+            definition = user
+        elif user is None:
+            definition = builtin
         else:
-            attributes = set()
-        if not user:
-            user = Definition(name=name)
-        if not builtin:
-            builtin = Definition(name=name)
-        options = builtin.options.copy()
-        options.update(user.options)
-        formatvalues = builtin.formatvalues.copy()
-        for form, rules in six.iteritems(user.formatvalues):
-            if form in formatvalues:
-                formatvalues[form].extend(rules)
+            if user:
+                attributes = user.attributes
+            elif builtin:
+                attributes = builtin.attributes
             else:
-                formatvalues[form] = rules
+                attributes = set()
+            if not user:
+                user = Definition(name=name)
+            if not builtin:
+                builtin = Definition(name=name)
+            options = builtin.options.copy()
+            options.update(user.options)
+            formatvalues = builtin.formatvalues.copy()
+            for form, rules in six.iteritems(user.formatvalues):
+                if form in formatvalues:
+                    formatvalues[form].extend(rules)
+                else:
+                    formatvalues[form] = rules
 
-        return Definition(name=name,
-                          ownvalues=user.ownvalues + builtin.ownvalues,
-                          downvalues=user.downvalues + builtin.downvalues,
-                          subvalues=user.subvalues + builtin.subvalues,
-                          upvalues=user.upvalues + builtin.upvalues,
-                          formatvalues=formatvalues,
-                          messages=user.messages + builtin.messages,
-                          attributes=attributes,
-                          options=options,
-                          nvalues=user.nvalues + builtin.nvalues,
-                          defaultvalues=user.defaultvalues +
-                          builtin.defaultvalues,
-                          )
+            definition = Definition(name=name,
+                              ownvalues=user.ownvalues + builtin.ownvalues,
+                              downvalues=user.downvalues + builtin.downvalues,
+                              subvalues=user.subvalues + builtin.subvalues,
+                              upvalues=user.upvalues + builtin.upvalues,
+                              formatvalues=formatvalues,
+                              messages=user.messages + builtin.messages,
+                              attributes=attributes,
+                              options=options,
+                              nvalues=user.nvalues + builtin.nvalues,
+                              defaultvalues=user.defaultvalues +
+                              builtin.defaultvalues,
+                              )
+
+        if not only_if_exists:
+            self.cache[name] = definition
+
+        return definition
 
     def get_attributes(self, name):
         return self.get_definition(name).attributes
@@ -324,30 +337,37 @@ class Definitions(object):
     def reset_user_definition(self, name):
         assert not isinstance(name, Symbol)
         del self.user[self.lookup_name(name)]
+        self.cache = {}
 
     def add_user_definition(self, name, definition):
         assert not isinstance(name, Symbol)
         self.user[self.lookup_name(name)] = definition
+        self.cache = {}
 
     def set_attribute(self, name, attribute):
         definition = self.get_user_definition(self.lookup_name(name))
         definition.attributes.add(attribute)
+        self.cache = {}
 
     def set_attributes(self, name, attributes):
         definition = self.get_user_definition(self.lookup_name(name))
         definition.attributes = set(attributes)
+        self.cache = {}
 
     def clear_attribute(self, name, attribute):
         definition = self.get_user_definition(self.lookup_name(name))
         if attribute in definition.attributes:
             definition.attributes.remove(attribute)
+        self.cache = {}
 
     def add_rule(self, name, rule, position=None):
         name = self.lookup_name(name)
         if position is None:
-            return self.get_user_definition(name).add_rule(rule)
+            result = self.get_user_definition(name).add_rule(rule)
         else:
-            return self.get_user_definition(name).add_rule_at(rule, position)
+            result = self.get_user_definition(name).add_rule_at(rule, position)
+        self.cache = {}
+        return result
 
     def add_format(self, name, rule, form=''):
         definition = self.get_user_definition(self.lookup_name(name))
@@ -359,29 +379,35 @@ class Definitions(object):
             if form not in definition.formatvalues:
                 definition.formatvalues[form] = []
             insert_rule(definition.formatvalues[form], rule)
+        self.cache = {}
 
     def add_nvalue(self, name, rule):
         definition = self.get_user_definition(self.lookup_name(name))
         definition.add_rule_at(rule, 'n')
+        self.cache = {}
 
     def add_default(self, name, rule):
         definition = self.get_user_definition(self.lookup_name(name))
         definition.add_rule_at(rule, 'default')
+        self.cache = {}
 
     def add_message(self, name, rule):
         definition = self.get_user_definition(self.lookup_name(name))
         definition.add_rule_at(rule, 'messages')
+        self.cache = {}
 
     def set_values(self, name, values, rules):
         pos = valuesname(values)
         definition = self.get_user_definition(self.lookup_name(name))
         definition.set_values_list(pos, rules)
+        self.cache = {}
 
     def get_options(self, name):
         return self.get_definition(self.lookup_name(name)).options
 
     def reset_user_definitions(self):
         self.user = {}
+        self.cache = {}
 
     def get_user_definitions(self):
         if six.PY2:
@@ -397,6 +423,7 @@ class Definitions(object):
                 self.user = pickle.loads(base64.decodebytes(definitions.encode('ascii')))
         else:
             self.user = {}
+        self.cache = {}
 
     def get_ownvalue(self, name):
         ownvalues = self.get_definition(self.lookup_name(name)).ownvalues
@@ -410,14 +437,17 @@ class Definitions(object):
 
         name = self.lookup_name(name)
         self.add_rule(name, Rule(Symbol(name), value))
+        self.cache = {}
 
     def set_options(self, name, options):
         definition = self.get_user_definition(self.lookup_name(name))
         definition.options = options
+        self.cache = {}
 
     def unset(self, name, expr):
         definition = self.get_user_definition(self.lookup_name(name))
         return definition.remove_rule(expr)
+        self.cache = {}
 
     def get_config_value(self, name, default=None):
         'Infinity -> None, otherwise returns integer.'
@@ -437,9 +467,11 @@ class Definitions(object):
     def set_config_value(self, name, new_value):
         from mathics.core.expression import Integer
         self.set_ownvalue(name, Integer(new_value))
+        self.cache = {}
 
     def set_line_no(self, line_no):
         self.set_config_value('$Line', line_no)
+        self.cache = {}
 
     def get_line_no(self):
         return self.get_config_value('$Line', 0)

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -232,6 +232,7 @@ class Definitions(object):
             if definition is not None:
                 return definition
 
+        original_name = name
         name = self.lookup_name(name)
         user = self.user.get(name, None)
         builtin = self.builtin.get(name, None)
@@ -277,7 +278,7 @@ class Definitions(object):
                               )
 
         if not only_if_exists:
-            self.cache[name] = definition
+            self.cache[original_name] = definition
 
         return definition
 


### PR DESCRIPTION
This continues https://github.com/mathics/Mathics/pull/501 with a more general approach.

Depending on the situation, the performance gain with this seems to be between 5% and 15%:

[before.txt](https://github.com/mathics/Mathics/files/437771/before.txt)
[after.txt](https://github.com/mathics/Mathics/files/437772/after.txt)
