### PR TITLE
mathicsscript

### DIFF
--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -119,3 +119,25 @@ class CommandLine(Predefined):
 
     def evaluate(self, evaluation):
         return Expression('List', *(String(arg) for arg in sys.argv))
+
+
+class ScriptCommandLine(Predefined):
+    '''
+    <dl>
+    <dt>'$ScriptCommandLine'
+      <dd>is a list of string arguments when running the kernel is script mode.
+    </dl>
+    >> $ScriptCommandLine
+     = {...}
+    '''
+
+    name = '$ScriptCommandLine'
+
+    def evaluate(self, evaluation):
+        try:
+            dash_index = sys.argv.index('--')
+        except ValueError:
+            # not run in script mode
+            return Expression('List')
+
+        return Expression('List', *(String(arg) for arg in sys.argv[dash_index + 1:]))

--- a/mathics/main.py
+++ b/mathics/main.py
@@ -232,7 +232,7 @@ def main():
         '--version', '-v', action='version',
         version='%(prog)s ' + __version__)
 
-    args = argparser.parse_args()
+    args, script_args = argparser.parse_known_args()
 
     quit_command = 'CTRL-BREAK' if sys.platform == 'win32' else 'CONTROL-D'
 

--- a/mathics/script.py
+++ b/mathics/script.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+
+
+def error(msg):
+    print('error: {}'.format(msg))
+    sys.exit(1)
+
+
+def main():
+    try:
+        script_filename = sys.argv[1]
+    except IndexError:
+        error('script filename missing')
+    script_args = sys.argv[1:]
+
+    if sys.argv[0].endswith('script'):
+        shell = sys.argv[0][:-6]
+    else:
+        shell = None
+    if shell is None or not os.path.exists(shell):
+        error('cannot find mathics shell')
+    args = [shell, '-script', script_filename, '--'] + script_args
+    os.system(' '.join(args))

--- a/setup.py
+++ b/setup.py
@@ -186,6 +186,7 @@ setup(
         'console_scripts': [
             'mathics = mathics.main:main',
             'mathicsserver = mathics.server:main',
+            'mathicsscript = mathics.script:main',
         ],
     },
 


### PR DESCRIPTION
A new interface for writing scripts. Allows, e.g. 

```mathematica
#!/usr/bin/env mathicsscript

args = Rest[$ScriptCommandLine];
Print[Plus @@ args, " = ", (ToExpression /@ args) // Total]
```

```bash
> ./script.m 1 2 3
1 + 2 + 3 = 6
```