### PR TITLE
Overhaul of image.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,3 +23,22 @@ License
 -------
 
 Mathics is released under the GNU General Public License (GPL).
+
+------------------------------------------------------------------------------------------------------------------------
+
+Portions of Mathics are adapted from SciPy:
+
+SciPy license
+
+Copyright © 2001, 2002 Enthought, Inc.
+All rights reserved.
+
+Copyright © 2003-2013 SciPy Developers.
+All rights reserved.
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+Neither the name of Enthought nor the names of the SciPy Developers may be used to endorse or promote products derived from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/mathics/builtin/colors.py
+++ b/mathics/builtin/colors.py
@@ -395,6 +395,17 @@ conversions = {
     'RGB>XYZ': rgb_to_xyz,
 }
 
+colorspaces = frozenset((
+    'Grayscale',
+    'RGB',
+    'CMYK',
+    'HSB',
+    'XYZ',
+    'LAB',
+    'LCH',
+    'LUV',
+))
+
 
 def convert(components, src, dst, preserve_alpha=True):
     if not preserve_alpha:

--- a/mathics/builtin/colors.py
+++ b/mathics/builtin/colors.py
@@ -56,15 +56,6 @@ _rgb_from_xyz = [
 ]
 
 
-def omit_alpha(*c):
-    if len(c) == 2:
-        return (c,)
-    elif len(c) == 4:
-        return c[:3]
-    else:
-        return c
-
-
 def rgb_to_grayscale(r, g, b, *rest):
     # see https://en.wikipedia.org/wiki/Grayscale
     y = 0.299 * r + 0.587 * g + 0.114 * b  # Y of Y'UV
