### PR TITLE
Additional math layout backend

### DIFF
--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import
 from __future__ import division
 
 from math import floor, ceil, log10, sin, cos, pi, sqrt, atan2, degrees, radians, exp
+import re
 import json
 import base64
 from six.moves import map
@@ -179,48 +180,48 @@ def _euclidean_distance(a, b):
 def _component_distance(a, b, i):
     return abs(a[i] - b[i])
 
-	
+
 def _cie2000_distance(lab1, lab2):
     #reference: https://en.wikipedia.org/wiki/Color_difference#CIEDE2000
     e = machine_epsilon
     kL = kC = kH = 1 #common values
-    
+
     L1, L2 = lab1[0], lab2[0]
     a1, a2 = lab1[1], lab2[1]
     b1, b2 = lab1[2], lab2[2]
-    
+
     dL = L2 - L1
     Lm = (L1 + L2)/2
     C1 = sqrt(a1**2 + b1**2)
     C2 = sqrt(a2**2 + b2**2)
     Cm = (C1 + C2)/2;
-    
+
     a1 = a1 * (1 + (1 - sqrt(Cm**7/(Cm**7 + 25**7)))/2)
     a2 = a2 * (1 + (1 - sqrt(Cm**7/(Cm**7 + 25**7)))/2)
-    
+
     C1 = sqrt(a1**2 + b1**2)
     C2 = sqrt(a2**2 + b2**2)
     Cm = (C1 + C2)/2
     dC = C2 - C1
-    
+
     h1 = (180 * atan2(b1, a1 + e))/pi % 360
     h2 = (180 * atan2(b2, a2 + e))/pi % 360
     if abs(h2 - h1) <= 180:
-        dh = h2 - h1 
+        dh = h2 - h1
     elif abs(h2 - h1) > 180 and h2 <= h1:
         dh = h2 - h1 + 360
     elif abs(h2 - h1) > 180 and h2 > h1:
         dh = h2 - h1 - 360
-                    
+
     dH = 2*sqrt(C1*C2)*sin(radians(dh)/2)
-    
+
     Hm = (h1 + h2)/2 if abs(h2 - h1) <= 180 else (h1 + h2 + 360)/2
     T = 1 - 0.17*cos(radians(Hm - 30)) + 0.24*cos(radians(2*Hm)) + 0.32*cos(radians(3*Hm + 6)) - 0.2*cos(radians(4*Hm - 63))
-    
+
     SL = 1 + (0.015*(Lm - 50)**2)/sqrt(20 + (Lm - 50)**2)
     SC = 1 + 0.045*Cm
     SH = 1 + 0.015*Cm*T
-    
+
     rT = -2 * sqrt(Cm**7/(Cm**7 + 25**7))*sin(radians(60*exp(-((Hm - 275)**2 / 25**2))))
     return sqrt((dL/(SL*kL))**2 + (dC/(SC*kC))**2 + (dH/(SH*kH))**2 + rT*(dC/(SC*kC))*(dH/(SH*kH)))
 
@@ -230,19 +231,19 @@ def _CMC_distance(lab1, lab2, l, c):
     L1, L2 = lab1[0], lab2[0]
     a1, a2 = lab1[1], lab2[1]
     b1, b2 = lab1[2], lab2[2]
-    
+
     dL, da, db = L2-L1, a2-a1, b2-b1
     e = machine_epsilon
-    
+
     C1 = sqrt(a1**2 + b1**2);
     C2 = sqrt(a2**2 + b2**2);
-    
+
     h1 = (180 * atan2(b1, a1 + e))/pi % 360;
     dC = C2 - C1;
     dH2 = da**2 + db**2 - dC**2;
     F = C1**2/sqrt(C1**4 + 1900);
     T = 0.56 + abs(0.2*cos(radians(h1 + 168))) if (164 <= h1 and h1 <= 345) else 0.36 + abs(0.4*cos(radians(h1 + 35)));
-    
+
     SL = 0.511 if L1 < 16 else (0.040975*L1)/(1 + 0.01765*L1);
     SC = (0.0638*C1)/(1 + 0.0131*C1) + 0.638;
     SH = SC*(F*T + 1 - F);
@@ -746,7 +747,7 @@ class ColorDistance(Builtin):
      = 0.557976
     #> ColorDistance[Red, Black, DistanceFunction -> (Abs[#1[[1]] - #2[[1]]] &)]
      = 0.542917
