### PR TITLE
Expression caching

### DIFF
--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -630,6 +630,9 @@ class Times(BinaryOperator, SympyFunction):
                                 for leaf in leaves[0].leaves]
             number = None
 
+        for leaf in leaves:
+            leaf.last_evaluated = None
+
         if number is not None:
             leaves.insert(0, number)
 

--- a/mathics/builtin/control.py
+++ b/mathics/builtin/control.py
@@ -70,6 +70,10 @@ class CompoundExpression(BinaryOperator):
 
     #> CompoundExpression[]
     #> %
+
+    ## Issue 531
+    #> z = Max[1, 1 + x]; x = 2; z
+     = 3
     """
 
     operator = ';'
@@ -168,6 +172,12 @@ class Switch(Builtin):
 
     #> a; Switch[b, b]
      : Switch called with 2 arguments. Switch must be called with an odd number of arguments.
+     = Switch[b, b]
+
+    ## Issue 531
+    #> z = Switch[b, b];
+     : Switch called with 2 arguments. Switch must be called with an odd number of arguments.
+    #> z
      = Switch[b, b]
     """
 

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -1418,6 +1418,10 @@ class Cases(Builtin):
      = {2, 9, 10}
     #> Cases[{1, f[2], f[3, 3, 3], 4, f[5, 5]}, f[x__] -> Plus[x]]
      = {2, 3, 3, 3, 5, 5}
+
+    ## Issue 531
+    #> z = f[x, y]; x = 1; Cases[z, _Symbol, Infinity]
+     = {y}
     """
 
 
@@ -1477,6 +1481,10 @@ class DeleteCases(Builtin):
 
     >> DeleteCases[{a, b, 1, c, 2, 3}, _Symbol]
      = {1, 2, 3}
+
+    ## Issue 531
+    #> z = {x, y}; x = 1; DeleteCases[z, _Symbol]
+     = {1}
     """
 
     def apply(self, items, pattern, evaluation):

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -423,9 +423,9 @@ def walk_parts(list_of_list, indices, evaluation, assign_list=None):
                                                     assignment.leaves):
                     process_level(sub_item, sub_assignment)
         process_level(result, assign_list)
-        return list_of_list[0]
-    else:
-        return result
+        result = list_of_list[0]
+    result.last_evaluated = None
+    return result
 
 
 def is_in_level(current, depth, start=1, stop=None):

--- a/mathics/builtin/scoping.py
+++ b/mathics/builtin/scoping.py
@@ -107,10 +107,6 @@ class Block(Builtin):
 
         vars = dict(get_scoping_vars(vars, 'Block', evaluation))
         result = dynamic_scoping(expr.evaluate, vars, evaluation)
-
-        # Variables may have changed: must revalute
-        result.is_evaluated = False
-
         return result
 
 

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -97,9 +97,9 @@ class Rule(BaseRule):
         # options' values. this is achieved through Expression.evaluate(), which then triggers OptionValue.apply,
         # which in turn consults evaluation.options to return an option value.
 
-        # in order to get there, our expression 'new' (or parts of it) must not have is_evaluated True, since this
+        # in order to get there, our expression 'new' (or parts of it) must have last_evaluated None, since this
         # would make Expression.evaluate() quit early. doing a clean deep copy here, will reset
-        # Expression.is_evaluated for all nodes in the tree.
+        # Expression.last_evaluated for all nodes in the tree.
 
         # if the expression contains OptionValue[] patterns, but options is empty here, we don't need to act, as the
         # expression won't change in that case. the Expression.options would be None anyway, so OptionValue.apply


### PR DESCRIPTION
Fixes #531

Keep track of when each definition changes along with when each expression was last evaluated to prevent unnecessarily re-evaluating expressions.

I'm also wondering if the timestamps could be used to optimise definition caching as in #507.