@@ -409,6 +400,16 @@ colorspaces = frozenset((
 
 def convert(components, src, dst, preserve_alpha=True):
     if not preserve_alpha:
+        if src == 'Grayscale':
+            non_alpha = 1
+        elif src == 'CMYK':
+            non_alpha = 4
+        else:
+            non_alpha = 3
+
+        def omit_alpha(*c):
+            return c[:non_alpha]
+
         components = stacked(omit_alpha, components)
 
     if src == dst:

--- a/mathics/builtin/image.py
+++ b/mathics/builtin/image.py
@@ -826,6 +826,15 @@ class ImageAdjust(_ImageBuiltin):
 
 
 class Blur(_ImageBuiltin):
+    '''
+    <dl>
+    <dt>'Blur[$image$]'
+      <dd>gives a blurred version of $image$.
+    <dt>'Blur[$image$, $r$]'
+      <dd>blurs $image$ with a kernel of size $r$.
+    </dl>
+    '''
+
     rules = {
         'Blur[image_Image]': 'Blur[image, 2]',
         'Blur[image_Image, r_?RealNumberQ]': 'ImageConvolve[image, BoxMatrix[r] / Total[Flatten[BoxMatrix[r]]]]',
@@ -833,6 +842,15 @@ class Blur(_ImageBuiltin):
 
 
 class Sharpen(_ImageBuiltin):
+    '''
+    <dl>
+    <dt>'Sharpen[$image$]'
+      <dd>gives a sharpened version of $image$.
+    <dt>'Sharpen[$image$, $r$]'
+      <dd>sharpens $image$ with a kernel of size $r$.
+    </dl>
+    '''
+
     rules = {
         'Sharpen[i_Image]': 'Sharpen[i, 2]'
     }
@@ -844,6 +862,13 @@ class Sharpen(_ImageBuiltin):
 
 
 class GaussianFilter(_ImageBuiltin):
+    '''
+    <dl>
+    <dt>'GaussianFilter[$image$, $r$]'
+      <dd>blurs $image$ using a Gaussian blur filter of radius $r$.
+    </dl>
+    '''
+
     messages = {
         'only3': 'GaussianFilter only supports up to three channels.'
     }
@@ -866,24 +891,55 @@ class PillowImageFilter(_ImageBuiltin):
 
 
 class MinFilter(PillowImageFilter):
+    '''
+    <dl>
+    <dt>'MinFilter[$image$, $r$]'
+      <dd>gives $image$ with a minimum filter of radius $r$ applied on it. This always
+      picks the smallest value in the filter's area.
+    </dl>
+    '''
+
     def apply(self, image, r, evaluation):
         'MinFilter[image_Image, r_Integer]'
         return self.compute(image, PIL.ImageFilter.MinFilter(1 + 2 * r.get_int_value()))
 
 
 class MaxFilter(PillowImageFilter):
+    '''
+    <dl>
+    <dt>'MaxFilter[$image$, $r$]'
+      <dd>gives $image$ with a maximum filter of radius $r$ applied on it. This always
+      picks the largest value in the filter's area.
+    </dl>
+    '''
+
     def apply(self, image, r, evaluation):
         'MaxFilter[image_Image, r_Integer]'
         return self.compute(image, PIL.ImageFilter.MaxFilter(1 + 2 * r.get_int_value()))
 
 
 class MedianFilter(PillowImageFilter):
+    '''
+    <dl>
+    <dt>'MedianFilter[$image$, $r$]'
+      <dd>gives $image$ with a median filter of radius $r$ applied on it. This always
+      picks the median value in the filter's area.
+    </dl>
+    '''
+
     def apply(self, image, r, evaluation):
         'MedianFilter[image_Image, r_Integer]'
         return self.compute(image, PIL.ImageFilter.MedianFilter(1 + 2 * r.get_int_value()))
 
 
 class EdgeDetect(_ImageBuiltin):
+    '''
+    <dl>
+    <dt>'EdgeDetect[$image$]'
+      <dd>returns an image showing the edges in $image$.
+    </dl>
+    '''
+
     requires = _image_requires + (
         'skimage',
     )
@@ -1160,6 +1216,13 @@ class ColorConvert(Builtin):
 
 
 class ColorQuantize(_ImageBuiltin):
+    '''
+    <dl>
+    <dt>'ColorQuantize[$image$, $n$]'
+      <dd>gives a version of $image$ using only $n$ colors.
+    </dl>
+    '''
+
     def apply(self, image, n, evaluation):
         'ColorQuantize[image_Image, n_Integer]'
         converted = image.color_convert('RGB')
@@ -1172,6 +1235,15 @@ class ColorQuantize(_ImageBuiltin):
 
 
 class Threshold(_ImageBuiltin):
+    '''
+    <dl>
+    <dt>'Threshold[$image$]'
+      <dd>gives a value suitable for binarizing $image$.
+    </dl>
+
+    The option "Method" may be "Cluster" (use Otsu's threshold), "Median", or "Mean".
+    '''
+
     options = {
         'Method': '"Cluster"'
     }
@@ -1205,6 +1277,17 @@ class Threshold(_ImageBuiltin):
 
 
 class Binarize(_ImageBuiltin):
+    '''
+    <dl>
+    <dt>'Binarize[$image$]'
+      <dd>gives a binarized version of $image$, in which each pixel is either 0 or 1.
+    <dt>'Binarize[$image$, $t$]'
+      <dd>map values $x$ > $t$ to 1, and values $x$ <= $t$ to 0.
+    <dt>'Binarize[$image$, $t1$, $t2$]'
+      <dd>map $t1$ < $x$ < $t2$ to 1, and all other values to 0.
+    </dl>
+    '''
+
     def apply(self, image, evaluation):
         'Binarize[image_Image]'
         image = image.grayscale()
@@ -1381,7 +1464,18 @@ class DominantColors(Builtin):
       <dd>gives a list of colors which are dominant in the given image.
     <dt>'DominantColors[$image$, $n$]'
       <dd>returns at most $n$ colors.
+    <dt>'DominantColors[$image$, $n$, $prop$]'
+      <dd>returns the given property $prop$, which may be "Color" (return RGB colors), "LABColor" (return
+      LAB colors), "Count" (return the number of pixels a dominant color covers), "Coverage" (return the
+      fraction of the image a dominant color covers), or "CoverageImage" (return a black and white image
+      indicating with white the parts that are covered by a dominant color).
     </dl>
+
+    The option "ColorCoverage" specifies the minimum amount of coverage needed to include a dominant color
+    in the result.
+
+    The option "MinColorDistance" specifies the distance (in LAB color space) up to which colors are merged
+    and thus regarded as belonging to the same dominant color.
     '''
 
     rules = {
@@ -1492,6 +1586,13 @@ class DominantColors(Builtin):
 
 
 class ImageData(_ImageBuiltin):
+    '''
+    <dl>
+    <dt>'ImageData[$image$]'
+      <dd>gives a list of all color values of $image$ as a matrix.
+    </dl>
+    '''
+
     rules = {
         'ImageData[image_Image]': 'ImageData[image, "Real"]'
     }
@@ -1518,12 +1619,51 @@ class ImageData(_ImageBuiltin):
 
 
 class ImageTake(_ImageBuiltin):
+    '''
+    <dl>
+    <dt>'ImageTake[$image$, $n$]'
+      <dd>gives the first $n$ rows of $image$.
+    <dt>'ImageTake[$image$, -$n$]'
+      <dd>gives the last $n$ rows of $image$.
+    <dt>'ImageTake[$image$, {$r1$, $r2$}]'
+      <dd>gives rows $r1$, ..., $r2$ of $image$.
+    <dt>'ImageTake[$image$, {$r1$, $r2$}, {$c1$, $c2$}]'
+      <dd>gives a cropped version of $image$.
+    </dl>
+    '''
+
     def apply(self, image, n, evaluation):
         'ImageTake[image_Image, n_Integer]'
-        return Image(image.pixels[:n.get_int_value()], image.color_space)
+        py_n = n.get_int_value()
+        if py_n >= 0:
+            pixels = image.pixels[:py_n]
+        elif py_n < 0:
+            pixels = image.pixels[py_n:]
+        return Image(pixels, image.color_space)
+
+    def apply_rows(self, image, r1, r2, evaluation):
+        'ImageTake[image_Image, {r1_Integer, r2_Integer}]'
+        py_r1 = max(r1.get_int_value() - 1, 0)
+        py_r2 = max(r2.get_int_value() - 1, 0)
+        return Image(image.pixels[py_r1:1 + py_r2], image.color_space)
+
+    def apply_rows_cols(self, image, r1, r2, c1, c2, evaluation):
+        'ImageTake[image_Image, {r1_Integer, r2_Integer}, {c1_Integer, c2_Integer}]'
+        py_r1 = max(r1.get_int_value() - 1, 0)
+        py_r2 = max(r2.get_int_value() - 1, 0)
+        py_c1 = max(c1.get_int_value() - 1, 0)
+        py_c2 = max(c2.get_int_value() - 1, 0)
+        return Image(image.pixels[py_r1:1 + py_r2, py_c1:1 + py_c2], image.color_space)
 
 
 class PixelValue(_ImageBuiltin):
+    '''
+    <dl>
+    <dt>'PixelValue[$image$, {$x$, $y$}]'
+      <dd>gives the value of the pixel at position {$x$, $y$} in $image$.
+    </dl>
+    '''
+
     def apply(self, image, x, y, evaluation):
         'PixelValue[image_Image, {x_?RealNumberQ, y_?RealNumberQ}]'
         pixel = image.pixels[int(y.round_to_float() - 1), int(x.round_to_float() - 1)]
@@ -1534,6 +1674,13 @@ class PixelValue(_ImageBuiltin):
 
 
 class PixelValuePositions(_ImageBuiltin):
+    '''
+    <dl>
+    <dt>'PixelValuePositions[$image$, $val$]'
+      <dd>gives the positions of all pixels in $image$ that have value $val$.
+    </dl>
+    '''
+
     def apply(self, image, val, evaluation):
         'PixelValuePositions[image_Image, val_?RealNumberQ]'
         rows, cols = numpy.where(pixels_as_float(image.pixels) == float(val.round_to_float()))
@@ -1547,8 +1694,8 @@ class PixelValuePositions(_ImageBuiltin):
 class ImageDimensions(_ImageBuiltin):
     '''
     <dl>
-    <dt>'ImageDimensions[image]'
-      <dd>Returns the dimensions of an image in pixels.
+    <dt>'ImageDimensions[$image$]'
+      <dd>Returns the dimensions of $image$ in pixels.
     </dl>
 
     >> lena = Import["ExampleData/lena.tif"];
@@ -1564,6 +1711,13 @@ class ImageDimensions(_ImageBuiltin):
 
 
 class ImageAspectRatio(_ImageBuiltin):
+    '''
+    <dl>
+    <dt>'ImageAspectRatio[$image$]'
+      <dd>gives the aspect ratio of $image$.
+    </dl>
+    '''
+
     def apply(self, image, evaluation):
         'ImageAspectRatio[image_Image]'
         dim = image.dimensions()
@@ -1571,12 +1725,26 @@ class ImageAspectRatio(_ImageBuiltin):
 
 
 class ImageChannels(_ImageBuiltin):
+    '''
+    <dl>
+    <dt>'ImageChannels[$image$]'
+      <dd>gives the number of channels in $image$.
+    </dl>
+    '''
+
     def apply(self, image, evaluation):
         'ImageChannels[image_Image]'
         return Integer(image.channels())
 
 
 class ImageType(_ImageBuiltin):
+    '''
+    <dl>
+    <dt>'ImageType[$image$]'
+      <dd>gives the interval storage type of $image$, e.g. "Real", "Bit32", or "Bit".
+    </dl>
+    '''
+
     def apply(self, image, evaluation):
         'ImageType[image_Image]'
         return String(image.storage_type())

--- a/mathics/builtin/image.py
+++ b/mathics/builtin/image.py
@@ -952,8 +952,9 @@ class EdgeDetect(_ImageBuiltin):
     def apply(self, image, r, t, evaluation):
         'EdgeDetect[image_Image, r_?RealNumberQ, t_?RealNumberQ]'
         import skimage.feature
+        pixels = image.grayscale().pixels
         return Image(skimage.feature.canny(
-            image.grayscale().pixels, sigma=r.round_to_float() / 2,
+            pixels.reshape(pixels.shape[:2]), sigma=r.round_to_float() / 2,
             low_threshold=0.5 * t.round_to_float(), high_threshold=t.round_to_float()),
             'Grayscale')
 
@@ -1075,10 +1076,11 @@ class _MorphologyFilter(_ImageBuiltin):
         '%(name)s[image_Image, k_?MatrixQ]'
         if image.color_space != 'Grayscale':
             image = image.grayscale()
-            evaluation.message(self.name, 'grayscale')
+            evaluation.message(self.get_name(), 'grayscale')
         import skimage.morphology
         f = getattr(skimage.morphology, self.get_name(True).lower())
-        img = f(image.pixels, matrix_to_numpy(k))
+        shape = image.pixels.shape[:2]
+        img = f(image.pixels.reshape(shape), matrix_to_numpy(k))
         return Image(img, 'Grayscale')
 
 

--- a/mathics/builtin/image.py
+++ b/mathics/builtin/image.py
@@ -1869,7 +1869,7 @@ class Image(Atom):
             pixels = pixels_as_ubyte(pixels)
         elif n == 4:
             if self.color_space == 'CMYK':
-                mode ='CMYK'
+                mode = 'CMYK'
                 pixels = self.pixels
             elif self.color_space == 'RGB':
                 mode = 'RGBA'

--- a/mathics/builtin/image.py
+++ b/mathics/builtin/image.py
@@ -59,6 +59,8 @@ def pixels_as_float(pixels):
         return pixels.astype(numpy.float32) / 255.
     elif dtype == numpy.uint16:
         return pixels.astype(numpy.float32) / 65535.
+    elif dtype == numpy.bool:
+        return pixels.astype(numpy.float32)
     else:
         raise NotImplementedError
 
@@ -72,6 +74,8 @@ def pixels_as_ubyte(pixels):
         return pixels
     elif dtype == numpy.uint16:
         return (pixels / 256).astype(numpy.uint8)
+    elif dtype == numpy.bool:
+        return pixels.astype(numpy.uint8) * 255
     else:
         raise NotImplementedError
 
@@ -85,6 +89,8 @@ def pixels_as_uint(pixels):
         return pixels.astype(numpy.uint16) * 256
     elif dtype == numpy.uint16:
         return pixels
+    elif dtype == numpy.bool:
+        return pixels.astype(numpy.uint8) * 65535
     else:
         raise NotImplementedError
 

--- a/mathics/builtin/image.py
+++ b/mathics/builtin/image.py
@@ -1885,7 +1885,7 @@ class Image(Atom):
         return PIL.Image.fromarray(pixels, mode)
 
     def color_convert(self, to_color_space, preserve_alpha=True):
-        if to_color_space == self.color_space:
+        if to_color_space == self.color_space and preserve_alpha:
             return self
         else:
             pixels = pixels_as_float(self.pixels)

--- a/mathics/builtin/options.py
+++ b/mathics/builtin/options.py
@@ -12,6 +12,7 @@ import six
 
 from mathics.builtin.base import Builtin, Test
 from mathics.core.expression import Symbol, Expression, get_default_value
+from mathics.builtin.image import Image
 
 
 class Options(Builtin):
@@ -75,9 +76,14 @@ class Options(Builtin):
 
         name = f.get_name()
         if not name:
-            evaluation.message('Options', 'sym', f, 1)
-            return
-        options = evaluation.definitions.get_options(name)
+            if isinstance(f, Image):
+                # FIXME ColorSpace, MetaInformation
+                options = f.metadata
+            else:
+                evaluation.message('Options', 'sym', f, 1)
+                return
+        else:
+            options = evaluation.definitions.get_options(name)
         result = []
         for option, value in sorted(six.iteritems(options), key=lambda item: item[0]):
             # Don't use HoldPattern, since the returned List should be

--- a/mathics/builtin/plot.py
+++ b/mathics/builtin/plot.py
@@ -56,6 +56,7 @@ def gradient_palette(color_function, n, evaluation):  # always returns RGB value
     except ColorError:
         return
 
+
 class ColorDataFunction(Builtin):
     pass
 


### PR DESCRIPTION
- Removed dependency on skimage everywhere where it's not strictly necessary; everything except for morphology and edge detection now only relies on PIL and numpy
- Removed matplotlib dependency
- Extended Colorize[] to use arbitrary ColorData[] and color functions (also works on images now)
- Added support for reading JPEG EXIF data via Import["image.jpg", "RawExif"]
- Extended ImageTake[] for general cropping
- Added ColorCombine[]
- Added DominantColors[]
- Added ImageConvolve[]
- Reimplemented BoxMatrix, DiskMatrix, DiamondMatrix to match MMA
- Added docs

I've added the scipy license to README.rst, since ImageConvolve[] is basically a port of their code, and we might want to adapt some other of their stuff in the future; I'm not sure if this is the right way, though.