-    
+
     """
 
     options = {
@@ -757,17 +758,17 @@ class ColorDistance(Builtin):
         'invdist': '`1` is not Automatic or a valid distance specification.',
         'invarg': '`1` and `2` should be two colors or a color and a lists of colors or ' +
                   'two lists of colors of the same length.'
-        
+
     }
-    
-    # the docs say LABColor's colorspace corresponds to the CIE 1976 L^* a^* b^* color space 
+
+    # the docs say LABColor's colorspace corresponds to the CIE 1976 L^* a^* b^* color space
     # with {l,a,b}={L^*,a^*,b^*}/100. Corrections factors are put accordingly.
-    
+
     _distances = {
         "CIE76": lambda c1, c2: _euclidean_distance(c1.to_color_space('LAB')[:3], c2.to_color_space('LAB')[:3]),
         "CIE94": lambda c1, c2: _euclidean_distance(c1.to_color_space('LCH')[:3], c2.to_color_space('LCH')[:3]),
         "CIE2000": lambda c1, c2: _cie2000_distance(100*c1.to_color_space('LAB')[:3], 100*c2.to_color_space('LAB')[:3])/100,
-        "CIEDE2000": lambda c1, c2: _cie2000_distance(100*c1.to_color_space('LAB')[:3], 100*c2.to_color_space('LAB')[:3])/100,	
+        "CIEDE2000": lambda c1, c2: _cie2000_distance(100*c1.to_color_space('LAB')[:3], 100*c2.to_color_space('LAB')[:3])/100,
         "DeltaL": lambda c1, c2: _component_distance(c1.to_color_space('LCH'), c2.to_color_space('LCH'), 0),
         "DeltaC": lambda c1, c2: _component_distance(c1.to_color_space('LCH'), c2.to_color_space('LCH'), 1),
         "DeltaH": lambda c1, c2: _component_distance(c1.to_color_space('LCH'), c2.to_color_space('LCH'), 2),
@@ -792,7 +793,7 @@ class ColorDistance(Builtin):
                                                             100*c2.to_color_space('LAB')[:3], 2, 1)/100
                 elif distance_function.leaves[1].get_string_value() == 'Perceptibility':
                     compute = ColorDistance._distances.get("CMC")
-                    
+
                 elif distance_function.leaves[1].has_form('List', 2):
                     if (isinstance(distance_function.leaves[1].leaves[0], Integer)
                     and isinstance(distance_function.leaves[1].leaves[1], Integer)):
@@ -2214,12 +2215,14 @@ class ArrowBox(_Polyline):
 
 class InsetBox(_GraphicsElement):
     def init(self, graphics, style, item=None, content=None, pos=None,
-             opos=(0, 0)):
+             opos=(0, 0), font_size=None):
         super(InsetBox, self).init(graphics, item, style)
 
         self.color = self.style.get_option('System`FontColor')
         if self.color is None:
             self.color, _ = style.get_style(_Color, face_element=False)
+
+        self.font_size = font_size
 
         if item is not None:
             if len(item.leaves) not in (1, 2, 3):
@@ -2239,29 +2242,101 @@ class InsetBox(_GraphicsElement):
             self.content = content
             self.pos = pos
             self.opos = opos
-        self.content_text = self.content.boxes_to_text(
-            evaluation=self.graphics.evaluation)
+
+        if self.graphics.evaluation.output.svgify():
+            self._prepare_text_svg()
+        else:
+            self.svg = None
+
+            self.content_text = self.content.boxes_to_text(
+                evaluation=self.graphics.evaluation)
 
     def extent(self):
         p = self.pos.pos()
-        h = 25
-        w = len(self.content_text) * \
-            7  # rough approximation by numbers of characters
+
+        if not self.svg:
+            h = 25
+            w = len(self.content_text) * \
+                7  # rough approximation by numbers of characters
+        else:
+            _, w, h = self.svg
+            scale = self._text_svg_scale()
+            w *= scale
+            h *= scale
+
         opos = self.opos
         x = p[0] - w / 2.0 - opos[0] * w / 2.0
         y = p[1] - h / 2.0 + opos[1] * h / 2.0
         return [(x, y), (x + w, y + h)]
 
-    def to_svg(self):
-        x, y = self.pos.pos()
+    def _prepare_text_svg(self):
         content = self.content.boxes_to_xml(
             evaluation=self.graphics.evaluation)
+
+        svg = self.graphics.evaluation.output.mathml_to_svg(
+            '<math>%s</math>' % content)
+
+        # we could parse the svg and edit it. using regexps here should be
+        # a lot faster though.
+
+        def extract_dimension(svg, name):
+            values = [0.]
+
+            def replace(m):
+                value = m.group(1)
+                values.append(float(value))
+                return '%s="%s"' % (name, value)
+
+            svg = re.sub(name + r'="([0-9\.]+)ex"', replace, svg, 1)
+            return svg, values[-1]
+
+        svg, width = extract_dimension(svg, 'width')
+        svg, height = extract_dimension(svg, 'height')
+
+        self.svg = (svg, width, height)
+
+    def _text_svg_scale(self):
+        svg, width, height = self.svg
+
+        x, y = self.pos.pos()
+        x2, y2 = self.pos.add(width, height).pos()
+        target_height = abs(y2 - y)
+
+        if self.font_size is None:
+            font_size = 0.5
+            return font_size * target_height / height
+        else:
+            return self.font_size / height  # absolute coords
+
+    def _text_svg_xml(self, style, x, y):
+        svg, width, height = self.svg
+        svg = re.sub(r'<svg ', '<svg style="%s" ' % style, svg, 1)
+
+        scale = self._text_svg_scale()
+        ox, oy = self.opos
+
+        return '<g transform="translate(%f,%f) scale(%f) translate(%f, %f)">%s</g>' % (
+            x,
+            y,
+            scale,
+            -width / 2 - ox * width / 2,
+            -height / 2 + oy * height / 2,
+            svg)
+
+    def to_svg(self):
+        evaluation = self.graphics.evaluation
+        x, y = self.pos.pos()
+        content = self.content.boxes_to_xml(
+            evaluation=evaluation)
         style = create_css(font_color=self.color)
-        svg = (
-            '<foreignObject x="%f" y="%f" ox="%f" oy="%f" style="%s">'
-            '<math>%s</math></foreignObject>') % (
-                x, y, self.opos[0], self.opos[1], style, content)
-        return svg
+
+        if not self.svg:
+            return (
+                '<foreignObject x="%f" y="%f" ox="%f" oy="%f" style="%s">'
+                '<math>%s</math></foreignObject>') % (
+                    x, y, self.opos[0], self.opos[1], style, content)
+        else:
+            return self._text_svg_xml(style, x, y)
 
     def to_asy(self):
         x, y = self.pos.pos()
@@ -2827,19 +2902,23 @@ clip(%s);
         w += 2
         h += 2
 
-        svg_xml = '''
-            <svg xmlns:svg="http://www.w3.org/2000/svg"
-                xmlns="http://www.w3.org/2000/svg"
-                version="1.1"
-                viewBox="%s">
-                %s
-            </svg>
-        ''' % (' '.join('%f' % t for t in (xmin, ymin, w, h)), svg)
+        svgify = options['evaluation'].output.svgify()
 
-        return '<mglyph width="%dpx" height="%dpx" src="data:image/svg+xml;base64,%s"/>' % (
-            int(width),
-            int(height),
-            base64.b64encode(svg_xml.encode('utf8')).decode('utf8'))
+        if not svgify:
+            params = ''
+        else:
+            params = 'width="%dpx" height="%dpx"' % (width, height)
+
+        svg_xml = '<svg xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" ' \
+            'version="1.1" viewBox="%s" %s>%s</svg>' % (' '.join('%f' % t for t in (xmin, ymin, w, h)), params, svg)
+
+        if not svgify:
+            return '<mglyph width="%dpx" height="%dpx" src="data:image/svg+xml;base64,%s"/>' % (
+                int(width),
+                int(height),
+                base64.b64encode(svg_xml.encode('utf8')).decode('utf8'))
+        else:
+            return svg_xml
 
     def axis_ticks(self, xmin, xmax):
         def round_to_zero(value):
@@ -2959,6 +3038,7 @@ clip(%s);
                 ticks_lines = []
                 tick_label_style = ticks_style[index].clone()
                 tick_label_style.extend(label_style)
+                font_size = tick_large_size * 3.
                 for x in ticks:
                     ticks_lines.append([Coords(elements, pos=p_origin(x)),
                                         Coords(elements, pos=p_origin(x),
@@ -2973,7 +3053,7 @@ clip(%s);
                         elements, tick_label_style,
                         content=content,
                         pos=Coords(elements, pos=p_origin(x),
-                                   d=p_self0(-tick_label_d)), opos=p_self0(1)))
+                                   d=p_self0(-tick_label_d)), opos=p_self0(1), font_size=font_size))
                 for x in ticks_small:
                     pos = p_origin(x)
                     ticks_lines.append([Coords(elements, pos=pos),

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -2313,7 +2313,7 @@ class InsetBox(_GraphicsElement):
                 7  # rough approximation by numbers of characters
         else:
             _, w, h = self.svg
-            scale = self._text_svg_scale()
+            scale = self._text_svg_scale(h)
             w *= scale
             h *= scale
 
@@ -2328,6 +2328,8 @@ class InsetBox(_GraphicsElement):
 
         svg = self.graphics.evaluation.output.mathml_to_svg(
             '<math>%s</math>' % content)
+
+        svg = svg.replace('style', 'data-style', 1)  # HACK
 
         # we could parse the svg and edit it. using regexps here should be
         # a lot faster though.
@@ -2348,16 +2350,15 @@ class InsetBox(_GraphicsElement):
 
         self.svg = (svg, width, height)
 
-    def _text_svg_scale(self):
+    def _text_svg_scale(self, height):
         size = self.font_size.get_size()
-        # multiplying with 0.5 makes FontSize[] and FontSize[Scaled[]] work as expected
-        return size * 0.5
+        return size / height
 
     def _text_svg_xml(self, style, x, y):
         svg, width, height = self.svg
         svg = re.sub(r'<svg ', '<svg style="%s" ' % style, svg, 1)
 
-        scale = self._text_svg_scale()
+        scale = self._text_svg_scale(height)
         ox, oy = self.opos
 
         return '<g transform="translate(%f,%f) scale(%f) translate(%f, %f)">%s</g>' % (
@@ -2948,23 +2949,13 @@ clip(%s);
         w += 2
         h += 2
 
-        svgify = options['evaluation'].output.svgify()
-
-        if not svgify:
-            params = ''
-        else:
-            params = 'width="%dpx" height="%dpx"' % (width, height)
-
         svg_xml = '<svg xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" ' \
-            'version="1.1" viewBox="%s" %s>%s</svg>' % (' '.join('%f' % t for t in (xmin, ymin, w, h)), params, svg)
+            'version="1.1" viewBox="%s">%s</svg>' % (' '.join('%f' % t for t in (xmin, ymin, w, h)), svg)
 
-        if not svgify:
-            return '<mglyph width="%dpx" height="%dpx" src="data:image/svg+xml;base64,%s"/>' % (
-                int(width),
-                int(height),
-                base64.b64encode(svg_xml.encode('utf8')).decode('utf8'))
-        else:
-            return svg_xml
+        return '<mglyph width="%dpx" height="%dpx" src="data:image/svg+xml;base64,%s"/>' % (
+            int(width),
+            int(height),
+            base64.b64encode(svg_xml.encode('utf8')).decode('utf8'))
 
     def axis_ticks(self, xmin, xmax):
         def round_to_zero(value):

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -2305,10 +2305,9 @@ class InsetBox(_GraphicsElement):
             self.content_text = self.content.boxes_to_text(
                 evaluation=self.graphics.evaluation)
 
-            if not self.graphics.web_engine_warning_issued:
+            if self.graphics.evaluation.output.warn_about_web_engine():
                 self.graphics.evaluation.message(
-                    'General', 'nowebeng', str(e))
-                self.graphics.web_engine_warning_issued = True
+                    'General', 'nowebeng', str(e), once=True)
 
     def extent(self):
         p = self.pos.pos()

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -2308,6 +2308,11 @@ class InsetBox(_GraphicsElement):
             if self.graphics.evaluation.output.warn_about_web_engine():
                 self.graphics.evaluation.message(
                     'General', 'nowebeng', str(e), once=True)
+        except Exception as e:
+            self.svg = None
+
+            self.graphics.evaluation.message(
+                'General', 'nowebeng', str(e), once=True)
 
     def extent(self):
         p = self.pos.pos()

--- a/mathics/builtin/image.py
+++ b/mathics/builtin/image.py
@@ -11,6 +11,7 @@ from mathics.builtin.base import (
 from mathics.core.expression import (
     Atom, Expression, Integer, Rational, Real, MachineReal, Symbol, from_python)
 from mathics.builtin.colors import convert as convert_color, colorspaces as known_colorspaces
+from mathics.layout.client import WebEngineUnavailable
 
 import six
 import base64
@@ -2424,3 +2425,49 @@ class WordCloud(Builtin):
 
         image = wc.to_image()
         return Image(numpy.array(image), 'RGB')
+
+
+class Rasterize(Builtin):
+    requires = _image_requires
+
+    options = {
+        'RasterSize': '300',
+    }
+
+    messages = {
+        'err': 'Rasterize[] failed: `1`',
+    }
+
+    def apply(self, expr, evaluation, options):
+        'Rasterize[expr_, OptionsPattern[%(name)s]]'
+
+        raster_size = self.get_option(options, 'RasterSize', evaluation)
+        if isinstance(raster_size, Integer):
+            s = raster_size.get_int_value()
+            py_raster_size = (s, s)
+        elif raster_size.has_form('List', 2) and all(isinstance(s, Integer) for s in raster_size.leaves):
+            py_raster_size = tuple(s.get_int_value for s in raster_size.leaves)
+        else:
+            return
+
+        mathml = evaluation.format_output(expr, 'xml')
+        try:
+            svg = evaluation.output.mathml_to_svg(mathml)
+            reply = evaluation.output.rasterize(svg, py_raster_size)
+            buffer = reply.get('buffer')
+
+            if buffer:
+                stream = BytesIO()
+                stream.write(bytearray(buffer['data']))
+                stream.seek(0)
+                pixels = skimage.io.imread(stream)
+                stream.close()
+
+                return Image(pixels, 'RGB')
+            else:
+                error = reply.get('error', 'could not identify the reason for the error')
+                evaluation.message('Rasterize', 'err', error)
+
+        except WebEngineUnavailable as e:
+            evaluation.message(
+                'General', 'nowebeng', 'Rasterize[] is not available: ' + str(e), once=True)

--- a/mathics/builtin/image.py
+++ b/mathics/builtin/image.py
@@ -2454,7 +2454,10 @@ class Rasterize(Builtin):
             stream = BytesIO()
             stream.write(png)
             stream.seek(0)
-            pixels = skimage.io.imread(stream)
+            im = PIL.Image.open(stream)
+            # note that we need to get these pixels as long as stream is still open,
+            # otherwise PIL will generate an IO error.
+            pixels = numpy.array(im)
             stream.close()
 
             return Image(pixels, 'RGB')

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -1774,13 +1774,7 @@ class MathMLForm(Builtin):
         # mathml = '<math><mstyle displaystyle="true">%s</mstyle></math>' % xml
         # #convert_box(boxes)
 
-        if not evaluation.output.svgify():
-            result = '<math>%s</math>' % xml
-        else:
-            if xml.startswith('<svg'):
-                result = xml
-            else:
-                result = evaluation.output.mathml_to_svg('<math>%s</math>' % xml)
+        result = '<math>%s</math>' % xml
 
         return Expression('RowBox', Expression('List', String(result)))
 

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -1632,6 +1632,7 @@ class General(Builtin):
         'notboxes': "`1` is not a valid box structure.",
 
         'pyimport': "`1`[] is not available. Your Python installation misses the \"`2`\" module.",
+        'nowebeng': "Web Engine is not available: `1`",
     }
 
 

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -1773,8 +1773,16 @@ class MathMLForm(Builtin):
             xml = ''
         # mathml = '<math><mstyle displaystyle="true">%s</mstyle></math>' % xml
         # #convert_box(boxes)
-        mathml = '<math>%s</math>' % xml  # convert_box(boxes)
-        return Expression('RowBox', Expression('List', String(mathml)))
+
+        if not evaluation.output.svgify():
+            result = '<math>%s</math>' % xml
+        else:
+            if xml.startswith('<svg'):
+                result = xml
+            else:
+                result = evaluation.output.mathml_to_svg('<math>%s</math>' % xml)
+
+        return Expression('RowBox', Expression('List', String(result)))
 
 
 class TeXForm(Builtin):

--- a/mathics/core/evaluation.py
+++ b/mathics/core/evaluation.py
@@ -412,7 +412,7 @@ class Evaluation(object):
             return []
         return value.leaves
 
-    def message(self, symbol, tag, *args, once=False):
+    def message(self, symbol, tag, *args, **kwargs):
         from mathics.core.expression import (String, Symbol, Expression,
                                              from_python)
 
@@ -423,7 +423,7 @@ class Evaluation(object):
 
         pattern = Expression('MessageName', Symbol(symbol), String(tag))
 
-        if once:
+        if kwargs.get('once', False):
             if pattern in self.once_messages:
                 return
             self.once_messages.add(pattern)

--- a/mathics/core/evaluation.py
+++ b/mathics/core/evaluation.py
@@ -180,6 +180,15 @@ class Result(object):
 
 
 class Output(object):
+    def __init__(self, layout_engine=None):
+        self.layout_engine = layout_engine
+
+    def svgify(self):
+        # True if the MathML output should be instantly rendered into SVG
+        # in the backend, i.e. the browser will only see SVG. False for the
+        # classic mode, i.e. Mathics gives <math> tags to the browser.
+        return False
+
     def max_stored_size(self, settings):
         return settings.MAX_STORED_SIZE
 
@@ -191,6 +200,22 @@ class Output(object):
 
     def display(self, data, metadata):
         raise NotImplementedError
+
+    def mathml_to_svg(self, mathml):
+        svg = None
+        if self.layout_engine:
+            svg = self.layout_engine.mathml_to_svg(mathml)
+        if svg is None:
+            raise RuntimeError("LayoutEngine is unavailable")
+        return svg
+
+    def rasterize(self, svg):
+        png = None
+        if self.layout_engine:
+            png = self.layout_engine.rasterize(svg)
+        if png is None:
+            raise RuntimeError("LayoutEngine is unavailable")
+        return png
 
 
 class Evaluation(object):

--- a/mathics/core/evaluation.py
+++ b/mathics/core/evaluation.py
@@ -15,6 +15,7 @@ from threading import Thread, stack_size as set_thread_stack_size
 
 from mathics import settings
 from mathics.core.expression import ensure_context, KeyComparable
+from mathics.layout.client import NoWebEngine
 
 FORMATS = ['StandardForm', 'FullForm', 'TraditionalForm',
            'OutputForm', 'InputForm',
@@ -180,7 +181,7 @@ class Result(object):
 
 
 class Output(object):
-    def __init__(self, web_engine=None):
+    def __init__(self, web_engine=NoWebEngine()):
         self.web_engine = web_engine
 
     def max_stored_size(self, settings):
@@ -204,8 +205,8 @@ class Output(object):
     def mathml_to_svg(self, mathml):
         return self.web_engine.mathml_to_svg(mathml)
 
-    def rasterize(self, svg):
-        return self.web_engine.rasterize(svg)
+    def rasterize(self, svg, *args, **kwargs):
+        return self.web_engine.rasterize(svg, *args, **kwargs)
 
 
 class Evaluation(object):

--- a/mathics/core/evaluation.py
+++ b/mathics/core/evaluation.py
@@ -180,14 +180,8 @@ class Result(object):
 
 
 class Output(object):
-    def __init__(self, layout_engine=None):
-        self.layout_engine = layout_engine
-
-    def svgify(self):
-        # True if the MathML output should be instantly rendered into SVG
-        # in the backend, i.e. the browser will only see SVG. False for the
-        # classic mode, i.e. Mathics gives <math> tags to the browser.
-        return False
+    def __init__(self, web_engine=None):
+        self.web_engine = web_engine
 
     def max_stored_size(self, settings):
         return settings.MAX_STORED_SIZE
@@ -201,21 +195,14 @@ class Output(object):
     def display(self, data, metadata):
         raise NotImplementedError
 
+    def is_web_engine_available(self):
+        return self.web_engine.is_available()
+
     def mathml_to_svg(self, mathml):
-        svg = None
-        if self.layout_engine:
-            svg = self.layout_engine.mathml_to_svg(mathml)
-        if svg is None:
-            raise RuntimeError("LayoutEngine is unavailable")
-        return svg
+        return self.web_engine.mathml_to_svg(mathml)
 
     def rasterize(self, svg):
-        png = None
-        if self.layout_engine:
-            png = self.layout_engine.rasterize(svg)
-        if png is None:
-            raise RuntimeError("LayoutEngine is unavailable")
-        return png
+        return self.web_engine.rasterize(svg)
 
 
 class Evaluation(object):

--- a/mathics/core/evaluation.py
+++ b/mathics/core/evaluation.py
@@ -195,8 +195,11 @@ class Output(object):
     def display(self, data, metadata):
         raise NotImplementedError
 
-    def is_web_engine_available(self):
-        return self.web_engine.is_available()
+    def warn_about_web_engine(self):
+        return False
+
+    def assume_web_engine(self):
+        return self.web_engine.assume_is_available()
 
     def mathml_to_svg(self, mathml):
         return self.web_engine.mathml_to_svg(mathml)
@@ -225,6 +228,7 @@ class Evaluation(object):
         self.quiet_all = False
         self.format = format
         self.catch_interrupt = catch_interrupt
+        self.once_messages = set()
 
     def parse(self, query):
         'Parse a single expression and print the messages.'
@@ -407,7 +411,7 @@ class Evaluation(object):
             return []
         return value.leaves
 
-    def message(self, symbol, tag, *args):
+    def message(self, symbol, tag, *args, once=False):
         from mathics.core.expression import (String, Symbol, Expression,
                                              from_python)
 
@@ -417,6 +421,11 @@ class Evaluation(object):
         quiet_messages = set(self.get_quiet_messages())
 
         pattern = Expression('MessageName', Symbol(symbol), String(tag))
+
+        if once:
+            if pattern in self.once_messages:
+                return
+            self.once_messages.add(pattern)
 
         if pattern in quiet_messages or self.quiet_all:
             return

--- a/mathics/layout/__init__.py
+++ b/mathics/layout/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-

--- a/mathics/layout/client.py
+++ b/mathics/layout/client.py
@@ -79,8 +79,8 @@ class LayoutEngine(object):
     def __init__(self):
         try:
             popen_env = os.environ.copy()
-            if settings.NODE_PATH:
-                popen_env["NODE_PATH"] = settings.NODE_PATH
+            if settings.NODE_MODULES:
+                popen_env["NODE_PATH"] = os.path.expandvars(settings.NODE_MODULES)
 
             server_path = os.path.dirname(os.path.realpath(__file__)) + "/server.js"
 
@@ -89,7 +89,7 @@ class LayoutEngine(object):
                 raise RuntimeError(error_text + message)
 
             self.process = Popen(
-                [settings.NODE, server_path],
+                [os.path.expandvars(settings.NODE), server_path],
                 stdout=subprocess.PIPE,
                 env=popen_env)
 

--- a/mathics/layout/client.py
+++ b/mathics/layout/client.py
@@ -162,6 +162,15 @@ class WebEngine:
             server_path = os.path.join(
                 os.path.dirname(os.path.realpath(__file__)), 'server.js')
 
+            if True:
+                # fixes problems on Windows network drives
+                import tempfile
+                fd, copied_path = tempfile.mkstemp(suffix='js')
+                with open(server_path, 'rb') as f:
+                    os.write(fd, f.read())
+                os.fsync(fd)
+                server_path = copied_path
+
             def abort(message):
                 error_text = 'Node.js failed to startup %s:\n\n' % server_path
                 raise WebEngineUnavailable(error_text + message)

--- a/mathics/layout/client.py
+++ b/mathics/layout/client.py
@@ -49,14 +49,14 @@ class LayoutEngine(object):
 
                 status = self.process.stdout.readline().decode('utf8').strip()
                 if status != 'OK':
-                    self.process.terminate()
-
                     error = ''
                     while True:
                         line = self.process.stdout.readline().decode('utf8')
                         if not line:
                             break
                         error += '  ' + line
+
+                    self.process.terminate()
 
                     raise RuntimeError(
                         'Node.js failed to start web layout engine:\n' + error + '\n' +

--- a/mathics/layout/client.py
+++ b/mathics/layout/client.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# In order to use LayoutEngine, you need the "zerorpc" in your Python installation, and nodejs in your path.
+# you may use "NODE" in settings.py to specify a custom node binary, and you may use NODE_PATH in settings.py
+# to specify a custom node_modules path (that has the necessary node modules mathjax-node, zerorpc, ...).
+#
+# The zerorpc package from https://github.com/0rpc/zerorpc-python. needs to be installed manually using
+# "/your/python setup.py install". For Python 3, you need to use the zerorpc 3.4 branch.
+
+# Your installation of nodejs with the following packages: mathjax-node zerorpc svg2png (install them using
+# npm).
+
+# Some tips for installing nodejs and zmq on OS X:
+# see https://gist.github.com/DanHerbert/9520689
+# https://github.com/JustinTulloss/zeromq.node/issues/283
+# brew install zmq && npm install zmq
+# export NODE_PATH=/your/path/to/homebrew/bin/node_modules:$NODE_PATH
+
+import subprocess
+from subprocess import Popen
+import os
+
+from mathics import settings
+
+try:
+    import zerorpc
+    supported = True
+except ImportError:
+    supported = False
+
+
+def warn(s):
+    print(s)
+
+
+class LayoutEngine(object):
+    def __init__(self):
+        if not supported:
+            self.process = None
+            warn('Web layout engine is disabled as zerorpc is not installed.')
+        else:
+            try:
+                popen_env = os.environ.copy()
+                if settings.NODE_PATH:
+                    popen_env["NODE_PATH"] = settings.NODE_PATH
+
+                base = os.path.dirname(os.path.realpath(__file__))
+
+                self.process = Popen(
+                    [settings.NODE, base + "/server.js"],
+                    stdout=subprocess.PIPE,
+                    env=popen_env)
+
+                status = self.process.stdout.readline().decode('utf8').strip()
+                if status != 'OK':
+                    error = ''
+                    while True:
+                        line = self.process.stdout.readline().decode('utf8')
+                        if not line:
+                            break
+                        error += '  ' + line
+                    warn('Node.js failed to start web layout engine:')
+                    warn(error)
+                    warn('Check necessary node.js modules and that NODE_PATH is set correctly.')
+                    self.process.terminate()
+                    self.process = None
+            except OSError as e:
+                warn('Failed to start web layout engine:')
+                warn(str(e))
+                self.process = None
+
+        if self.process is None:
+            self.client = None
+        else:
+            try:
+                self.client = zerorpc.Client()
+                self.client.connect("tcp://127.0.0.1:4241")
+            except Exception as e:
+                self.client = None
+                warn('node.js failed to start web layout engine:')
+                warn(str(e))
+                warn('Probably you are missing node.js modules.')
+
+    def mathml_to_svg(self, mathml):
+        if self.client:
+            return self.client.mathml_to_svg(mathml)
+
+    def rasterize(self, svg):
+        if self.client:
+            return self.client.rasterize(svg)
+
+    def terminate(self):
+        if self.process:
+            self.process.terminate()

--- a/mathics/layout/client.py
+++ b/mathics/layout/client.py
@@ -1,14 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# In order to use LayoutEngine, you need the "zerorpc" in your Python installation, and nodejs in your path.
 # you may use "NODE" in settings.py to specify a custom node binary, and you may use NODE_PATH in settings.py
-# to specify a custom node_modules path (that has the necessary node modules mathjax-node, zerorpc, ...).
+# to specify a custom node_modules path (that has the necessary node modules mathjax-node, ...).
 #
-# The zerorpc package from https://github.com/0rpc/zerorpc-python. needs to be installed manually using
-# "/your/python setup.py install". For Python 3, you need to use the zerorpc 3.4 branch.
-
-# Your installation of nodejs with the following packages: mathjax-node zerorpc svg2png (install them using
+# Your installation of nodejs with the following packages: mathjax-node svg2png (install them using
 # npm).
 
 # Some tips for installing nodejs and zmq on OS X:
@@ -23,55 +19,100 @@ import os
 
 from mathics import settings
 
-try:
-    import zerorpc
-    supported = True
-except ImportError:
-    supported = False
+import socket
+import json
+import struct
+
+# the following three functions are taken from
+# http://stackoverflow.com/questions/17667903/python-socket-receive-large-amount-of-data
+
+def send_msg(sock, msg):
+    # Prefix each message with a 4-byte length (network byte order)
+    msg = struct.pack('>I', len(msg)) + msg
+    sock.sendall(msg)
+
+
+def recv_msg(sock):
+    # Read message length and unpack it into an integer
+    raw_msglen = recvall(sock, 4)
+    if not raw_msglen:
+        return None
+    msglen = struct.unpack('>I', raw_msglen)[0]
+    # Read the message data
+    return recvall(sock, msglen)
+
+
+def recvall(sock, n):
+    # Helper function to recv n bytes or return None if EOF is hit
+    data = b''
+    while len(data) < n:
+        packet = sock.recv(n - len(data))
+        if not packet:
+            return None
+        data += packet
+    return data
+
+
+class RemoteMethod:
+    def __init__(self, socket, name):
+        self.socket = socket
+        self.name = name
+
+    def __call__(self, data):
+        send_msg(self.socket, json.dumps({'call': self.name, 'data': data}).encode('utf8'))
+        return json.loads(recv_msg(self.socket).decode('utf8'))
+
+
+class Client:
+    def __init__(self, ip, port):
+        self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.socket.connect((ip, port))
+
+    def __getattr__(self, name):
+        return RemoteMethod(self.socket, name)
+
+    def close(self):
+        return self.socket.close()
 
 
 class LayoutEngine(object):
     def __init__(self):
-        if not supported:
-            raise RuntimeError('Web layout engine is disabled as zerorpc is not installed.')
-        else:
-            try:
-                popen_env = os.environ.copy()
-                if settings.NODE_PATH:
-                    popen_env["NODE_PATH"] = settings.NODE_PATH
+        try:
+            popen_env = os.environ.copy()
+            if settings.NODE_PATH:
+                popen_env["NODE_PATH"] = settings.NODE_PATH
 
-                server_path = os.path.dirname(os.path.realpath(__file__)) + "/server.js"
+            server_path = os.path.dirname(os.path.realpath(__file__)) + "/server.js"
 
-                def abort(message):
-                    error_text = 'Node.js failed to start %s:\n' % server_path
-                    raise RuntimeError(error_text + message)
+            def abort(message):
+                error_text = 'Node.js failed to start %s:\n' % server_path
+                raise RuntimeError(error_text + message)
 
-                self.process = Popen(
-                    [settings.NODE, server_path],
-                    stdout=subprocess.PIPE,
-                    env=popen_env)
+            self.process = Popen(
+                [settings.NODE, server_path],
+                stdout=subprocess.PIPE,
+                env=popen_env)
 
-                status = self.process.stdout.readline().decode('utf8').strip()
-                if status != 'OK':
-                    error = ''
-                    while True:
-                        line = self.process.stdout.readline().decode('utf8')
-                        if not line:
-                            break
-                        error += '  ' + line
+            status = self.process.stdout.readline().decode('utf8').strip()
+            if status != 'OK':
+                error = ''
+                while True:
+                    line = self.process.stdout.readline().decode('utf8')
+                    if not line:
+                        break
+                    error += '  ' + line
 
-                    self.process.terminate()
+                self.process.terminate()
 
-                    abort(error + '\nCheck Node.js modules and that NODE_PATH.')
-            except OSError as e:
-                abort(str(e))
+                abort(error + '\nCheck Node.js modules and that NODE_PATH.')
+        except OSError as e:
+            abort(str(e))
 
         if self.process is None:
             self.client = None
         else:
             try:
-                self.client = zerorpc.Client()
-                self.client.connect("tcp://127.0.0.1:4241")
+                self.client = Client('127.0.0.1', 5000)
             except Exception as e:
                 self.client = None
                 self.process.terminate()

--- a/mathics/layout/client.py
+++ b/mathics/layout/client.py
@@ -102,6 +102,53 @@ class NoWebEngine:
         raise WebEngineUnavailable
 
 
+def _normalize_svg(svg):
+    import xml.etree.ElementTree as ET
+    import base64
+    import re
+
+    ET.register_namespace('', 'http://www.w3.org/2000/svg')
+    root = ET.fromstring(svg)
+    prefix = 'data:image/svg+xml;base64,'
+
+    def rewrite(up):
+        changes = []
+
+        for i, node in enumerate(up):
+            if node.tag == '{http://www.w3.org/2000/svg}image':
+                src = node.attrib.get('src', '')
+                if src.startswith(prefix):
+                    attrib = node.attrib
+
+                    if 'width' in attrib and 'height' in attrib:
+                        target_width = float(attrib['width'])
+                        target_height = float(attrib['height'])
+                        target_transform = attrib.get('transform', '')
+
+                        image_svg = _normalize_svg(base64.b64decode(src[len(prefix):]))
+                        root = ET.fromstring(image_svg)
+
+                        view_box = re.split('\s+', root.attrib.get('viewBox', ''))
+
+                        if len(view_box) == 4:
+                            x, y, w, h = (float(t) for t in view_box)
+                            root.tag = '{http://www.w3.org/2000/svg}g'
+                            root.attrib = {'transform': '%s scale(%f, %f) translate(%f, %f)' % (
+                                target_transform, target_width / w, target_height / h, -x, -y)}
+
+                            changes.append((i, node, root))
+            else:
+                rewrite(node)
+
+        for i, node, new_node in reversed(changes):
+            up.remove(node)
+            up.insert(i, new_node)
+
+    rewrite(root)
+
+    return ET.tostring(root, 'utf8').decode('utf8')
+
+
 class WebEngine:
     def __init__(self):
         self.process = None
@@ -171,7 +218,7 @@ class WebEngine:
         return self._ensure_client().mathml_to_svg(mathml)
 
     def rasterize(self, svg, size):
-        buffer = self._ensure_client().rasterize(svg, size)
+        buffer = self._ensure_client().rasterize(_normalize_svg(svg), size)
         return bytearray(buffer['data'])
 
     def terminate(self):

--- a/mathics/layout/client.py
+++ b/mathics/layout/client.py
@@ -61,8 +61,8 @@ class RemoteMethod:
         self.pipe = Pipe(socket)
         self.name = name
 
-    def __call__(self, data):
-        self.pipe.put({'call': self.name, 'data': data})
+    def __call__(self, *args):
+        self.pipe.put({'call': self.name, 'args': args})
         return self.pipe.get()
 
 
@@ -87,7 +87,18 @@ class WebEngineUnavailable(RuntimeError):
     pass
 
 
-class WebEngine(object):
+class NoWebEngine:
+    def assume_is_available(self):
+        raise WebEngineUnavailable
+
+    def mathml_to_svg(self, mathml):
+        raise WebEngineUnavailable
+
+    def rasterize(self, svg, *args, **kwargs):
+        raise WebEngineUnavailable
+
+
+class WebEngine:
     def __init__(self):
         self.process = None
         self.client = None
@@ -157,8 +168,8 @@ class WebEngine(object):
     def mathml_to_svg(self, mathml):
         return self._ensure_client().mathml_to_svg(mathml)
 
-    def rasterize(self, svg):
-        return self._ensure_client().rasterize(svg)
+    def rasterize(self, svg, size):
+        return self._ensure_client().rasterize(svg, size)
 
     def terminate(self):
         if self.process:

--- a/mathics/layout/client.py
+++ b/mathics/layout/client.py
@@ -48,12 +48,12 @@ class Pipe:
 
     def get(self):
         # Read message length and unpack it into an integer
-        raw_msglen = self.recvall(4)
+        raw_msglen = self._recvall(4)
         if not raw_msglen:
             return None
         msglen = struct.unpack('>I', raw_msglen)[0]
         # Read the message data
-        return json.loads(self.recvall(msglen).decode('utf8'))
+        return json.loads(self._recvall(msglen).decode('utf8'))
 
 
 class RemoteMethod:
@@ -123,7 +123,7 @@ class WebEngine(object):
                     error += '  ' + line
 
                 process.terminate()
-                abort(error + '\nPlease check Node.js modules and NODE_PATH.')
+                abort(error + '\nPlease check Node.js modules and NODE_PATH')
 
             port = int(status[len(hello):])
         except OSError as e:

--- a/mathics/layout/client.py
+++ b/mathics/layout/client.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# you may use "NODE" in settings.py to specify a custom node binary, and you may use NODE_PATH in settings.py
-# to specify a custom node_modules path (that has the necessary node modules mathjax-node, ...).
-#
 # Your installation of nodejs with the following packages: mathjax-node svg2png (install them using
 # npm).
 
@@ -14,8 +11,6 @@
 import subprocess
 from subprocess import Popen
 import os
-
-from mathics import settings
 
 import socket
 import json
@@ -116,8 +111,6 @@ class WebEngine:
     def _create_client(self):
         try:
             popen_env = os.environ.copy()
-            if settings.NODE_MODULES:
-                popen_env["NODE_PATH"] = os.path.expandvars(settings.NODE_MODULES)
 
             server_path = os.path.join(
                 os.path.dirname(os.path.realpath(__file__)), 'server.js')
@@ -127,7 +120,7 @@ class WebEngine:
                 raise WebEngineUnavailable(error_text + message)
 
             process = Popen(
-                [os.path.expandvars(settings.NODE), server_path],
+                ['node', server_path],
                 stdout=subprocess.PIPE,
                 env=popen_env)
 

--- a/mathics/layout/server.js
+++ b/mathics/layout/server.js
@@ -1,0 +1,44 @@
+// to install: npm install mathjax-node zerorpc svg2png
+
+try {
+    var zerorpc = require("zerorpc");
+
+    var mathjax = require("mathjax-node/lib/mj-single.js");
+    mathjax.config({
+        MathJax: {
+            // traditional MathJax configuration
+        }
+    });
+    mathjax.start();
+
+    var svg2png = require("svg2png");
+
+    var server = new zerorpc.Server({
+        mathml_to_svg: function(mathml, reply) {
+            mathjax.typeset({
+                math: mathml,
+                format: "MathML",
+                svg: true,
+            }, function (data) {
+                if (!data.errors) {
+                    reply(null, data.svg);
+                }
+            });
+        },
+        rasterize: function(svg, reply) {
+            svg2png(Buffer.from(svg, 'utf8'), {
+                width: 300,
+                height: 400
+            })
+            .then(buffer => reply(null, buffer))
+            .catch(e => console.error(e));
+        }
+    });
+
+    console.log('OK')
+
+    server.bind("tcp://0.0.0.0:4241");
+} catch (ex) {
+    console.log('FAIL')
+    console.log(ex)
+}

--- a/mathics/layout/server.js
+++ b/mathics/layout/server.js
@@ -41,6 +41,11 @@ try {
                 }
             }
 
+            socket.on('close', function() {
+                // means our Python client has lost us. quit.
+                process.exit();
+            });
+
             socket.on('data', function(data) {
                 state.buffer = Buffer.concat(
                     [state.buffer, data]);
@@ -56,10 +61,11 @@ try {
         });
 
         server.on('listening', function() {
-            console.log('OK');
+            var port = server.address().port;
+            process.stdout.write('HELLO:' + port.toString() + '\n');
         });
 
-        server.listen(5000);
+        server.listen(0);  // pick a free port
     }
 
     var mathjax = require("mathjax-node/lib/mj-single.js");
@@ -94,6 +100,5 @@ try {
         }
     });
 } catch (ex) {
-    console.log('FAIL')
-    console.log(ex)
+    process.stdout.write('FAIL.' + '\n' + ex.toString() + '\n');
 }

--- a/mathics/layout/server.js
+++ b/mathics/layout/server.js
@@ -1,7 +1,66 @@
-// to install: npm install mathjax-node zerorpc svg2png
+// to install: npm install mathjax-node svg2png
 
 try {
-    var zerorpc = require("zerorpc");
+    function server(methods) {
+        net = require('net');
+
+        var uint32 = {
+            parse: function(buffer) {
+                return (buffer[0] << 24) |
+                    (buffer[1] << 16) |
+                    (buffer[2] << 8) |
+                    (buffer[3] << 0);
+            },
+            make: function(x) {
+                var buffer = new Buffer(4);
+                buffer[0] = x >> 24;
+                buffer[1] = x >> 16;
+                buffer[2] = x >> 8;
+                buffer[3] = x >> 0;
+                return buffer;
+            }
+        };
+
+        var server = net.createServer(function (socket) {
+            function write(data) {
+                var json = JSON.stringify(data);
+                var size = json.length;
+                socket.write(Buffer.concat([uint32.make(size), new Buffer(json)]));
+            }
+
+            var state = {
+                buffer: new Buffer(0)
+            };
+
+            function rpc(size) {
+                var json = JSON.parse(state.buffer.slice(4, size + 4));
+                state.buffer = state.buffer.slice(size + 4)
+                var method = methods[json.call];
+                if (method) {
+                    method(json.data, write);
+                }
+            }
+
+            socket.on('data', function(data) {
+                state.buffer = Buffer.concat(
+                    [state.buffer, data]);
+
+                if (state.buffer.length >= 4) {
+                    var buffer = state.buffer;
+                    var size = uint32.parse(buffer);
+                    if (buffer.length >= size + 4) {
+                        rpc(size);
+                    }
+                }
+            });
+        });
+
+        server.on('listening', function() {
+            console.log('OK');
+        });
+
+        server.listen(5000);
+    }
 
     var mathjax = require("mathjax-node/lib/mj-single.js");
     mathjax.config({
@@ -13,7 +72,7 @@ try {
 
     var svg2png = require("svg2png");
 
-    var server = new zerorpc.Server({
+    server({
         mathml_to_svg: function(mathml, reply) {
             mathjax.typeset({
                 math: mathml,
@@ -21,7 +80,7 @@ try {
                 svg: true,
             }, function (data) {
                 if (!data.errors) {
-                    reply(null, data.svg);
+                    reply(data.svg);
                 }
             });
         },
@@ -30,14 +89,10 @@ try {
                 width: 300,
                 height: 400
             })
-            .then(buffer => reply(null, buffer))
+            .then(buffer => reply(buffer))
             .catch(e => console.error(e));
         }
     });
-
-    console.log('OK')
-
-    server.bind("tcp://0.0.0.0:4241");
 } catch (ex) {
     console.log('FAIL')
     console.log(ex)

--- a/mathics/main.py
+++ b/mathics/main.py
@@ -181,6 +181,7 @@ class TerminalOutput(Output):
         return None
 
     def __init__(self, shell):
+        super(TerminalOutput, self).__init__()
         self.shell = shell
 
     def out(self, out):

--- a/mathics/server.py
+++ b/mathics/server.py
@@ -15,9 +15,9 @@ import subprocess
 import mathics
 from mathics import server_version_string, license_string
 from mathics import settings as mathics_settings  # Prevents UnboundLocalError
-from mathics.layout.client import LayoutEngine
+from mathics.layout.client import WebEngine
 
-layout_engine = None
+web_engine = None
 
 
 def check_database():
@@ -66,9 +66,6 @@ def parse_args():
     argparser.add_argument(
         "--external", "-e", dest="external", action="store_true",
         help="allow external access to server")
-    argparser.add_argument(
-        '--svg-math', '-s', dest="svg_math", action='store_true',
-        help='prerender all math using svg (experimental)')
 
     return argparser.parse_args()
 
@@ -92,9 +89,8 @@ http://localhost:%d\nin Firefox, Chrome, or Safari to use Mathics\n""" % port)
     else:
         addr = '127.0.0.1'
 
