### PR TITLE
Fixes PlotSize

### DIFF
--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -177,6 +177,9 @@ class Graphics(Builtin):
     >> Graphics[{Rectangle[{1, 1}]}, Axes -> True, PlotRange -> {{-2, 1.5}, {-1, 1.5}}]
      = -Graphics-
 
+    >> Graphics[{Rectangle[],Red,Disk[{1,0}]},PlotRange->{{0,1},{0,1}}]
+     = -Graphics-
+
     'Graphics' produces 'GraphicsBox' boxes:
     >> Graphics[Rectangle[]] // ToBoxes // Head
      = GraphicsBox
@@ -1659,6 +1662,7 @@ class GraphicsBox(BoxConstruct):
             raise BoxConstructError
 
         elements = GraphicsElements(leaves[0], options['evaluation'], neg_y)
+        axes = []  # to be filled further down
 
         def calc_dimensions(final_pass=True):
             """
@@ -1677,8 +1681,8 @@ class GraphicsBox(BoxConstruct):
                 xmin, xmax, ymin, ymax = elements.extent()
             else:
                 xmin = xmax = ymin = ymax = None
-            if final_pass and plot_range != ['System`Automatic',
-                                             'System`Automatic']:
+
+            if final_pass and any(x for x in axes) and plot_range != ['System`Automatic', 'System`Automatic']:
                 # Take into account the dimensiosn of axes and axes labels
                 # (they should be displayed completely even when a specific
                 # PlotRange is given).
@@ -1733,6 +1737,8 @@ class GraphicsBox(BoxConstruct):
                     ymin, ymax = get_range(ymin, ymax)
                     ymin = elements.translate((0, ymin))[1]
                     ymax = elements.translate((0, ymax))[1]
+                    if ymin > ymax:
+                        ymin, ymax = ymax, ymin
                     if eymin is not None and eymin < ymin:
                         ymin = eymin
                     if eymax is not None and eymax > ymax:
@@ -1774,7 +1780,7 @@ class GraphicsBox(BoxConstruct):
         ymin -= h * 0.02
         ymax += h * 0.02
 
-        self.create_axes(elements, graphics_options, xmin, xmax, ymin, ymax)
+        axes.extend(self.create_axes(elements, graphics_options, xmin, xmax, ymin, ymax))
 
         return elements, calc_dimensions
 
@@ -1976,6 +1982,7 @@ clip(box((%s,%s), (%s,%s)));
                                                d=p_self0(tick_small_size))])
                 add_element(LineBox(elements, axes_style[0],
                                     lines=ticks_lines))
+        return axes
 
         """if axes[1]:
             add_element(LineBox(elements, axes_style[1], lines=[[Coords(elements, pos=(origin_x,ymin), d=(0,-axes_extra)),


### PR DESCRIPTION
Currently, if `PlotSize` is used without axes, it fails, e.g. `Graphics[{Rectangle[]},PlotRange->{{0,1},{0,1}}]` fails. This PR fixes this.