-    global layout_engine
-    if args.svg_math:
-        layout_engine = LayoutEngine()
+    global web_engine
+    web_engine = WebEngine()
 
     try:
         from django.core.servers.basehttp import (
@@ -113,14 +109,14 @@ http://localhost:%d\nin Firefox, Chrome, or Safari to use Mathics\n""" % port)
         except KeyError:
             error_text = str(e)
         sys.stderr.write("Error: %s" % error_text + '\n')
-        if layout_engine is not None:
-            layout_engine.terminate()
+        if web_engine is not None:
+            web_engine.terminate()
         # Need to use an OS exit because sys.exit doesn't work in a thread
         os._exit(1)
     except KeyboardInterrupt:
         print("\nGoodbye!\n")
-        if layout_engine is not None:
-            layout_engine.terminate()
+        if web_engine is not None:
+            web_engine.terminate()
         sys.exit(0)
 
 

--- a/mathics/server.py
+++ b/mathics/server.py
@@ -15,6 +15,9 @@ import subprocess
 import mathics
 from mathics import server_version_string, license_string
 from mathics import settings as mathics_settings  # Prevents UnboundLocalError
+from mathics.layout.client import LayoutEngine
+
+layout_engine = None
 
 
 def check_database():
@@ -86,6 +89,9 @@ http://localhost:%d\nin Firefox, Chrome, or Safari to use Mathics\n""" % port)
     else:
         addr = '127.0.0.1'
 
+    global layout_engine
+    layout_engine = LayoutEngine()
+
     try:
         from django.core.servers.basehttp import (
             run, get_internal_wsgi_application)
@@ -103,10 +109,12 @@ http://localhost:%d\nin Firefox, Chrome, or Safari to use Mathics\n""" % port)
         except KeyError:
             error_text = str(e)
         sys.stderr.write("Error: %s" % error_text + '\n')
+        layout_engine.terminate()
         # Need to use an OS exit because sys.exit doesn't work in a thread
         os._exit(1)
     except KeyboardInterrupt:
         print("\nGoodbye!\n")
+        layout_engine.terminate()
         sys.exit(0)
 
 

--- a/mathics/server.py
+++ b/mathics/server.py
@@ -66,6 +66,9 @@ def parse_args():
     argparser.add_argument(
         "--external", "-e", dest="external", action="store_true",
         help="allow external access to server")
+    argparser.add_argument(
+        '--svg-math', '-s', dest="svg_math", action='store_true',
+        help='prerender all math using svg (experimental)')
 
     return argparser.parse_args()
 
@@ -90,7 +93,8 @@ http://localhost:%d\nin Firefox, Chrome, or Safari to use Mathics\n""" % port)
         addr = '127.0.0.1'
 
     global layout_engine
-    layout_engine = LayoutEngine()
+    if args.svg_math:
+        layout_engine = LayoutEngine()
 
     try:
         from django.core.servers.basehttp import (
@@ -109,12 +113,14 @@ http://localhost:%d\nin Firefox, Chrome, or Safari to use Mathics\n""" % port)
         except KeyError:
             error_text = str(e)
         sys.stderr.write("Error: %s" % error_text + '\n')
-        layout_engine.terminate()
+        if layout_engine is not None:
+            layout_engine.terminate()
         # Need to use an OS exit because sys.exit doesn't work in a thread
         os._exit(1)
     except KeyboardInterrupt:
         print("\nGoodbye!\n")
-        layout_engine.terminate()
+        if layout_engine is not None:
+            layout_engine.terminate()
         sys.exit(0)
 
 

--- a/mathics/settings.py
+++ b/mathics/settings.py
@@ -15,7 +15,7 @@ TEMPLATE_DEBUG = DEBUG
 
 # node.js based layout engine
 NODE = 'node'  # path to node binary; default 'node' assumes it is in PATH
-NODE_PATH = None  # overrides NODE_PATH environment variable if not None
+NODE_MODULES = None  # overrides NODE_PATH environment variable if not None
 
 # set only to True in DEBUG mode
 DEBUG_MAIL = True

--- a/mathics/settings.py
+++ b/mathics/settings.py
@@ -13,10 +13,6 @@ from os import path
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 
-# node.js based layout engine
-NODE = 'node'  # path to node binary; default 'node' assumes it is in PATH
-NODE_MODULES = None  # overrides NODE_PATH environment variable if not None
-
 # set only to True in DEBUG mode
 DEBUG_MAIL = True
 PROPAGATE_EXCEPTIONS = True

--- a/mathics/settings.py
+++ b/mathics/settings.py
@@ -13,6 +13,10 @@ from os import path
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 
+# node.js based layout engine
+NODE = 'node'  # path to node binary; default 'node' assumes it is in PATH
+NODE_PATH = None  # overrides NODE_PATH environment variable if not None
+
 # set only to True in DEBUG mode
 DEBUG_MAIL = True
 PROPAGATE_EXCEPTIONS = True

--- a/mathics/web/views.py
+++ b/mathics/web/views.py
@@ -49,8 +49,7 @@ class JsonResponse(HttpResponse):
 
 
 class WebOutput(Output):
-    def svgify(self):
-        return layout_engine is not None
+    pass
 
 
 def require_ajax_login(func):

--- a/mathics/web/views.py
+++ b/mathics/web/views.py
@@ -107,9 +107,11 @@ def query(request):
                           )
         query_log.save()
 
+    from mathics.server import layout_engine
+
     user_definitions = request.session.get('definitions')
     definitions.set_user_definitions(user_definitions)
-    evaluation = Evaluation(definitions, format='xml', output=WebOutput())
+    evaluation = Evaluation(definitions, format='xml', output=WebOutput(layout_engine))
     feeder = MultiLineFeeder(input, '<notebook>')
     results = []
     try:

--- a/mathics/web/views.py
+++ b/mathics/web/views.py
@@ -26,6 +26,7 @@ from mathics.web.models import Query, Worksheet
 from mathics.web.forms import LoginForm, SaveForm
 from mathics.doc import documentation
 from mathics.doc.doc import DocPart, DocChapter, DocSection
+from mathics.server import layout_engine
 import six
 from six.moves import range
 from string import Template
@@ -48,7 +49,8 @@ class JsonResponse(HttpResponse):
 
 
 class WebOutput(Output):
-    pass
+    def svgify(self):
+        return layout_engine is not None
 
 
 def require_ajax_login(func):

--- a/mathics/web/views.py
+++ b/mathics/web/views.py
@@ -26,7 +26,6 @@ from mathics.web.models import Query, Worksheet
 from mathics.web.forms import LoginForm, SaveForm
 from mathics.doc import documentation
 from mathics.doc.doc import DocPart, DocChapter, DocSection
-from mathics.server import layout_engine
 import six
 from six.moves import range
 from string import Template
@@ -108,11 +107,11 @@ def query(request):
                           )
         query_log.save()
 
-    from mathics.server import layout_engine
+    from mathics.server import web_engine
 
     user_definitions = request.session.get('definitions')
     definitions.set_user_definitions(user_definitions)
-    evaluation = Evaluation(definitions, format='xml', output=WebOutput(layout_engine))
+    evaluation = Evaluation(definitions, format='xml', output=WebOutput(web_engine))
     feeder = MultiLineFeeder(input, '<notebook>')
     results = []
     try:

--- a/setup.py
+++ b/setup.py
@@ -162,7 +162,8 @@ setup(
         'mathics.builtin', 'mathics.builtin.pymimesniffer', 'mathics.builtin.numpy_utils',
         'mathics.builtin.pympler', 'mathics.builtin.compile',
         'mathics.doc',
-        'mathics.web', 'mathics.web.templatetags'
+        'mathics.web', 'mathics.web.templatetags',
+        'mathics.layout',
     ],
 
     install_requires=INSTALL_REQUIRES,
@@ -182,6 +183,7 @@ setup(
             'media/js/three/Detector.js', 'media/js/*.js', 'templates/*.html',
             'templates/doc/*.html'] + mathjax_files,
         'mathics.builtin.pymimesniffer': ['mimetypes.xml'],
+        'mathics.layout': ['server.js'],
     },
 
     entry_points={


### PR DESCRIPTION
This is a rather large change aimed at the Jupyter kernel that, as far as I can tell now, fixes all remaining problems pertaining to 2D output with Jupyter.

Specifically, it fixes the output of `Text[]` and `Plot[]`, which were broken even with the `mglyph` approach, as `mglyph` does not support `foreignObject`s in SVGs.

This PR also introduces methods that could be called from the classic Mathics kernel for some functionality like better text rendering or `Rasterize[]`.

Basically, this adds a node.js server that runs mathjax (and other useful web  engine stuff). This server is automatically started (and terminated) as a subprocess from the Mathics kernel. Using this, Mathics can then render any formula or text into SVG. Not only does this allow the exact computation of the extents and formatting (e.g. centering) of the text, but as we only output SVG, Jupyter does not have to deal with any MathML anymore (and no custom JavaScript therefore to fix things up in the browser). It just outputs preformatted, perfectly layouted SVG.

I investigated two other approaches to achieve this, namely:

(1) make all this happen in the browser using WebSockets, i.e. make the client browser render math through MathJax and send back the data to the server. With the classic Mathics kernel, this can be achieved using Django channels, and I got it running, but it's convoluted as it uses a couple of threads and so akin to deadlocks if any of the underlying socket implementation changed  (for the general idea, see https://github.com/poke1024/Mathics/tree/websockets); Django channels are cool. For Jupyter, I tried to use the `comm` interface for the same thing, but Jupyter expects reponses to by synchrononous and it deadlocks if a kernel wants to interact with the browser before responding (for the general idea, see https://github.com/poke1024/IMathics/tree/sockets).

(2) use a headless WebKit browser through PyQT or PySide. I didn't manage to install PySide under Python 3.5 (only 3.4 is supported) and I figured it would need two processes as well, since one process solutions don't work (see https://github.com/niwinz/phantompy). So, evaluating between a client-server solution using PySide or node.js, I figured node.js is not worse than PySide in terms of bulkiness.

The actual node.js server implementation is really small (44 lines of code currently).
