### PR TITLE
LLVM compilation

### DIFF
--- a/mathics/builtin/__init__.py
+++ b/mathics/builtin/__init__.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 
 from mathics.builtin import (
-    algebra, arithmetic, assignment, attributes, calculus, combinatorial,
+    algebra, arithmetic, assignment, attributes, calculus, combinatorial, compilation,
     comparison, control, datentime, diffeqns, evaluation, exptrig, functional,
     graphics, graphics3d, image, inout, integer, linalg, lists, logic, manipulate, natlang, numbertheory,
     numeric, options, patterns, plot, physchemdata, randomnumbers, recurrence,
@@ -17,7 +17,7 @@ from mathics.builtin.base import (
 from mathics.settings import ENABLE_FILES_MODULE
 
 modules = [
-    algebra, arithmetic, assignment, attributes, calculus, combinatorial,
+    algebra, arithmetic, assignment, attributes, calculus, combinatorial, compilation,
     comparison, control, datentime, diffeqns, evaluation, exptrig, functional,
     graphics, graphics3d, image, inout, integer, linalg, lists, logic, manipulate, natlang, numbertheory,
     numeric, options, patterns, plot, physchemdata, randomnumbers, recurrence,

--- a/mathics/builtin/compilation.py
+++ b/mathics/builtin/compilation.py
@@ -21,6 +21,19 @@ class Compile(Builtin):
     #> cf[x]
      : Invalid argument x should be Integer, Real or boolean.
      = CompiledFunction[{x}, Sin[x], -CompiledCode-][x]
+
+    #> cf = Compile[{{x, _Real}, {x, _Integer}}, Sin[x + y]]
+     : TODO: repeated arg warning
+     = Compile[{{x, _Real}, {x, _Integer}}, Sin[x + y]]
+
+    #> cf = Compile[{{x, _Real}, {y, _Integer}}, Sin[x + y]]
+     = CompiledFunction[{x, y}, Sin[x + y], -CompiledCode-]
+    #> cf[1, 2]
+     = 0.14112
+
+    #> cf[x + y]
+     : TODO: wrong number of args warning
+     = cf[x + y]
     '''
 
     requires = (

--- a/mathics/builtin/compilation.py
+++ b/mathics/builtin/compilation.py
@@ -1,0 +1,137 @@
+import ctypes
+
+from mathics.builtin.base import Builtin, BoxConstruct
+from mathics.core.expression import Atom, Expression, Symbol, String, from_python, Integer, Real
+
+
+class Compile(Builtin):
+    '''
+    >> cf = Compile[{{x, _Real}}, Sin[x]]
+     = CompiledFunction[{x}, Sin[x], -CompiledCode-]
+
+    >> cf[1.4]
+     = 0.98545
+
+    #> cf[1/2]
+     = 0.479426
+
+    #> cf[4]
+     = -0.756802
+
+    #> cf[x]
+     : Invalid argument x should be Integer, Real or boolean.
+     = CompiledFunction[{x}, Sin[x], -CompiledCode-][x]
+    '''
+
+    requires = (
+        'llvmlite',
+    )
+
+    messages = {
+        'invar': 'var `1` should be {symbol, type} annotation.',
+        'invars': 'vars should be a list of {symbol, type} annotations.',
+        'comperr': 'expression `1` could not be compiled.',
+    }
+
+    def apply(self, vars, expr, evaluation):
+        'Compile[vars_, expr_]'
+        from mathics.builtin.compile import _compile, int_type, real_type, bool_type, CompileArg, CompileError
+
+        # _Complex not implemented
+        permitted_types = {
+            Expression('Blank', Symbol('Integer')): int_type,
+            Expression('Blank', Symbol('Real')): real_type,
+            Symbol('True'): bool_type,
+            Symbol('False'): bool_type,
+        }
+
+        if not vars.has_form('List', None):
+            return evaluation.message('Compile', 'invars')
+        args = []
+        for var in vars.get_leaves():
+            if var.has_form('List', 1) and isinstance(var.leaves[0], Symbol):
+                args.append(CompileArg(var.leaves[0].get_name(), real_type))
+            elif var.has_form('List', 2):
+                symb, typ = var.get_leaves()
+                if isinstance(symb, Symbol) and typ in permitted_types:
+                    args.append(CompileArg(symb.get_name(), permitted_types[typ]))
+                else:
+                    return evaluation.message('Compile', 'invar', var)
+            else:
+                return evaluation.message('Compile', 'invar', var)
+
+        try:
+            cfunc = _compile(expr, args)
+        except CompileError:
+            return evaluation.message('Compile', 'comperr', expr)
+        code = CompiledCode(cfunc)
+        arg_names = Expression('List', *(Symbol(arg.name) for arg in args))
+        return Expression('CompiledFunction', arg_names, expr, code)
+
+
+class CompiledCode(Atom):
+    def __init__(self, cfunc, **kwargs):
+        super(CompiledCode, self).__init__(**kwargs)
+        self.cfunc = cfunc
+
+    def __str__(self):
+        return '-CompiledCode-'
+
+    def do_copy(self):
+        return CompiledCode(self.cfunc)
+
+    def default_format(self, evaluation, form):
+        return str(self)
+
+    def get_sort_key(self, pattern_sort=False):
+        if pattern_sort:
+            return super(CompiledCode, self).get_sort_key(True)
+        else:
+            return hash(self)
+
+    def same(self, other):
+        return self is other
+
+    def to_python(self, *args, **kwargs):
+        return None
+
+    def __hash__(self):
+        return hash(("CompiledCode", ctypes.addressof(self.cfunc)))  # XXX hack
+
+    def atom_to_boxes(self, f, evaluation):
+        return Expression('CompiledCodeBox')
+
+
+class CompiledCodeBox(BoxConstruct):
+    def boxes_to_text(self, leaves, **options):
+        return '-CompiledCode-'
+
+    def boxes_to_xml(self, leaves, **options):
+        return '-CompiledCode-'
+
+    def boxes_to_tex(self, leaves, **options):
+        return '-CompiledCode-'
+
+
+class CompiledFunction(Builtin):
+    messages = {
+        'argerr': 'Invalid argument `1` should be Integer, Real or boolean.',
+    }
+
+    def apply(self, argnames, expr, code, args, evaluation):
+        'CompiledFunction[argnames_, expr_, code_CompiledCode][args__]'
+        py_args = []
+        for arg in args.get_sequence():
+            if isinstance(arg, Integer):
+                py_args.append(arg.get_int_value())
+            elif arg.same(Symbol('True')):
+                py_args.append(True)
+            elif arg.same(Symbol('False')):
+                py_args.append(False)
+            else:
+                py_args.append(arg.round_to_float(evaluation))
+        try:
+            result = code.cfunc(*py_args)
+        except ctypes.ArgumentError:
+            return evaluation.message('CompiledFunction', 'argerr', args)
+        return from_python(result)

--- a/mathics/builtin/compile.py
+++ b/mathics/builtin/compile.py
@@ -1,0 +1,115 @@
+from llvmlite import ir
+import llvmlite.binding as llvm
+
+from mathics.core.expression import Expression, Integer, Symbol
+
+from ctypes import c_int64, CFUNCTYPE
+
+
+class CompilationError(Exception):
+    pass
+
+# create some useful types
+int_type = ir.IntType(64)
+ifunc2_type = ir.FunctionType(int_type, (int_type, int_type))
+
+
+class MathicsArg(object):
+    def __init__(self, name, type):
+        self.name = name
+        self.type = type
+
+
+def generate_ir(expr, args, func_name):
+    '''
+    generates LLVM IR for a given expression
+    '''
+    # create an empty module
+    module = ir.Module(name=__file__)
+
+    # TODO infer function type from args
+
+    # declare a function inside it
+    func = ir.Function(module, ifunc2_type, name=func_name)
+
+    # implement the function
+    block = func.append_basic_block(name='entry')
+    builder = ir.IRBuilder(block)
+
+    lookup_args = {arg.name: func_arg for arg, func_arg in zip(args, func.args)}
+
+    builder.ret(_gen_ir(expr, lookup_args, builder))
+    return str(module)
+
+
+def _gen_ir(expr, lookup_args, builder):
+    '''
+    walks an expression tree and constructs the ir block
+    '''
+    if isinstance(expr, Symbol):
+        arg = lookup_args[expr.get_name()]
+        return arg
+    elif isinstance(expr, Integer):
+        raise NotImplementedError
+    elif expr.has_form('Plus', 2):
+        a, b = [_gen_ir(leaf, lookup_args, builder) for leaf in expr.get_leaves()]
+        result = builder.add(a, b, name='res')
+        return result
+    else:
+        raise CompilationError
+
+
+def create_execution_engine():
+    """
+    Create an ExecutionEngine suitable for JIT code generation on
+    the host CPU.  The engine is reusable for an arbitrary number of
+    modules.
+    """
+    # Create a target machine representing the host
+    target = llvm.Target.from_default_triple()
+    target_machine = target.create_target_machine()
+    # And an execution engine with an empty backing module
+    backing_mod = llvm.parse_assembly("")
+    engine = llvm.create_mcjit_compiler(backing_mod, target_machine)
+    return engine
+
+
+def compile_ir(engine, llvm_ir):
+    """
+    Compile the LLVM IR string with the given engine.
+    The compiled module object is returned.
+    """
+    # Create a LLVM module object from the IR
+    mod = llvm.parse_assembly(llvm_ir)
+    mod.verify()
+    # Now add the module and make sure it is ready for execution
+    engine.add_module(mod)
+    engine.finalize_object()
+    return mod
+
+
+# setup llvm for code generation
+llvm.initialize()
+llvm.initialize_native_target()
+llvm.initialize_native_asmprinter()  # yes, even this one
+
+engine = create_execution_engine()
+
+
+def _compile(expr, args):
+    llvm_ir = generate_ir(expr, args, 'plus')
+    mod = compile_ir(engine, llvm_ir)
+
+    # lookup function pointer
+    func_ptr = engine.get_function_address('plus')
+
+    # run function via ctypes
+    cfunc = CFUNCTYPE(c_int64, c_int64, c_int64)(func_ptr)
+    return cfunc
+
+# Example: compile an expression
+expr = Expression('Plus', Symbol('x'), Symbol('y'))
+args = [MathicsArg('System`x', 'int'), MathicsArg('System`y', 'int')]
+cfunc = _compile(expr, args)
+
+assert cfunc(1, 2) == 3

--- a/mathics/builtin/compile.py
+++ b/mathics/builtin/compile.py
@@ -161,6 +161,12 @@ def _gen_ir(expr, lookup_args, builder):
             a = call_fp_intr(builder, 'llvm.sin', args)
             b = call_fp_intr(builder, 'llvm.cos', args)
             return builder.fdiv(a, b)
+    elif expr.has_form('Cot', 1):
+        if ret_type == real_type:
+            # FIXME this approach is inaccurate
+            a = call_fp_intr(builder, 'llvm.sin', args)
+            b = call_fp_intr(builder, 'llvm.cos', args)
+            return builder.fdiv(b, a)
     elif expr.has_form('Power', 2):
         # FIXME unknown intrinsic
         # TODO llvm.powi if second argument is integer

--- a/mathics/builtin/compile.py
+++ b/mathics/builtin/compile.py
@@ -189,6 +189,50 @@ def _gen_ir(expr, lookup_args, builder):
     elif expr.has_form('Max', 1, None):
         if ret_type == real_type:
             return reduce(lambda arg1, arg2: call_fp_intr(builder, 'llvm.maxnum', [arg1, arg2]), args)
+    elif expr.has_form('Sinh', 1) and ret_type == real_type:
+        # FIXME this approach is inaccurate
+        # Sinh[x] = (Exp[x] - Exp[-x]) / 2
+        a = call_fp_intr(builder, 'llvm.exp', args)
+        negx = builder.fsub(real_type(0.0), args[0])
+        b = call_fp_intr(builder, 'llvm.exp', [negx])
+        c = builder.fsub(a, b)
+        return builder.fmul(c, real_type(0.5))
+    elif expr.has_form('Cosh', 1) and ret_type == real_type:
+        # FIXME this approach is inaccurate
+        # Cosh[x] = (Exp[x] + Exp[-x]) / 2
+        a = call_fp_intr(builder, 'llvm.exp', args)
+        negx = builder.fsub(real_type(0.0), args[0])
+        b = call_fp_intr(builder, 'llvm.exp', [negx])
+        c = builder.fadd(a, b)
+        return builder.fmul(c, real_type(0.5))
+    elif expr.has_form('Tanh', 1) and ret_type == real_type:
+        # FIXME this approach is inaccurate
+        # Tanh[x] = (Exp[x] - Exp[-x]) / (Exp[x] + Exp[-x])
+        a = call_fp_intr(builder, 'llvm.exp', args)
+        negx = builder.fsub(real_type(0.0), args[0])
+        b = call_fp_intr(builder, 'llvm.exp', [negx])
+        return builder.fdiv(builder.fsub(a, b), builder.fadd(a, b))
+    elif expr.has_form('Sech', 1) and ret_type == real_type:
+        # FIXME this approach is inaccurate
+        # Sech[x] = 2 / (Exp[x] - Exp[-x])
+        a = call_fp_intr(builder, 'llvm.exp', args)
+        negx = builder.fsub(real_type(0.0), args[0])
+        b = call_fp_intr(builder, 'llvm.exp', [negx])
+        return builder.fdiv(real_type(2.0), builder.fadd(a, b))
+    elif expr.has_form('Csch', 1) and ret_type == real_type:
+        # FIXME this approach is inaccurate
+        # Csch[x] = 2 / (Exp[x] + Exp[-x])
+        a = call_fp_intr(builder, 'llvm.exp', args)
+        negx = builder.fsub(real_type(0.0), args[0])
+        b = call_fp_intr(builder, 'llvm.exp', [negx])
+        return builder.fdiv(real_type(2.0), builder.fsub(a, b))
+    elif expr.has_form('Coth', 1) and ret_type == real_type:
+        # FIXME this approach is inaccurate
+        # Coth[x] = (Exp[x] + Exp[-x]) / (Exp[x] - Exp[-x])
+        a = call_fp_intr(builder, 'llvm.exp', args)
+        negx = builder.fsub(real_type(0.0), args[0])
+        b = call_fp_intr(builder, 'llvm.exp', [negx])
+        return builder.fdiv(builder.fadd(a, b), builder.fsub(a, b))
     elif expr.has_form('Equal', 2, None):
         result = []
         for lhs, rhs in pairwise(args):

--- a/mathics/builtin/compile.py
+++ b/mathics/builtin/compile.py
@@ -27,70 +27,6 @@ class MathicsArg(object):
         self.type = type
 
 
-def generate_ir(expr, args, func_name, known_ret_type=None):
-    '''
-    generates LLVM IR for a given expression
-    '''
-    # assume that the function returns a real. Note that this is verified by
-    # looking at the type of the head of the converted expression.
-    ret_type = real_type if known_ret_type is None else known_ret_type
-
-    # create an empty module
-    module = ir.Module(name=__file__)
-
-    func_type = ir.FunctionType(ret_type, tuple(arg.type for arg in args))
-
-    # declare a function inside the module
-    func = ir.Function(module, func_type, name=func_name)
-
-    # implement the function
-    block = func.append_basic_block(name='entry')
-    builder = ir.IRBuilder(block)
-
-    lookup_args = {arg.name: func_arg for arg, func_arg in zip(args, func.args)}
-
-    ir_code = _gen_ir(expr, lookup_args, builder)
-
-    # if the return isn't correct then try again
-    if known_ret_type is None:
-        if ir_code.type == void_type:
-            return generate_ir(expr, args, func_name, lookup_args['_result'])
-        elif ir_code.type != ret_type:
-            return generate_ir(expr, args, func_name, ir_code.type)
-
-    if ir_code.type != void_type:
-        # type was known or guessed correctly
-        assert ir_code.type == ret_type
-        builder.ret(ir_code)
-    return str(module), ret_type
-
-
-
-def call_fp_intr(builder, name, args):
-    '''
-    call a LLVM intrinsic floating-point operation
-    '''
-    mod = builder.module
-    intr = lc.Function.intrinsic(mod, name, [arg.type for arg in args])
-    return builder.call(intr, args)
-
-
-def convert_args(args, builder):
-    # check/convert leaf types
-    if any(arg.type == real_type for arg in args):
-        for i, arg in enumerate(args):
-            if arg.type == int_type:
-                args[i] = builder.sitofp(arg, real_type)
-        ret_type = real_type
-    elif all(arg.type == int_type for arg in args):
-        ret_type = int_type
-    elif all(arg.type == bool_type for arg in args):
-        ret_type = bool_type
-    else:
-        raise CompilationError()
-    return ret_type, args
-
-
 def pairwise(args):
     '''
     [a, b, c] -> [(a, b), (b, c)]
@@ -105,277 +41,361 @@ def pairwise(args):
         last = arg
 
 
-def _gen_ir(expr, lookup_args, builder):
-    '''
-    walks an expression tree and constructs the ir block
-    '''
-    if isinstance(expr, Symbol):
-        arg = lookup_args[expr.get_name()]
-        return arg
-    elif isinstance(expr, Integer):
-        return int_type(expr.get_int_value())
-    elif isinstance(expr, Real):
-        return real_type(expr.round_to_float())
-    elif not isinstance(expr, Expression):
-        raise CompilationError()
+class IRGenerator(object):
+    def __init__(self, expr, args, func_name):
+        self.expr = expr
+        self.args = args
+        self.func_name = func_name      # function name of entry point
+        self.builder = None
+        self._known_ret_type = None
+        self._returned_type = None
+        self.lookup_args = None
 
-    if expr.has_form('If', 3):
-        args = expr.get_leaves()
+    def generate_ir(self):
+        '''
+        generates LLVM IR for a given expression
+        '''
+        # assume that the function returns a real. Note that this is verified by
+        # looking at the type of the head of the converted expression.
+        ret_type = real_type if self._known_ret_type is None else self._known_ret_type
 
-        # condition
-        cond = _gen_ir(args[0], lookup_args, builder)
-        if cond.type == int_type:
-            cond = builder.icmp_signed('!=', cond, int_type(0))
-        if cond.type != bool_type:
-            raise CompilationError()
+        # create an empty module
+        module = ir.Module(name=__file__)
 
-        # construct new blocks
-        then_block = builder.append_basic_block()
-        else_block = builder.append_basic_block()
+        func_type = ir.FunctionType(ret_type, tuple(arg.type for arg in self.args))
 
-        # branch to then or else block
-        builder.cbranch(cond, then_block, else_block)
+        # declare a function inside the module
+        func = ir.Function(module, func_type, name=self.func_name)
 
-        # results for both block
-        with builder.goto_block(then_block):
-            then_result = _gen_ir(args[1], lookup_args, builder)
-        with builder.goto_block(else_block):
-            else_result = _gen_ir(args[2], lookup_args, builder)
+        # implement the function
+        block = func.append_basic_block(name='entry')
+        self.builder = ir.IRBuilder(block)
 
-        # type check both blocks - determine resulting type
-        if then_result.type == void_type and else_result.type == void_type:
-            # both blocks terminate so no continuation block
-            return then_result
-        elif then_result.type == else_result.type:
-            ret_type = then_result.type
-        elif then_result.type == int_type and else_result.type == real_type:
-            builder.position_at_end(then_block)
-            then_result = builder.sitofp(then_result, real_type)
+        self.lookup_args = {arg.name: func_arg for arg, func_arg in zip(self.args, func.args)}
+
+        ir_code = self._gen_ir(self.expr)
+
+        # if the return type isn't correct then try again
+        if self._known_ret_type is None:
+            # determine the type returned
+            if ir_code.type == void_type:
+                self._known_ret_type = self._returned_type
+                assert self._known_ret_type is not None
+                # force generation again in case multiple returns of different types
+                return self.generate_ir()
+
+            if ir_code.type != ret_type:
+                # guessed incorrectly - try again
+                self._known_ret_type = ir_code.type
+                return self.generate_ir()
+
+        if ir_code.type != void_type:
+            self.builder.ret(ir_code)
+
+        return str(module), ret_type
+
+    def call_fp_intr(self, name, args):
+        '''
+        call a LLVM intrinsic floating-point operation
+        '''
+        mod = self.builder.module
+        intr = lc.Function.intrinsic(mod, name, [arg.type for arg in args])
+        return self.builder.call(intr, args)
+
+    def convert_args(self, args):
+        # check/convert leaf types
+        if any(arg.type == real_type for arg in args):
+            for i, arg in enumerate(args):
+                if arg.type == int_type:
+                    args[i] = self.builder.sitofp(arg, real_type)
             ret_type = real_type
-        elif then_result.type == real_type and else_result.type == int_type:
-            builder.position_at_end(else_block)
-            else_result = builder.sitofp(else_result, real_type)
-            ret_type = real_type
-        elif then_result.type == void_type and else_result.type != void_type:
-            ret_type = else_result.type
-        elif then_result.type != void_type and else_result.type == void_type:
-            ret_type = then_result.type
+        elif all(arg.type == int_type for arg in args):
+            ret_type = int_type
+        elif all(arg.type == bool_type for arg in args):
+            ret_type = bool_type
         else:
             raise CompilationError()
+        return ret_type, args
 
-        # continuation block
-        cont_block = builder.append_basic_block()
-        builder.position_at_start(cont_block)
-        result = builder.phi(ret_type)
+    def _gen_ir(self, expr):
+        '''
+        walks an expression tree and constructs the ir block
+        '''
+        builder = self.builder
 
-        # both blocks branch to continuation block (unless they terminate)
-        if then_result.type != void_type:
-            with builder.goto_block(then_block):
-                builder.branch(cont_block)
-            result.add_incoming(then_result, then_block)
-        if else_result.type != void_type:
-            with builder.goto_block(else_block):
-                builder.branch(cont_block)
-            result.add_incoming(else_result, else_block)
-        return result
-
-    # generate leaves
-    args = [_gen_ir(leaf, lookup_args, builder) for leaf in expr.get_leaves()]
-
-    for arg in args:
-        if arg.type == void_type:
+        if isinstance(expr, Symbol):
+            arg = self.lookup_args[expr.get_name()]
             return arg
-
-    # check leaf types
-    ret_type, args = convert_args(args, builder)
-
-    # convert expression
-    if expr.has_form('Plus', 1, None):
-        if ret_type == real_type:
-            return reduce(builder.fadd, args)
-        elif ret_type == int_type:
-            return reduce(builder.add, args)
-    elif expr.has_form('Times', 1, None):
-        if ret_type == real_type:
-            return reduce(builder.fmul, args)
-        elif ret_type == int_type:
-            return reduce(builder.mul, args)
-    elif expr.has_form('Sin', 1):
-        if ret_type == real_type:
-            return call_fp_intr(builder, 'llvm.sin', args)
-    elif expr.has_form('Cos', 1):
-        if ret_type == real_type:
-            return call_fp_intr(builder, 'llvm.cos', args)
-    elif expr.has_form('Tan', 1):
-        if ret_type == real_type:
-            # FIXME this approach is inaccurate
-            sinx = call_fp_intr(builder, 'llvm.sin', args)
-            cosx = call_fp_intr(builder, 'llvm.cos', args)
-            return builder.fdiv(sinx, cosx)
-    elif expr.has_form('Sec', 1) and ret_type == real_type:
-        # FIXME this approach is inaccurate
-        cosx = call_fp_intr(builder, 'llvm.cos', args)
-        return builder.fdiv(real_type(1.0), cosx)
-    elif expr.has_form('Csc', 1) and ret_type == real_type:
-        # FIXME this approach is inaccurate
-        sinx = call_fp_intr(builder, 'llvm.sin', args)
-        return builder.fdiv(real_type(1.0), sinx)
-    elif expr.has_form('Cot', 1) and ret_type == real_type:
-        # FIXME this approach is inaccurate
-        sinx = call_fp_intr(builder, 'llvm.sin', args)
-        cosx = call_fp_intr(builder, 'llvm.cos', args)
-        return builder.fdiv(cosx, sinx)
-    elif expr.has_form('Power', 2):
-        # TODO llvm.powi if second argument is integer
-        # TODO llvm.exp if first argument is E
-        # TODO llvm.exp2 if first argument is 2
-        if ret_type == real_type:
-            return call_fp_intr(builder, 'llvm.pow', args)
-    elif expr.has_form('Exp', 1):
-        if ret_type == real_type:
-            return call_fp_intr(builder, 'llvm.exp', args)
-    elif expr.has_form('Log', 1):
-        # TODO log2 and log10 special cases
-        if ret_type == real_type:
-            return call_fp_intr(builder, 'llvm.log', args)
-    elif expr.has_form('Abs', 1):
-        if ret_type == real_type:
-            return call_fp_intr(builder, 'llvm.fabs', args)
-    elif expr.has_form('Min', 1, None):
-        if ret_type == real_type:
-            return reduce(lambda arg1, arg2: call_fp_intr(builder, 'llvm.minnum', [arg1, arg2]), args)
-    elif expr.has_form('Max', 1, None):
-        if ret_type == real_type:
-            return reduce(lambda arg1, arg2: call_fp_intr(builder, 'llvm.maxnum', [arg1, arg2]), args)
-    elif expr.has_form('Sinh', 1) and ret_type == real_type:
-        # FIXME this approach is inaccurate
-        # Sinh[x] = (Exp[x] - Exp[-x]) / 2
-        a = call_fp_intr(builder, 'llvm.exp', args)
-        negx = builder.fsub(real_type(0.0), args[0])
-        b = call_fp_intr(builder, 'llvm.exp', [negx])
-        c = builder.fsub(a, b)
-        return builder.fmul(c, real_type(0.5))
-    elif expr.has_form('Cosh', 1) and ret_type == real_type:
-        # FIXME this approach is inaccurate
-        # Cosh[x] = (Exp[x] + Exp[-x]) / 2
-        a = call_fp_intr(builder, 'llvm.exp', args)
-        negx = builder.fsub(real_type(0.0), args[0])
-        b = call_fp_intr(builder, 'llvm.exp', [negx])
-        c = builder.fadd(a, b)
-        return builder.fmul(c, real_type(0.5))
-    elif expr.has_form('Tanh', 1) and ret_type == real_type:
-        # FIXME this approach is inaccurate
-        # Tanh[x] = (Exp[x] - Exp[-x]) / (Exp[x] + Exp[-x])
-        a = call_fp_intr(builder, 'llvm.exp', args)
-        negx = builder.fsub(real_type(0.0), args[0])
-        b = call_fp_intr(builder, 'llvm.exp', [negx])
-        return builder.fdiv(builder.fsub(a, b), builder.fadd(a, b))
-    elif expr.has_form('Sech', 1) and ret_type == real_type:
-        # FIXME this approach is inaccurate
-        # Sech[x] = 2 / (Exp[x] - Exp[-x])
-        a = call_fp_intr(builder, 'llvm.exp', args)
-        negx = builder.fsub(real_type(0.0), args[0])
-        b = call_fp_intr(builder, 'llvm.exp', [negx])
-        return builder.fdiv(real_type(2.0), builder.fadd(a, b))
-    elif expr.has_form('Csch', 1) and ret_type == real_type:
-        # FIXME this approach is inaccurate
-        # Csch[x] = 2 / (Exp[x] + Exp[-x])
-        a = call_fp_intr(builder, 'llvm.exp', args)
-        negx = builder.fsub(real_type(0.0), args[0])
-        b = call_fp_intr(builder, 'llvm.exp', [negx])
-        return builder.fdiv(real_type(2.0), builder.fsub(a, b))
-    elif expr.has_form('Coth', 1) and ret_type == real_type:
-        # FIXME this approach is inaccurate
-        # Coth[x] = (Exp[x] + Exp[-x]) / (Exp[x] - Exp[-x])
-        a = call_fp_intr(builder, 'llvm.exp', args)
-        negx = builder.fsub(real_type(0.0), args[0])
-        b = call_fp_intr(builder, 'llvm.exp', [negx])
-        return builder.fdiv(builder.fadd(a, b), builder.fsub(a, b))
-    elif expr.has_form('Equal', 2, None):
-        result = []
-        for lhs, rhs in pairwise(args):
-            if ret_type == real_type:
-                result.append(builder.fcmp_ordered('==', lhs, rhs))
-            elif ret_type == int_type:
-                result.append(builder.icmp_signed('==', lhs, rhs))
-            else:
-                raise CompilationError()
-        return reduce(builder.and_, result)
-    elif expr.has_form('Unequal', 2, None):
-        # Unequal[e1, e2, ... en] gives True only if none of the ei are equal.
-        result = []
-        for lhs, rhs in itertools.combinations(args, 2):
-            if ret_type == real_type:
-                result.append(builder.fcmp_ordered('!=', lhs, rhs))
-            elif ret_type == int_type:
-                result.append(builder.icmp_signed('!=', lhs, rhs))
-            else:
-                raise CompilationError()
-        return reduce(builder.and_, result)
-    elif expr.has_form('Less', 2, None):
-        result = []
-        for lhs, rhs in pairwise(args):
-            if ret_type == real_type:
-                result.append(builder.fcmp_ordered('<', lhs, rhs))
-            elif ret_type == int_type:
-                result.append(builder.icmp_signed('<', lhs, rhs))
-            else:
-                raise CompilationError()
-        return reduce(builder.and_, result)
-    elif expr.has_form('LessEqual', 2, None):
-        result = []
-        for lhs, rhs in pairwise(args):
-            if ret_type == real_type:
-                result.append(builder.fcmp_ordered('<=', lhs, rhs))
-            elif ret_type == int_type:
-                result.append(builder.icmp_signed('<=', lhs, rhs))
-            else:
-                raise CompilationError()
-        return reduce(builder.and_, result)
-    elif expr.has_form('Greater', 2, None):
-        result = []
-        for lhs, rhs in pairwise(args):
-            if ret_type == real_type:
-                result.append(builder.fcmp_ordered('>', lhs, rhs))
-            elif ret_type == int_type:
-                result.append(builder.icmp_signed('>', lhs, rhs))
-            else:
-                raise CompilationError()
-        return reduce(builder.and_, result)
-    elif expr.has_form('GreaterEqual', 2, None):
-        result = []
-        for lhs, rhs in pairwise(args):
-            if ret_type == real_type:
-                result.append(builder.fcmp_ordered('>=', lhs, rhs))
-            elif ret_type == int_type:
-                result.append(builder.icmp_signed('>=', lhs, rhs))
-            else:
-                raise CompilationError()
-        return reduce(builder.and_, result)
-    elif expr.has_form('And', 1, None) and ret_type == bool_type:
-        return reduce(builder.and_, args)
-    elif expr.has_form('Or', 1, None) and ret_type == bool_type:
-        return reduce(builder.or_, args)
-    elif expr.has_form('Xor', 1, None) and ret_type == bool_type:
-        return reduce(builder.xor, args)
-    elif expr.has_form('Not', 1) and ret_type == bool_type:
-        return builder.not_(args[0])
-    elif expr.has_form('BitAnd', 1, None) and ret_type == int_type:
-        return reduce(builder.and_, args)
-    elif expr.has_form('BitOr', 1, None) and ret_type == int_type:
-        return reduce(builder.or_, args)
-    elif expr.has_form('BitXor', 1, None) and ret_type == int_type:
-        return reduce(builder.xor, args)
-    elif expr.has_form('BitNot', 1) and ret_type == int_type:
-        return builder.not_(args[0])
-    elif expr.has_form('Return', 1):
-        ret_type = args[0].type
-        predetermined_ret_type = lookup_args.get('_result')
-        if predetermined_ret_type is not None and ret_type != predetermined_ret_type:
+        elif isinstance(expr, Integer):
+            return int_type(expr.get_int_value())
+        elif isinstance(expr, Real):
+            return real_type(expr.round_to_float())
+        elif not isinstance(expr, Expression):
             raise CompilationError()
-        lookup_args['_result'] = ret_type
-        return builder.ret(args[0])
-    raise CompilationError()
+
+        if expr.has_form('If', 3):
+            args = expr.get_leaves()
+
+            # condition
+            cond = self._gen_ir(args[0])
+            if cond.type == int_type:
+                cond = builder.icmp_signed('!=', cond, int_type(0))
+            if cond.type != bool_type:
+                raise CompilationError()
+
+            # construct new blocks
+            then_block = builder.append_basic_block()
+            else_block = builder.append_basic_block()
+
+            # branch to then or else block
+            builder.cbranch(cond, then_block, else_block)
+
+            # results for both block
+            with builder.goto_block(then_block):
+                then_result = self._gen_ir(args[1])
+            with builder.goto_block(else_block):
+                else_result = self._gen_ir(args[2])
+
+            # type check both blocks - determine resulting type
+            if then_result.type == void_type and else_result.type == void_type:
+                # both blocks terminate so no continuation block
+                return then_result
+            elif then_result.type == else_result.type:
+                ret_type = then_result.type
+            elif then_result.type == int_type and else_result.type == real_type:
+                builder.position_at_end(then_block)
+                then_result = builder.sitofp(then_result, real_type)
+                ret_type = real_type
+            elif then_result.type == real_type and else_result.type == int_type:
+                builder.position_at_end(else_block)
+                else_result = builder.sitofp(else_result, real_type)
+                ret_type = real_type
+            elif then_result.type == void_type and else_result.type != void_type:
+                ret_type = else_result.type
+            elif then_result.type != void_type and else_result.type == void_type:
+                ret_type = then_result.type
+            else:
+                raise CompilationError()
+
+            # continuation block
+            cont_block = builder.append_basic_block()
+            builder.position_at_start(cont_block)
+            result = builder.phi(ret_type)
+
+            # both blocks branch to continuation block (unless they terminate)
+            if then_result.type != void_type:
+                with builder.goto_block(then_block):
+                    builder.branch(cont_block)
+                result.add_incoming(then_result, then_block)
+            if else_result.type != void_type:
+                with builder.goto_block(else_block):
+                    builder.branch(cont_block)
+                result.add_incoming(else_result, else_block)
+            return result
+
+        # generate leaves
+        args = [self._gen_ir(leaf) for leaf in expr.get_leaves()]
+
+        for arg in args:
+            if arg.type == void_type:
+                return arg
+
+        # check leaf types
+        ret_type, args = self.convert_args(args)
+
+        # convert expression
+        if expr.has_form('Plus', 1, None):
+            if ret_type == real_type:
+                return reduce(builder.fadd, args)
+            elif ret_type == int_type:
+                return reduce(builder.add, args)
+        elif expr.has_form('Times', 1, None):
+            if ret_type == real_type:
+                return reduce(builder.fmul, args)
+            elif ret_type == int_type:
+                return reduce(builder.mul, args)
+        elif expr.has_form('Sin', 1):
+            if ret_type == real_type:
+                return self.call_fp_intr('llvm.sin', args)
+        elif expr.has_form('Cos', 1):
+            if ret_type == real_type:
+                return self.call_fp_intr('llvm.cos', args)
+        elif expr.has_form('Tan', 1):
+            if ret_type == real_type:
+                # FIXME this approach is inaccurate
+                sinx = self.call_fp_intr('llvm.sin', args)
+                cosx = self.call_fp_intr('llvm.cos', args)
+                return builder.fdiv(sinx, cosx)
+        elif expr.has_form('Sec', 1) and ret_type == real_type:
+            # FIXME this approach is inaccurate
+            cosx = self.call_fp_intr('llvm.cos', args)
+            return builder.fdiv(real_type(1.0), cosx)
+        elif expr.has_form('Csc', 1) and ret_type == real_type:
+            # FIXME this approach is inaccurate
+            sinx = self.call_fp_intr('llvm.sin', args)
+            return builder.fdiv(real_type(1.0), sinx)
+        elif expr.has_form('Cot', 1) and ret_type == real_type:
+            # FIXME this approach is inaccurate
+            sinx = self.call_fp_intr('llvm.sin', args)
+            cosx = self.call_fp_intr('llvm.cos', args)
+            return builder.fdiv(cosx, sinx)
+        elif expr.has_form('Power', 2):
+            # TODO llvm.powi if second argument is integer
+            # TODO llvm.exp if first argument is E
+            # TODO llvm.exp2 if first argument is 2
+            if ret_type == real_type:
+                return self.call_fp_intr('llvm.pow', args)
+        elif expr.has_form('Exp', 1):
+            if ret_type == real_type:
+                return self.call_fp_intr('llvm.exp', args)
+        elif expr.has_form('Log', 1):
+            # TODO log2 and log10 special cases
+            if ret_type == real_type:
+                return self.call_fp_intr('llvm.log', args)
+        elif expr.has_form('Abs', 1):
+            if ret_type == real_type:
+                return self.call_fp_intr('llvm.fabs', args)
+        elif expr.has_form('Min', 1, None):
+            if ret_type == real_type:
+                return reduce(lambda arg1, arg2: self.call_fp_intr('llvm.minnum', [arg1, arg2]), args)
+        elif expr.has_form('Max', 1, None):
+            if ret_type == real_type:
+                return reduce(lambda arg1, arg2: self.call_fp_intr('llvm.maxnum', [arg1, arg2]), args)
+        elif expr.has_form('Sinh', 1) and ret_type == real_type:
+            # FIXME this approach is inaccurate
+            # Sinh[x] = (Exp[x] - Exp[-x]) / 2
+            a = self.call_fp_intr('llvm.exp', args)
+            negx = builder.fsub(real_type(0.0), args[0])
+            b = self.call_fp_intr('llvm.exp', [negx])
+            c = builder.fsub(a, b)
+            return builder.fmul(c, real_type(0.5))
+        elif expr.has_form('Cosh', 1) and ret_type == real_type:
+            # FIXME this approach is inaccurate
+            # Cosh[x] = (Exp[x] + Exp[-x]) / 2
+            a = self.call_fp_intr('llvm.exp', args)
+            negx = builder.fsub(real_type(0.0), args[0])
+            b = self.call_fp_intr('llvm.exp', [negx])
+            c = builder.fadd(a, b)
+            return builder.fmul(c, real_type(0.5))
+        elif expr.has_form('Tanh', 1) and ret_type == real_type:
+            # FIXME this approach is inaccurate
+            # Tanh[x] = (Exp[x] - Exp[-x]) / (Exp[x] + Exp[-x])
+            a = self.call_fp_intr('llvm.exp', args)
+            negx = builder.fsub(real_type(0.0), args[0])
+            b = self.call_fp_intr('llvm.exp', [negx])
+            return builder.fdiv(builder.fsub(a, b), builder.fadd(a, b))
+        elif expr.has_form('Sech', 1) and ret_type == real_type:
+            # FIXME this approach is inaccurate
+            # Sech[x] = 2 / (Exp[x] - Exp[-x])
+            a = self.call_fp_intr('llvm.exp', args)
+            negx = builder.fsub(real_type(0.0), args[0])
+            b = self.call_fp_intr('llvm.exp', [negx])
+            return builder.fdiv(real_type(2.0), builder.fadd(a, b))
+        elif expr.has_form('Csch', 1) and ret_type == real_type:
+            # FIXME this approach is inaccurate
+            # Csch[x] = 2 / (Exp[x] + Exp[-x])
+            a = self.call_fp_intr('llvm.exp', args)
+            negx = builder.fsub(real_type(0.0), args[0])
+            b = self.call_fp_intr('llvm.exp', [negx])
+            return builder.fdiv(real_type(2.0), builder.fsub(a, b))
+        elif expr.has_form('Coth', 1) and ret_type == real_type:
+            # FIXME this approach is inaccurate
+            # Coth[x] = (Exp[x] + Exp[-x]) / (Exp[x] - Exp[-x])
+            a = self.call_fp_intr('llvm.exp', args)
+            negx = builder.fsub(real_type(0.0), args[0])
+            b = self.call_fp_intr('llvm.exp', [negx])
+            return builder.fdiv(builder.fadd(a, b), builder.fsub(a, b))
+        elif expr.has_form('Equal', 2, None):
+            result = []
+            for lhs, rhs in pairwise(args):
+                if ret_type == real_type:
+                    result.append(builder.fcmp_ordered('==', lhs, rhs))
+                elif ret_type == int_type:
+                    result.append(builder.icmp_signed('==', lhs, rhs))
+                else:
+                    raise CompilationError()
+            return reduce(builder.and_, result)
+        elif expr.has_form('Unequal', 2, None):
+            # Unequal[e1, e2, ... en] gives True only if none of the ei are equal.
+            result = []
+            for lhs, rhs in itertools.combinations(args, 2):
+                if ret_type == real_type:
+                    result.append(builder.fcmp_ordered('!=', lhs, rhs))
+                elif ret_type == int_type:
+                    result.append(builder.icmp_signed('!=', lhs, rhs))
+                else:
+                    raise CompilationError()
+            return reduce(builder.and_, result)
+        elif expr.has_form('Less', 2, None):
+            result = []
+            for lhs, rhs in pairwise(args):
+                if ret_type == real_type:
+                    result.append(builder.fcmp_ordered('<', lhs, rhs))
+                elif ret_type == int_type:
+                    result.append(builder.icmp_signed('<', lhs, rhs))
+                else:
+                    raise CompilationError()
+            return reduce(builder.and_, result)
+        elif expr.has_form('LessEqual', 2, None):
+            result = []
+            for lhs, rhs in pairwise(args):
+                if ret_type == real_type:
+                    result.append(builder.fcmp_ordered('<=', lhs, rhs))
+                elif ret_type == int_type:
+                    result.append(builder.icmp_signed('<=', lhs, rhs))
+                else:
+                    raise CompilationError()
+            return reduce(builder.and_, result)
+        elif expr.has_form('Greater', 2, None):
+            result = []
+            for lhs, rhs in pairwise(args):
+                if ret_type == real_type:
+                    result.append(builder.fcmp_ordered('>', lhs, rhs))
+                elif ret_type == int_type:
+                    result.append(builder.icmp_signed('>', lhs, rhs))
+                else:
+                    raise CompilationError()
+            return reduce(builder.and_, result)
+        elif expr.has_form('GreaterEqual', 2, None):
+            result = []
+            for lhs, rhs in pairwise(args):
+                if ret_type == real_type:
+                    result.append(builder.fcmp_ordered('>=', lhs, rhs))
+                elif ret_type == int_type:
+                    result.append(builder.icmp_signed('>=', lhs, rhs))
+                else:
+                    raise CompilationError()
+            return reduce(builder.and_, result)
+        elif expr.has_form('And', 1, None) and ret_type == bool_type:
+            return reduce(builder.and_, args)
+        elif expr.has_form('Or', 1, None) and ret_type == bool_type:
+            return reduce(builder.or_, args)
+        elif expr.has_form('Xor', 1, None) and ret_type == bool_type:
+            return reduce(builder.xor, args)
+        elif expr.has_form('Not', 1) and ret_type == bool_type:
+            return builder.not_(args[0])
+        elif expr.has_form('BitAnd', 1, None) and ret_type == int_type:
+            return reduce(builder.and_, args)
+        elif expr.has_form('BitOr', 1, None) and ret_type == int_type:
+            return reduce(builder.or_, args)
+        elif expr.has_form('BitXor', 1, None) and ret_type == int_type:
+            return reduce(builder.xor, args)
+        elif expr.has_form('BitNot', 1) and ret_type == int_type:
+            return builder.not_(args[0])
+        elif expr.has_form('Return', 1):
+            result = args[0]
+            if self._returned_type == real_type and ret_type == int_type:
+               result = builder.sitofp(result, real_type)
+            elif self._returned_type == int_type and ret_type == real_type:
+                self._returned_type = ret_type
+            self._returned_type = ret_type
+            return builder.ret(result)
+        raise CompilationError()
+
+    def set_returned_type(self, ret_type):
+        if self._returned_type is not None and self._returned_type != ret_type:
+            raise CompilationError()
+        self._returned_type = ret_type
 
 
 def create_execution_engine():
@@ -428,7 +448,8 @@ def llvm_to_ctype(t):
 
 
 def _compile(expr, args):
-    llvm_ir, ret_type = generate_ir(expr, args, 'mathics')
+    ir_gen = IRGenerator(expr, args, 'mathics')
+    llvm_ir, ret_type = ir_gen.generate_ir()
     mod = compile_ir(engine, llvm_ir)
 
     # lookup function pointer

--- a/mathics/builtin/compile.py
+++ b/mathics/builtin/compile.py
@@ -168,7 +168,6 @@ def _gen_ir(expr, lookup_args, builder):
             b = call_fp_intr(builder, 'llvm.cos', args)
             return builder.fdiv(b, a)
     elif expr.has_form('Power', 2):
-        # FIXME unknown intrinsic
         # TODO llvm.powi if second argument is integer
         # TODO llvm.exp if first argument is E
         # TODO llvm.exp2 if first argument is 2
@@ -186,11 +185,9 @@ def _gen_ir(expr, lookup_args, builder):
             return call_fp_intr(builder, 'llvm.fabs', args)
     elif expr.has_form('Min', 1, None):
         if ret_type == real_type:
-            # FIXME unknown intrinsic
             return reduce(lambda arg1, arg2: call_fp_intr(builder, 'llvm.minnum', [arg1, arg2]), args)
     elif expr.has_form('Max', 1, None):
         if ret_type == real_type:
-            # FIXME unknown intrinsic
             return reduce(lambda arg1, arg2: call_fp_intr(builder, 'llvm.maxnum', [arg1, arg2]), args)
     elif expr.has_form('Equal', 2, None):
         result = []

--- a/mathics/builtin/compile.py
+++ b/mathics/builtin/compile.py
@@ -121,13 +121,21 @@ def llvm_to_ctype(t):
         return c_double
 
 
-def _compile(expr, args, ret_type):
-    llvm_ir = generate_ir(expr, args, 'plus', ret_type)
-    # print(llvm_ir)
+def infer_return_type(expr, args):
+    if all(arg.type == int_type for arg in args):
+        return int_type
+    else:
+        return real_type
+
+
+def _compile(expr, args):
+    ret_type = infer_return_type(expr, args)
+
+    llvm_ir = generate_ir(expr, args, 'mathics', ret_type)
     mod = compile_ir(engine, llvm_ir)
 
     # lookup function pointer
-    func_ptr = engine.get_function_address('plus')
+    func_ptr = engine.get_function_address('mathics')
 
     # run function via ctypes
     cfunc = CFUNCTYPE(llvm_to_ctype(ret_type), *(llvm_to_ctype(arg.type) for arg in args))(func_ptr)

--- a/mathics/builtin/compile.py
+++ b/mathics/builtin/compile.py
@@ -158,15 +158,22 @@ def _gen_ir(expr, lookup_args, builder):
     elif expr.has_form('Tan', 1):
         if ret_type == real_type:
             # FIXME this approach is inaccurate
-            a = call_fp_intr(builder, 'llvm.sin', args)
-            b = call_fp_intr(builder, 'llvm.cos', args)
-            return builder.fdiv(a, b)
-    elif expr.has_form('Cot', 1):
-        if ret_type == real_type:
-            # FIXME this approach is inaccurate
-            a = call_fp_intr(builder, 'llvm.sin', args)
-            b = call_fp_intr(builder, 'llvm.cos', args)
-            return builder.fdiv(b, a)
+            sinx = call_fp_intr(builder, 'llvm.sin', args)
+            cosx = call_fp_intr(builder, 'llvm.cos', args)
+            return builder.fdiv(sinx, cosx)
+    elif expr.has_form('Sec', 1) and ret_type == real_type:
+        # FIXME this approach is inaccurate
+        cosx = call_fp_intr(builder, 'llvm.cos', args)
+        return builder.fdiv(real_type(1.0), cosx)
+    elif expr.has_form('Csc', 1) and ret_type == real_type:
+        # FIXME this approach is inaccurate
+        sinx = call_fp_intr(builder, 'llvm.sin', args)
+        return builder.fdiv(real_type(1.0), sinx)
+    elif expr.has_form('Cot', 1) and ret_type == real_type:
+        # FIXME this approach is inaccurate
+        sinx = call_fp_intr(builder, 'llvm.sin', args)
+        cosx = call_fp_intr(builder, 'llvm.cos', args)
+        return builder.fdiv(cosx, sinx)
     elif expr.has_form('Power', 2):
         # TODO llvm.powi if second argument is integer
         # TODO llvm.exp if first argument is E

--- a/mathics/builtin/compile/__init__.py
+++ b/mathics/builtin/compile/__init__.py
@@ -3,5 +3,5 @@
 
 from .ir import IRGenerator
 from .compile import _compile
-from .base import MathicsArg
+from .base import CompileArg
 from .types import *

--- a/mathics/builtin/compile/__init__.py
+++ b/mathics/builtin/compile/__init__.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from .ir import IRGenerator
+from .compile import _compile
+from .base import MathicsArg
+from .types import *

--- a/mathics/builtin/compile/__init__.py
+++ b/mathics/builtin/compile/__init__.py
@@ -1,7 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from .ir import IRGenerator
-from .compile import _compile
-from .base import CompileArg
-from .types import *
+try:
+    import llvmlite
+    has_llvmlite = True
+except ImportError:
+    has_llvmlite = False
+
+
+if has_llvmlite:
+    from .ir import IRGenerator
+    from .compile import _compile
+    from .base import CompileArg, CompileError
+    from .types import *

--- a/mathics/builtin/compile/base.py
+++ b/mathics/builtin/compile/base.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 
-class CompilationError(Exception):
+class CompileError(Exception):
     pass
 
 

--- a/mathics/builtin/compile/base.py
+++ b/mathics/builtin/compile/base.py
@@ -6,7 +6,7 @@ class CompilationError(Exception):
     pass
 
 
-class MathicsArg(object):
+class CompileArg(object):
     def __init__(self, name, type):
         self.name = name
         self.type = type

--- a/mathics/builtin/compile/base.py
+++ b/mathics/builtin/compile/base.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+class CompilationError(Exception):
+    pass
+
+
+class MathicsArg(object):
+    def __init__(self, name, type):
+        self.name = name
+        self.type = type

--- a/mathics/builtin/compile/compile.py
+++ b/mathics/builtin/compile/compile.py
@@ -1,0 +1,59 @@
+
+import llvmlite.binding as llvm
+from llvmlite.llvmpy.core import Type
+from ctypes import CFUNCTYPE
+
+from mathics.builtin.compile.utils import llvm_to_ctype
+from mathics.builtin.compile.ir import IRGenerator
+
+
+# setup llvm for code generation
+llvm.initialize()
+llvm.initialize_native_target()
+llvm.initialize_native_asmprinter()  # yes, even this one
+
+
+def create_execution_engine():
+    """
+    Create an ExecutionEngine suitable for JIT code generation on
+    the host CPU.  The engine is reusable for an arbitrary number of
+    modules.
+    """
+    # Create a target machine representing the host
+    target = llvm.Target.from_default_triple()
+    target_machine = target.create_target_machine()
+    # And an execution engine with an empty backing module
+    backing_mod = llvm.parse_assembly("")
+    engine = llvm.create_mcjit_compiler(backing_mod, target_machine)
+    return engine
+
+
+def compile_ir(engine, llvm_ir):
+    """
+    Compile the LLVM IR string with the given engine.
+    The compiled module object is returned.
+    """
+    # Create a LLVM module object from the IR
+    mod = llvm.parse_assembly(llvm_ir)
+    mod.verify()
+    # Now add the module and make sure it is ready for execution
+    engine.add_module(mod)
+    engine.finalize_object()
+    return mod
+
+
+engine = create_execution_engine()
+
+
+def _compile(expr, args):
+    ir_gen = IRGenerator(expr, args, 'mathics')
+    llvm_ir, ret_type = ir_gen.generate_ir()
+    mod = compile_ir(engine, llvm_ir)
+
+    # lookup function pointer
+    func_ptr = engine.get_function_address('mathics')
+
+    # run function via ctypes
+    cfunc = CFUNCTYPE(llvm_to_ctype(ret_type), *(llvm_to_ctype(arg.type) for arg in args))(func_ptr)
+    return cfunc
+

--- a/mathics/builtin/compile/ir.py
+++ b/mathics/builtin/compile/ir.py
@@ -169,6 +169,11 @@ class IRGenerator(object):
         assert arg.type == int_type
         return self.builder.sitofp(arg, real_type)
 
+    def int_to_bool(self, arg):
+        assert arg.type == int_type
+        # any non-zero int is true
+        return self.builder.icmp_signed('!=', arg, int_type(0))
+
     def add_caller(self, py_f, ret_type, args):
         '''
         Inserts a caller to a python function
@@ -224,7 +229,7 @@ class IRGenerator(object):
         # condition
         cond = self._gen_ir(args[0])
         if cond.type == int_type:
-            cond = builder.icmp_signed('!=', cond, int_type(0))
+            cond = self.int_to_bool(cond)
         if cond.type != bool_type:
             raise CompileError()
 

--- a/mathics/builtin/compile/ir.py
+++ b/mathics/builtin/compile/ir.py
@@ -299,13 +299,17 @@ class IRGenerator(object):
         if arg.type == void_type:
             return arg
 
-        builder = self.builder
-        if self._returned_type == real_type and arg.type == int_type:
+        if self._returned_type == arg.type:
+            pass
+        elif self._returned_type is None:
+            self._returned_type = arg.type
+        elif self._returned_type == real_type and arg.type == int_type:
             arg = self.int_to_real(arg)
         elif self._returned_type == int_type and arg.type == real_type:
             self._returned_type = arg.type
-        self._returned_type = arg.type
-        return builder.ret(arg)
+        else:
+            raise CompileError('Conflicting return types {} and {}.'.format(self._returned_type, arg.type))
+        return self.builder.ret(arg)
 
     @int_real_args(1)
     def _gen_Plus(self, args, ret_type):

--- a/mathics/builtin/compile/ir.py
+++ b/mathics/builtin/compile/ir.py
@@ -223,7 +223,10 @@ class IRGenerator(object):
         walks an expression tree and constructs the ir block
         '''
         if isinstance(expr, Symbol):
-            arg = self.lookup_args[expr.get_name()]
+            try:
+                arg = self.lookup_args[expr.get_name()]
+            except KeyError:
+                raise CompileError()
             return arg
         elif isinstance(expr, Integer):
             return int_type(expr.get_int_value())

--- a/mathics/builtin/compile/ir.py
+++ b/mathics/builtin/compile/ir.py
@@ -7,7 +7,7 @@ import llvmlite.llvmpy.core as lc
 from mathics.core.expression import Expression, Integer, Symbol, Real
 from mathics.builtin.compile.types import int_type, real_type, bool_type, void_type
 from mathics.builtin.compile.utils import pairwise
-from mathics.builtin.compile.base import CompilationError, MathicsArg
+from mathics.builtin.compile.base import CompilationError
 
 
 class IRGenerator(object):

--- a/mathics/builtin/compile/ir.py
+++ b/mathics/builtin/compile/ir.py
@@ -7,7 +7,7 @@ import llvmlite.llvmpy.core as lc
 from mathics.core.expression import Expression, Integer, Symbol, Real
 from mathics.builtin.compile.types import int_type, real_type, bool_type, void_type
 from mathics.builtin.compile.utils import pairwise
-from mathics.builtin.compile.base import CompilationError
+from mathics.builtin.compile.base import CompileError
 
 
 class IRGenerator(object):
@@ -83,7 +83,7 @@ class IRGenerator(object):
         elif all(arg.type == bool_type for arg in args):
             ret_type = bool_type
         else:
-            raise CompilationError()
+            raise CompileError()
         return ret_type, args
 
     def _gen_ir(self, expr):
@@ -100,7 +100,7 @@ class IRGenerator(object):
         elif isinstance(expr, Real):
             return real_type(expr.round_to_float())
         elif not isinstance(expr, Expression):
-            raise CompilationError()
+            raise CompileError()
 
         if expr.has_form('If', 3):
             args = expr.get_leaves()
@@ -110,7 +110,7 @@ class IRGenerator(object):
             if cond.type == int_type:
                 cond = builder.icmp_signed('!=', cond, int_type(0))
             if cond.type != bool_type:
-                raise CompilationError()
+                raise CompileError()
 
             # construct new blocks
             then_block = builder.append_basic_block()
@@ -144,7 +144,7 @@ class IRGenerator(object):
             elif then_result.type != void_type and else_result.type == void_type:
                 ret_type = then_result.type
             else:
-                raise CompilationError()
+                raise CompileError()
 
             # continuation block
             cont_block = builder.append_basic_block()
@@ -282,7 +282,7 @@ class IRGenerator(object):
                 elif ret_type == int_type:
                     result.append(builder.icmp_signed('==', lhs, rhs))
                 else:
-                    raise CompilationError()
+                    raise CompileError()
             return reduce(builder.and_, result)
         elif expr.has_form('Unequal', 2, None):
             # Unequal[e1, e2, ... en] gives True only if none of the ei are equal.
@@ -293,7 +293,7 @@ class IRGenerator(object):
                 elif ret_type == int_type:
                     result.append(builder.icmp_signed('!=', lhs, rhs))
                 else:
-                    raise CompilationError()
+                    raise CompileError()
             return reduce(builder.and_, result)
         elif expr.has_form('Less', 2, None):
             result = []
@@ -303,7 +303,7 @@ class IRGenerator(object):
                 elif ret_type == int_type:
                     result.append(builder.icmp_signed('<', lhs, rhs))
                 else:
-                    raise CompilationError()
+                    raise CompileError()
             return reduce(builder.and_, result)
         elif expr.has_form('LessEqual', 2, None):
             result = []
@@ -313,7 +313,7 @@ class IRGenerator(object):
                 elif ret_type == int_type:
                     result.append(builder.icmp_signed('<=', lhs, rhs))
                 else:
-                    raise CompilationError()
+                    raise CompileError()
             return reduce(builder.and_, result)
         elif expr.has_form('Greater', 2, None):
             result = []
@@ -323,7 +323,7 @@ class IRGenerator(object):
                 elif ret_type == int_type:
                     result.append(builder.icmp_signed('>', lhs, rhs))
                 else:
-                    raise CompilationError()
+                    raise CompileError()
             return reduce(builder.and_, result)
         elif expr.has_form('GreaterEqual', 2, None):
             result = []
@@ -333,7 +333,7 @@ class IRGenerator(object):
                 elif ret_type == int_type:
                     result.append(builder.icmp_signed('>=', lhs, rhs))
                 else:
-                    raise CompilationError()
+                    raise CompileError()
             return reduce(builder.and_, result)
         elif expr.has_form('And', 1, None) and ret_type == bool_type:
             return reduce(builder.and_, args)
@@ -359,9 +359,9 @@ class IRGenerator(object):
                 self._returned_type = ret_type
             self._returned_type = ret_type
             return builder.ret(result)
-        raise CompilationError()
+        raise CompileError()
 
     def set_returned_type(self, ret_type):
         if self._returned_type is not None and self._returned_type != ret_type:
-            raise CompilationError()
+            raise CompileError()
         self._returned_type = ret_type

--- a/mathics/builtin/compile/types.py
+++ b/mathics/builtin/compile/types.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from llvmlite import ir
+
+int_type = ir.IntType(64)
+real_type = ir.DoubleType()
+bool_type = ir.IntType(1)
+void_type = ir.VoidType()

--- a/mathics/builtin/compile/utils.py
+++ b/mathics/builtin/compile/utils.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from mathics.builtin.compile.types import int_type, real_type, bool_type
+from ctypes import c_int64, c_double, c_bool
+
+
+def pairwise(args):
+    '''
+    [a, b, c] -> [(a, b), (b, c)]
+    >>> list(pairwise([1, 2, 3]))
+    [(1, 2), (2, 3)]
+    '''
+    first = True
+    for arg in args:
+        if not first:
+            yield last, arg
+        first = False
+        last = arg
+
+
+def llvm_to_ctype(t):
+    'converts llvm types to ctypes'
+    if t == int_type:
+        return c_int64
+    elif t == real_type:
+        return c_double
+    elif t == bool_type:
+        return c_bool
+    else:
+        raise TypeError(t)

--- a/mathics/builtin/compile/utils.py
+++ b/mathics/builtin/compile/utils.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from mathics.builtin.compile.types import int_type, real_type, bool_type
-from ctypes import c_int64, c_double, c_bool
+from mathics.builtin.compile.types import int_type, real_type, bool_type, void_type
+from ctypes import c_int64, c_double, c_bool, c_void_p
 
 
 def pairwise(args):
@@ -27,5 +27,7 @@ def llvm_to_ctype(t):
         return c_double
     elif t == bool_type:
         return c_bool
+    elif t == void_type:
+        return c_void_p
     else:
         raise TypeError(t)

--- a/mathics/core/evaluation.py
+++ b/mathics/core/evaluation.py
@@ -318,8 +318,11 @@ class Evaluation(object):
         # DB's max_allowed_packet size
         max_stored_size = self.output.max_stored_size(settings)
         if max_stored_size is not None:
-            data = pickle.dumps(result)
-            if len(data) > max_stored_size:
+            try:
+                data = pickle.dumps(result)
+                if len(data) > max_stored_size:
+                    return Symbol('Null')
+            except ValueError:
                 return Symbol('Null')
         return result
 

--- a/mathics/core/evaluation.py
+++ b/mathics/core/evaluation.py
@@ -322,7 +322,7 @@ class Evaluation(object):
                 data = pickle.dumps(result)
                 if len(data) > max_stored_size:
                     return Symbol('Null')
-            except ValueError:
+            except (ValueError, pickle.PicklingError):
                 return Symbol('Null')
         return result
 

--- a/setup.py
+++ b/setup.py
@@ -160,7 +160,7 @@ setup(
         'mathics.core',
         'mathics.core.parser',
         'mathics.builtin', 'mathics.builtin.pymimesniffer', 'mathics.builtin.numpy_utils',
-        'mathics.builtin.pympler',
+        'mathics.builtin.pympler', 'mathics.builtin.compile',
         'mathics.doc',
         'mathics.web', 'mathics.web.templatetags'
     ],

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -64,19 +64,17 @@ class ArithmeticTest(unittest.TestCase):
     def test_tan(self):
         self._test_unary_math('Tan', math.tan)
 
-    @unittest.expectedFailure
     def test_pow(self):
         self._test_binary_math('Power', lambda x, y : x ** y)
 
-    @unittest.expectedFailure
     def test_div0(self):
         expr = Expression('Power', Symbol('x'), Symbol('y'))
         args = [MathicsArg('System`x', real_type), MathicsArg('System`y', real_type)]
         cfunc = _compile(expr, args)
         self.assertEqual(cfunc(0.0, -1.5), float('+inf'))
         self.assertEqual(cfunc(0.0, -1.0), float('+inf'))
-        self.assertEqual(cfunc(-0.0, -1.0), float('+inf'))
-        self.assertEqual(cfunc(0.0, 0.0), float('nan'))
+        self.assertEqual(cfunc(-0.0, -1.0), float('-inf'))
+        self.assertEqual(cfunc(0.0, 0.0), float('1.0'))     # NaN?
 
     def test_exp(self):
         self._test_unary_math('Exp', math.exp)
@@ -87,10 +85,8 @@ class ArithmeticTest(unittest.TestCase):
     def test_abs(self):
         self._test_unary_math('Abs', abs)
 
-    @unittest.expectedFailure
     def test_max(self):
         self._test_binary_math('Max', max)
 
-    @unittest.expectedFailure
     def test_min(self):
         self._test_binary_math('Min', min)

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -66,6 +66,12 @@ class ArithmeticTest(unittest.TestCase):
     def test_cot(self):
         self._test_unary_math('Cot', mpmath.cot)
 
+    def test_sec(self):
+        self._test_unary_math('Sec', mpmath.sec)
+
+    def test_csc(self):
+        self._test_unary_math('Csc', mpmath.csc)
+
     def test_pow(self):
         self._test_binary_math('Power', mpmath.power)
 

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -82,10 +82,26 @@ class ArithmeticTest(CompileTest):
     def test_csc(self):
         self._test_unary_math('Csc', mpmath.csc)
 
-    def test_pow(self):
+    def test_pow_real(self):
         self._test_binary_math('Power', mpmath.power)
-        # TODO 2 ^ x
-        # TODO E ^ x
+
+    def test_pow_2(self):
+        # 2 ^ x
+        expr = Expression('Power', Integer(2), Symbol('x'))
+        args = [CompileArg('System`x', real_type)]
+        cfunc = _compile(expr, args)
+        for _ in range(1000):
+            x = random.random()
+            self.assertAlmostEqual(cfunc(x), mpmath.power(2, x))
+
+    def test_pow_E(self):
+        # E ^ x
+        expr = Expression('Power', Symbol('E'), Symbol('x'))
+        args = [CompileArg('System`x', real_type)]
+        cfunc = _compile(expr, args)
+        for _ in range(1000):
+            x = random.random()
+            self.assertAlmostEqual(cfunc(x), mpmath.exp(x))
 
     def test_hyperbolics(self):
         self._test_unary_math('Sinh', mpmath.sinh)

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -69,6 +69,14 @@ class ArithmeticTest(unittest.TestCase):
     def test_pow(self):
         self._test_binary_math('Power', mpmath.power)
 
+    def test_hyperbolics(self):
+        self._test_unary_math('Sinh', mpmath.sinh)
+        self._test_unary_math('Cosh', mpmath.cosh)
+        self._test_unary_math('Tanh', mpmath.tanh)
+        self._test_unary_math('Csch', mpmath.csch)
+        self._test_unary_math('Sech', mpmath.sech)
+        self._test_unary_math('Coth', mpmath.coth)
+
     def test_div0(self):
         expr = Expression('Power', Symbol('x'), Symbol('y'))
         args = [MathicsArg('System`x', real_type), MathicsArg('System`y', real_type)]

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -21,25 +21,25 @@ class ArithmeticTest(CompileTest):
         expr = Expression('Plus', Symbol('x'), Integer(2))
         args = [CompileArg('System`x', int_type), CompileArg('System`y', int_type)]
         cfunc = _compile(expr, args)
-        self.assertEqual(cfunc(2, 4), 4)
+        self.assertIs(cfunc(2, 4), 4)
 
     def test_b(self):
         expr = Expression('Plus', Symbol('x'), Symbol('y'))
         args = [CompileArg('System`x', int_type), CompileArg('System`y', real_type)]
         cfunc = _compile(expr, args)
-        self.assertEqual(cfunc(1, 2.5), 3.5)
+        self.assertIs(cfunc(1, 2.5), 3.5)
 
     def test_c(self):
         expr = Expression('Plus', Expression('Plus', Symbol('x'), Symbol('y')),  Integer(5))
         args = [CompileArg('System`x', int_type), CompileArg('System`y', real_type)]
         cfunc = _compile(expr, args)
-        self.assertEqual(cfunc(1, 2.5), 8.5)
+        self.assertIs(cfunc(1, 2.5), 8.5)
 
     def test_d(self):
         expr = Expression('Plus', Symbol('x'), MachineReal(1.5), Integer(2), Symbol('x'))
         args = [CompileArg('System`x', real_type)]
         cfunc = _compile(expr, args)
-        self.assertEqual(cfunc(2.5), 8.5)
+        self.assertIs(cfunc(2.5), 8.5)
 
     def _test_unary_math(self, name, fn):
         expr = Expression(name, Symbol('x'))
@@ -134,10 +134,10 @@ class ArithmeticTest(CompileTest):
         expr = Expression('Power', Symbol('x'), Symbol('y'))
         args = [CompileArg('System`x', real_type), CompileArg('System`y', real_type)]
         cfunc = _compile(expr, args)
-        self.assertEqual(cfunc(0.0, -1.5), float('+inf'))
-        self.assertEqual(cfunc(0.0, -1.0), float('+inf'))
-        self.assertEqual(cfunc(-0.0, -1.0), float('-inf'))
-        self.assertEqual(cfunc(0.0, 0.0), float('1.0'))     # NaN?
+        self.assertIs(cfunc(0.0, -1.5), float('+inf'))
+        self.assertIs(cfunc(0.0, -1.0), float('+inf'))
+        self.assertIs(cfunc(-0.0, -1.0), float('-inf'))
+        self.assertIs(cfunc(0.0, 0.0), float('1.0'))     # NaN?
 
     def test_exp(self):
         self._test_unary_math('Exp', mpmath.exp)
@@ -161,37 +161,37 @@ class FlowControlTest(CompileTest):
         expr = Expression('If', Symbol('x'), Symbol('y'), Symbol('z'))
         args = [CompileArg('System`x', int_type), CompileArg('System`y', real_type), CompileArg('System`z', real_type)]
         cfunc = _compile(expr, args)
-        self.assertEqual(cfunc(0, 3.0, 4.0), 4.0)
-        self.assertEqual(cfunc(1, 3.0, 4.0), 3.0)
-        self.assertEqual(cfunc(2, 3.0, 4.0), 3.0)
+        self.assertIs(cfunc(0, 3.0, 4.0), 4.0)
+        self.assertIs(cfunc(1, 3.0, 4.0), 3.0)
+        self.assertIs(cfunc(2, 3.0, 4.0), 3.0)
 
     def test_if_cont(self):
         expr = Expression('Plus', Integer(1), Expression('If', Symbol('x'), Expression('Sin', Symbol('y')), Expression('Cos', Symbol('y'))))
         args = [CompileArg('System`x', int_type), CompileArg('System`y', real_type)]
         cfunc = _compile(expr, args)
-        self.assertEqual(cfunc(0, 0.0), 2.0)
-        self.assertEqual(cfunc(1, 0.0), 1.0)
+        self.assertIs(cfunc(0, 0.0), 2.0)
+        self.assertIs(cfunc(1, 0.0), 1.0)
 
     def test_if_eq(self):
         expr = Expression('If', Expression('Equal', Symbol('x'), Integer(1)), Integer(2), Integer(3))
         args = [CompileArg('System`x', int_type)]
         cfunc = _compile(expr, args)
-        self.assertEqual(cfunc(1), 2)
-        self.assertEqual(cfunc(2), 3)
+        self.assertIs(cfunc(1), 2)
+        self.assertIs(cfunc(2), 3)
 
     def test_if_int_real(self):
         expr = Expression('If', Symbol('x'), Integer(2), MachineReal(3))
         args = [CompileArg('System`x', bool_type)]
         cfunc = _compile(expr, args)
-        self.assertEqual(cfunc(True), 2.0)
-        self.assertEqual(cfunc(False), 3.0)
+        self.assertIs(cfunc(True), 2.0)
+        self.assertIs(cfunc(False), 3.0)
 
     def test_if_real_int(self):
         expr = Expression('If', Symbol('x'), MachineReal(3), Integer(2))
         args = [CompileArg('System`x', bool_type)]
         cfunc = _compile(expr, args)
-        self.assertEqual(cfunc(True), 3.0)
-        self.assertEqual(cfunc(False), 2.0)
+        self.assertIs(cfunc(True), 3.0)
+        self.assertIs(cfunc(False), 2.0)
 
     def test_if_bool_bool(self):
         expr = Expression('If', Symbol('x'), Symbol('y'), Symbol('z'))
@@ -206,35 +206,35 @@ class FlowControlTest(CompileTest):
         expr = Expression('Return', Symbol('x'))
         args = [CompileArg('System`x', int_type)]
         cfunc = _compile(expr, args)
-        self.assertEqual(cfunc(1), 1)
+        self.assertIs(cfunc(1), 1)
 
     def test_if_return1(self):
         expr = Expression('If', Symbol('x'), Expression('Return', Symbol('y')), Integer(3))
         args = [CompileArg('System`x', bool_type), CompileArg('System`y', int_type)]
         cfunc = _compile(expr, args)
-        self.assertEqual(cfunc(True, 1), 1)
-        self.assertEqual(cfunc(False, 1), 3)
+        self.assertIs(cfunc(True, 1), 1)
+        self.assertIs(cfunc(False, 1), 3)
 
     def test_if_return2(self):
         expr = Expression('If', Symbol('x'), Expression('Return', Symbol('y')), Expression('Return', Integer(3)))
         args = [CompileArg('System`x', bool_type), CompileArg('System`y', int_type)]
         cfunc = _compile(expr, args)
-        self.assertEqual(cfunc(True, 1), 1)
-        self.assertEqual(cfunc(False, 1), 3)
+        self.assertIs(cfunc(True, 1), 1)
+        self.assertIs(cfunc(False, 1), 3)
 
     def test_if_return3(self):
         expr = Expression('If', Symbol('x'), Symbol('y'), Expression('Return', Integer(3)))
         args = [CompileArg('System`x', bool_type), CompileArg('System`y', int_type)]
         cfunc = _compile(expr, args)
-        self.assertEqual(cfunc(True, 1), 1)
-        self.assertEqual(cfunc(False, 1), 3)
+        self.assertIs(cfunc(True, 1), 1)
+        self.assertIs(cfunc(False, 1), 3)
 
     def test_expr_return(self):
         expr = Expression('Plus', Integer(3), Expression('Return', Symbol('x')))
         args = [CompileArg('System`x', int_type)]
         cfunc = _compile(expr, args)
-        self.assertEqual(cfunc(1), 1)
-        self.assertEqual(cfunc(4), 4)
+        self.assertIs(cfunc(1), 1)
+        self.assertIs(cfunc(4), 4)
 
 class ComparisonTest(CompileTest):
     def test_int_equal(self):
@@ -355,7 +355,7 @@ class BitwiseTest(CompileTest):
             expr = Expression(head, *(Symbol(arg_name) for arg_name in arg_names))
             int_args = [CompileArg('System`' + arg_name, int_type) for arg_name in arg_names]
             cfunc = _compile(expr, int_args)
-            self.assertEqual(cfunc(*args), result)
+            self.assertIs(cfunc(*args), result)
 
     def test_bitand(self):
         self._test_bitwise('BitAnd', [17], 17)

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -17,31 +17,35 @@ class CompileTest(unittest.TestCase):
         if not has_llvmlite:
             self.skipTest('No llvmlite detected. Skipping all compile tests')
 
+    def assertTypeEqual(self, a, b):
+        self.assertEqual(type(a), type(b))
+        self.assertEqual(a, b)
+
 
 class ArithmeticTest(CompileTest):
     def test_a(self):
         expr = Expression('Plus', Symbol('x'), Integer(2))
         args = [CompileArg('System`x', int_type), CompileArg('System`y', int_type)]
         cfunc = _compile(expr, args)
-        self.assertIs(cfunc(2, 4), 4)
+        self.assertTypeEqual(cfunc(2, 4), 4)
 
     def test_b(self):
         expr = Expression('Plus', Symbol('x'), Symbol('y'))
         args = [CompileArg('System`x', int_type), CompileArg('System`y', real_type)]
         cfunc = _compile(expr, args)
-        self.assertIs(cfunc(1, 2.5), 3.5)
+        self.assertTypeEqual(cfunc(1, 2.5), 3.5)
 
     def test_c(self):
         expr = Expression('Plus', Expression('Plus', Symbol('x'), Symbol('y')),  Integer(5))
         args = [CompileArg('System`x', int_type), CompileArg('System`y', real_type)]
         cfunc = _compile(expr, args)
-        self.assertIs(cfunc(1, 2.5), 8.5)
+        self.assertTypeEqual(cfunc(1, 2.5), 8.5)
 
     def test_d(self):
         expr = Expression('Plus', Symbol('x'), MachineReal(1.5), Integer(2), Symbol('x'))
         args = [CompileArg('System`x', real_type)]
         cfunc = _compile(expr, args)
-        self.assertIs(cfunc(2.5), 8.5)
+        self.assertTypeEqual(cfunc(2.5), 8.5)
 
     def _test_unary_math(self, name, fn):
         expr = Expression(name, Symbol('x'))
@@ -92,19 +96,19 @@ class ArithmeticTest(CompileTest):
         expr = Expression('Power', Symbol('x'), Symbol('y'))
         args = [CompileArg('System`x', int_type), CompileArg('System`y', int_type)]
         cfunc = _compile(expr, args)
-        self.assertIs(cfunc(4, 9), 4 ** 9)
+        self.assertTypeEqual(cfunc(4, 9), 4 ** 9)
 
     def test_pow_real_int(self):
         expr = Expression('Power', MachineReal(2.5), Symbol('x'))
         args = [CompileArg('System`x', int_type)]
         cfunc = _compile(expr, args)
-        self.assertIs(cfunc(4), 2.5 ** 4)
+        self.assertTypeEqual(cfunc(4), 2.5 ** 4)
 
     def test_pow_int_real(self):
         expr = Expression('Power', Symbol('x'), MachineReal(5.5))
         args = [CompileArg('System`x', int_type)]
         cfunc = _compile(expr, args)
-        self.assertIs(cfunc(8), 8 ** 5.5)
+        self.assertTypeEqual(cfunc(8), 8 ** 5.5)
 
     def test_pow_2(self):
         # 2 ^ x
@@ -136,10 +140,10 @@ class ArithmeticTest(CompileTest):
         expr = Expression('Power', Symbol('x'), Symbol('y'))
         args = [CompileArg('System`x', real_type), CompileArg('System`y', real_type)]
         cfunc = _compile(expr, args)
-        self.assertIs(cfunc(0.0, -1.5), float('+inf'))
-        self.assertIs(cfunc(0.0, -1.0), float('+inf'))
-        self.assertIs(cfunc(-0.0, -1.0), float('-inf'))
-        self.assertIs(cfunc(0.0, 0.0), float('1.0'))     # NaN?
+        self.assertTypeEqual(cfunc(0.0, -1.5), float('+inf'))
+        self.assertTypeEqual(cfunc(0.0, -1.0), float('+inf'))
+        self.assertTypeEqual(cfunc(-0.0, -1.0), float('-inf'))
+        self.assertTypeEqual(cfunc(0.0, 0.0), float('1.0'))     # NaN?
 
     def test_exp(self):
         self._test_unary_math('Exp', mpmath.exp)
@@ -163,37 +167,37 @@ class FlowControlTest(CompileTest):
         expr = Expression('If', Symbol('x'), Symbol('y'), Symbol('z'))
         args = [CompileArg('System`x', int_type), CompileArg('System`y', real_type), CompileArg('System`z', real_type)]
         cfunc = _compile(expr, args)
-        self.assertIs(cfunc(0, 3.0, 4.0), 4.0)
-        self.assertIs(cfunc(1, 3.0, 4.0), 3.0)
-        self.assertIs(cfunc(2, 3.0, 4.0), 3.0)
+        self.assertTypeEqual(cfunc(0, 3.0, 4.0), 4.0)
+        self.assertTypeEqual(cfunc(1, 3.0, 4.0), 3.0)
+        self.assertTypeEqual(cfunc(2, 3.0, 4.0), 3.0)
 
     def test_if_cont(self):
         expr = Expression('Plus', Integer(1), Expression('If', Symbol('x'), Expression('Sin', Symbol('y')), Expression('Cos', Symbol('y'))))
         args = [CompileArg('System`x', int_type), CompileArg('System`y', real_type)]
         cfunc = _compile(expr, args)
-        self.assertIs(cfunc(0, 0.0), 2.0)
-        self.assertIs(cfunc(1, 0.0), 1.0)
+        self.assertTypeEqual(cfunc(0, 0.0), 2.0)
+        self.assertTypeEqual(cfunc(1, 0.0), 1.0)
 
     def test_if_eq(self):
         expr = Expression('If', Expression('Equal', Symbol('x'), Integer(1)), Integer(2), Integer(3))
         args = [CompileArg('System`x', int_type)]
         cfunc = _compile(expr, args)
-        self.assertIs(cfunc(1), 2)
-        self.assertIs(cfunc(2), 3)
+        self.assertTypeEqual(cfunc(1), 2)
+        self.assertTypeEqual(cfunc(2), 3)
 
     def test_if_int_real(self):
         expr = Expression('If', Symbol('x'), Integer(2), MachineReal(3))
         args = [CompileArg('System`x', bool_type)]
         cfunc = _compile(expr, args)
-        self.assertIs(cfunc(True), 2.0)
-        self.assertIs(cfunc(False), 3.0)
+        self.assertTypeEqual(cfunc(True), 2.0)
+        self.assertTypeEqual(cfunc(False), 3.0)
 
     def test_if_real_int(self):
         expr = Expression('If', Symbol('x'), MachineReal(3), Integer(2))
         args = [CompileArg('System`x', bool_type)]
         cfunc = _compile(expr, args)
-        self.assertIs(cfunc(True), 3.0)
-        self.assertIs(cfunc(False), 2.0)
+        self.assertTypeEqual(cfunc(True), 3.0)
+        self.assertTypeEqual(cfunc(False), 2.0)
 
     def test_if_bool_bool(self):
         expr = Expression('If', Symbol('x'), Symbol('y'), Symbol('z'))
@@ -208,7 +212,7 @@ class FlowControlTest(CompileTest):
         expr = Expression('Return', Symbol('x'))
         args = [CompileArg('System`x', int_type)]
         cfunc = _compile(expr, args)
-        self.assertIs(cfunc(1), 1)
+        self.assertTypeEqual(cfunc(1), 1)
 
     @unittest.expectedFailure
     def test_print(self):
@@ -230,29 +234,29 @@ class FlowControlTest(CompileTest):
         expr = Expression('If', Symbol('x'), Expression('Return', Symbol('y')), Integer(3))
         args = [CompileArg('System`x', bool_type), CompileArg('System`y', int_type)]
         cfunc = _compile(expr, args)
-        self.assertIs(cfunc(True, 1), 1)
-        self.assertIs(cfunc(False, 1), 3)
+        self.assertTypeEqual(cfunc(True, 1), 1)
+        self.assertTypeEqual(cfunc(False, 1), 3)
 
     def test_if_return2(self):
         expr = Expression('If', Symbol('x'), Expression('Return', Symbol('y')), Expression('Return', Integer(3)))
         args = [CompileArg('System`x', bool_type), CompileArg('System`y', int_type)]
         cfunc = _compile(expr, args)
-        self.assertIs(cfunc(True, 1), 1)
-        self.assertIs(cfunc(False, 1), 3)
+        self.assertTypeEqual(cfunc(True, 1), 1)
+        self.assertTypeEqual(cfunc(False, 1), 3)
 
     def test_if_return3(self):
         expr = Expression('If', Symbol('x'), Symbol('y'), Expression('Return', Integer(3)))
         args = [CompileArg('System`x', bool_type), CompileArg('System`y', int_type)]
         cfunc = _compile(expr, args)
-        self.assertIs(cfunc(True, 1), 1)
-        self.assertIs(cfunc(False, 1), 3)
+        self.assertTypeEqual(cfunc(True, 1), 1)
+        self.assertTypeEqual(cfunc(False, 1), 3)
 
     def test_expr_return(self):
         expr = Expression('Plus', Integer(3), Expression('Return', Symbol('x')))
         args = [CompileArg('System`x', int_type)]
         cfunc = _compile(expr, args)
-        self.assertIs(cfunc(1), 1)
-        self.assertIs(cfunc(4), 4)
+        self.assertTypeEqual(cfunc(1), 1)
+        self.assertTypeEqual(cfunc(4), 4)
 
 class ComparisonTest(CompileTest):
     def test_int_equal(self):
@@ -373,7 +377,7 @@ class BitwiseTest(CompileTest):
             expr = Expression(head, *(Symbol(arg_name) for arg_name in arg_names))
             int_args = [CompileArg('System`' + arg_name, int_type) for arg_name in arg_names]
             cfunc = _compile(expr, int_args)
-            self.assertIs(cfunc(*args), result)
+            self.assertTypeEqual(cfunc(*args), result)
 
     def test_bitand(self):
         self._test_bitwise('BitAnd', [17], 17)

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -1,0 +1,30 @@
+import unittest
+
+from mathics.builtin.compile import _compile, MathicsArg, int_type, real_type
+from mathics.core.expression import Expression, Symbol, Integer, MachineReal
+
+
+class ArithmeticTest(unittest.TestCase):
+    def test_a(self):
+        expr = Expression('Plus', Symbol('x'), Integer(2))
+        args = [MathicsArg('System`x', int_type), MathicsArg('System`y', int_type)]
+        cfunc = _compile(expr, args, int_type)
+        self.assertEqual(cfunc(2, 4), 4)
+
+    def test_b(self):
+        expr = Expression('Plus', Symbol('x'), Symbol('y'))
+        args = [MathicsArg('System`x', int_type), MathicsArg('System`y', real_type)]
+        cfunc = _compile(expr, args, real_type)
+        self.assertEqual(cfunc(1, 2.5), 3.5)
+
+    def test_c(self):
+        expr = Expression('Plus', Expression('Plus', Symbol('x'), Symbol('y')),  Integer(5))
+        args = [MathicsArg('System`x', int_type), MathicsArg('System`y', real_type)]
+        cfunc = _compile(expr, args, real_type)
+        self.assertEqual(cfunc(1, 2.5), 8.5)
+
+    def test_d(self):
+        expr = Expression('Plus', Symbol('x'), MachineReal(1.5))
+        args = [MathicsArg('System`x', real_type)]
+        cfunc = _compile(expr, args, real_type)
+        self.assertEqual(cfunc(2.5), 4.0)

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -1,5 +1,5 @@
 import unittest
-import math
+import mpmath
 import random
 
 from mathics.builtin.compile import _compile, MathicsArg, int_type, real_type, bool_type
@@ -35,18 +35,18 @@ class ArithmeticTest(unittest.TestCase):
         expr = Expression(name, Symbol('x'))
         args = [MathicsArg('System`x', real_type)]
         cfunc = _compile(expr, args)
-        for _ in range(100):
+        for _ in range(1000):
             x = random.random()
-            self.assertEqual(cfunc(x), fn(x))
+            self.assertAlmostEqual(cfunc(x), float(fn(x)))
 
     def _test_binary_math(self, name, fn):
         expr = Expression(name, Symbol('x'), Symbol('y'))
         args = [MathicsArg('System`x', real_type), MathicsArg('System`y', real_type)]
         cfunc = _compile(expr, args)
-        for _ in range(100):
+        for _ in range(1000):
             x = random.random()
             y = random.random()
-            self.assertEqual(cfunc(x, y), fn(x, y))
+            self.assertAlmostEqual(cfunc(x, y), fn(x, y))
 
     def test_plus(self):
         self._test_binary_math('Plus', lambda x, y: x + y)
@@ -55,17 +55,19 @@ class ArithmeticTest(unittest.TestCase):
         self._test_binary_math('Times', lambda x, y: x * y)
 
     def test_sin(self):
-        self._test_unary_math('Sin', math.sin)
+        self._test_unary_math('Sin', mpmath.sin)
 
     def test_cos(self):
-        self._test_unary_math('Cos', math.cos)
+        self._test_unary_math('Cos', mpmath.cos)
 
-    @unittest.expectedFailure
     def test_tan(self):
-        self._test_unary_math('Tan', math.tan)
+        self._test_unary_math('Tan', mpmath.tan)
+
+    def test_cot(self):
+        self._test_unary_math('Cot', mpmath.cot)
 
     def test_pow(self):
-        self._test_binary_math('Power', lambda x, y : x ** y)
+        self._test_binary_math('Power', mpmath.power)
 
     def test_div0(self):
         expr = Expression('Power', Symbol('x'), Symbol('y'))
@@ -77,10 +79,10 @@ class ArithmeticTest(unittest.TestCase):
         self.assertEqual(cfunc(0.0, 0.0), float('1.0'))     # NaN?
 
     def test_exp(self):
-        self._test_unary_math('Exp', math.exp)
+        self._test_unary_math('Exp', mpmath.exp)
 
     def test_log(self):
-        self._test_unary_math('Log', math.log)
+        self._test_unary_math('Log', mpmath.log)
 
     def test_abs(self):
         self._test_unary_math('Abs', abs)

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -132,12 +132,28 @@ class FlowControlTest(unittest.TestCase):
         self.assertEqual(cfunc(1), 2)
         self.assertEqual(cfunc(2), 3)
 
-    def test_if_types(self):
-        expr = Expression('If', Expression('Equal', Symbol('x'), Integer(1)), Integer(2), MachineReal(3))
-        args = [MathicsArg('System`x', int_type)]
+    def test_if_int_real(self):
+        expr = Expression('If', Symbol('x'), Integer(2), MachineReal(3))
+        args = [MathicsArg('System`x', bool_type)]
         cfunc = _compile(expr, args)
-        self.assertEqual(cfunc(1), 2.0)
-        self.assertEqual(cfunc(2), 3.0)
+        self.assertEqual(cfunc(True), 2.0)
+        self.assertEqual(cfunc(False), 3.0)
+
+    def test_if_real_int(self):
+        expr = Expression('If', Symbol('x'), MachineReal(3), Integer(2))
+        args = [MathicsArg('System`x', bool_type)]
+        cfunc = _compile(expr, args)
+        self.assertEqual(cfunc(True), 3.0)
+        self.assertEqual(cfunc(False), 2.0)
+
+    def test_if_bool_bool(self):
+        expr = Expression('If', Symbol('x'), Symbol('y'), Symbol('z'))
+        args = [MathicsArg('System`x', bool_type), MathicsArg('System`y', bool_type), MathicsArg('System`z', bool_type)]
+        cfunc = _compile(expr, args)
+        self.assertTrue(cfunc(True, True, False))
+        self.assertTrue(cfunc(False, False, True))
+        self.assertFalse(cfunc(True, False, True))
+        self.assertFalse(cfunc(False, True, False))
 
 
 class ComparisonTest(unittest.TestCase):

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -1,8 +1,10 @@
+import sys
 import unittest
 import mpmath
 import random
+from six import StringIO
 
-from mathics.core.expression import Expression, Symbol, Integer, MachineReal
+from mathics.core.expression import Expression, Symbol, Integer, MachineReal, String
 
 from mathics.builtin.compile import has_llvmlite
 
@@ -207,6 +209,22 @@ class FlowControlTest(CompileTest):
         args = [CompileArg('System`x', int_type)]
         cfunc = _compile(expr, args)
         self.assertIs(cfunc(1), 1)
+
+    @unittest.expectedFailure
+    def test_print(self):
+        expr = Expression('Print', String('Hello world'))
+        cfunc = _compile(expr, [])
+
+        # XXX Hack to capture the output
+        saved_stdout = sys.stdout
+        try:
+            out = StringIO()
+            sys.stdout = out
+            cfunc()
+            output = out.getvalue().strip()
+            self.assertEqual(output, 'Hello world')
+        finally:
+            sys.stdout = saved_stdout
 
     def test_if_return1(self):
         expr = Expression('If', Symbol('x'), Expression('Return', Symbol('y')), Integer(3))

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -23,8 +23,9 @@ class CompileTest(unittest.TestCase):
         self.assertEqual(type(a), type(b))
         self.assertEqual(a, b)
 
-    def assertNumEqual(self, a, b):
-        self.assertEqual(type(a), type(b))
+    def assertNumEqual(self, a, b, check_type=True):
+        if check_type:
+            self.assertEqual(type(a), type(b))
         if isinstance(a, float):
             self.assertEqual(math.isnan(a), math.isnan(b))
             self.assertEqual(math.isinf(a), math.isinf(b))
@@ -93,7 +94,7 @@ class ArithmeticTest(CompileTest):
                 c_result = cfunc(x)
                 self.assertNumEqual(c_result, py_result)
 
-    def _test_binary_math(self, name, fn):
+    def _test_binary_math(self, name, fn, check_type=True):
         expr = Expression(name, Symbol('x'), Symbol('y'))
         for xtype, ytype in itertools.product([int_type, real_type], repeat=2):
             args = [CompileArg('System`x', xtype), CompileArg('System`y', ytype)]
@@ -103,7 +104,7 @@ class ArithmeticTest(CompileTest):
                 y = self._random(ytype)
                 py_result = self._py_evaluate(fn, x, y)
                 c_result = cfunc(x, y)
-                self.assertNumEqual(py_result, c_result)
+                self.assertNumEqual(py_result, c_result, check_type)
 
     def test_plus(self):
         self._test_binary_math('Plus', lambda x, y: x + y)
@@ -196,10 +197,14 @@ class ArithmeticTest(CompileTest):
         self._test_unary_math('Abs', abs)
 
     def test_max(self):
-        self._test_binary_math('Max', max)
+        # disable type checks
+        # in python max(1.3, 2) -> 2 but max(2.4, 2) -> 2.4
+        # when they return 2.0 and 2.4 respectively
+        self._test_binary_math('Max', max, check_type=False)
 
     def test_min(self):
-        self._test_binary_math('Min', min)
+        # disable type check (see test_max)
+        self._test_binary_math('Min', min, check_type=False)
 
 
 class FlowControlTest(CompileTest):

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -155,6 +155,39 @@ class FlowControlTest(unittest.TestCase):
         self.assertFalse(cfunc(True, False, True))
         self.assertFalse(cfunc(False, True, False))
 
+    def test_return(self):
+        expr = Expression('Return', Symbol('x'))
+        args = [MathicsArg('System`x', int_type)]
+        cfunc = _compile(expr, args)
+        self.assertEqual(cfunc(1), 1)
+
+    def test_if_return1(self):
+        expr = Expression('If', Symbol('x'), Expression('Return', Symbol('y')), Integer(3))
+        args = [MathicsArg('System`x', bool_type), MathicsArg('System`y', int_type)]
+        cfunc = _compile(expr, args)
+        self.assertEqual(cfunc(True, 1), 1)
+        self.assertEqual(cfunc(False, 1), 3)
+
+    def test_if_return2(self):
+        expr = Expression('If', Symbol('x'), Expression('Return', Symbol('y')), Expression('Return', Integer(3)))
+        args = [MathicsArg('System`x', bool_type), MathicsArg('System`y', int_type)]
+        cfunc = _compile(expr, args)
+        self.assertEqual(cfunc(True, 1), 1)
+        self.assertEqual(cfunc(False, 1), 3)
+
+    def test_if_return3(self):
+        expr = Expression('If', Symbol('x'), Symbol('y'), Expression('Return', Integer(3)))
+        args = [MathicsArg('System`x', bool_type), MathicsArg('System`y', int_type)]
+        cfunc = _compile(expr, args)
+        self.assertEqual(cfunc(True, 1), 1)
+        self.assertEqual(cfunc(False, 1), 3)
+
+    def test_expr_return(self):
+        expr = Expression('Plus', Integer(3), Expression('Return', Symbol('x')))
+        args = [MathicsArg('System`x', int_type)]
+        cfunc = _compile(expr, args)
+        self.assertEqual(cfunc(1), 1)
+        self.assertEqual(cfunc(4), 4)
 
 class ComparisonTest(unittest.TestCase):
     def test_int_equal(self):

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -8,23 +8,23 @@ class ArithmeticTest(unittest.TestCase):
     def test_a(self):
         expr = Expression('Plus', Symbol('x'), Integer(2))
         args = [MathicsArg('System`x', int_type), MathicsArg('System`y', int_type)]
-        cfunc = _compile(expr, args, int_type)
+        cfunc = _compile(expr, args)
         self.assertEqual(cfunc(2, 4), 4)
 
     def test_b(self):
         expr = Expression('Plus', Symbol('x'), Symbol('y'))
         args = [MathicsArg('System`x', int_type), MathicsArg('System`y', real_type)]
-        cfunc = _compile(expr, args, real_type)
+        cfunc = _compile(expr, args)
         self.assertEqual(cfunc(1, 2.5), 3.5)
 
     def test_c(self):
         expr = Expression('Plus', Expression('Plus', Symbol('x'), Symbol('y')),  Integer(5))
         args = [MathicsArg('System`x', int_type), MathicsArg('System`y', real_type)]
-        cfunc = _compile(expr, args, real_type)
+        cfunc = _compile(expr, args)
         self.assertEqual(cfunc(1, 2.5), 8.5)
 
     def test_d(self):
         expr = Expression('Plus', Symbol('x'), MachineReal(1.5))
         args = [MathicsArg('System`x', real_type)]
-        cfunc = _compile(expr, args, real_type)
+        cfunc = _compile(expr, args)
         self.assertEqual(cfunc(2.5), 4.0)

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -85,6 +85,12 @@ class ArithmeticTest(CompileTest):
     def test_pow_real(self):
         self._test_binary_math('Power', mpmath.power)
 
+    def test_pow_int(self):
+        expr = Expression('Power', MachineReal(2.5), Symbol('x'))
+        args = [CompileArg('System`x', int_type)]
+        cfunc = _compile(expr, args)
+        self.assertEquals(cfunc(4), 2.5 ** 4)
+
     def test_pow_2(self):
         # 2 ^ x
         expr = Expression('Power', Integer(2), Symbol('x'))

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -2,38 +2,38 @@ import unittest
 import mpmath
 import random
 
-from mathics.builtin.compile import _compile, MathicsArg, int_type, real_type, bool_type
+from mathics.builtin.compile import _compile, CompileArg, int_type, real_type, bool_type
 from mathics.core.expression import Expression, Symbol, Integer, MachineReal
 
 
 class ArithmeticTest(unittest.TestCase):
     def test_a(self):
         expr = Expression('Plus', Symbol('x'), Integer(2))
-        args = [MathicsArg('System`x', int_type), MathicsArg('System`y', int_type)]
+        args = [CompileArg('System`x', int_type), CompileArg('System`y', int_type)]
         cfunc = _compile(expr, args)
         self.assertEqual(cfunc(2, 4), 4)
 
     def test_b(self):
         expr = Expression('Plus', Symbol('x'), Symbol('y'))
-        args = [MathicsArg('System`x', int_type), MathicsArg('System`y', real_type)]
+        args = [CompileArg('System`x', int_type), CompileArg('System`y', real_type)]
         cfunc = _compile(expr, args)
         self.assertEqual(cfunc(1, 2.5), 3.5)
 
     def test_c(self):
         expr = Expression('Plus', Expression('Plus', Symbol('x'), Symbol('y')),  Integer(5))
-        args = [MathicsArg('System`x', int_type), MathicsArg('System`y', real_type)]
+        args = [CompileArg('System`x', int_type), CompileArg('System`y', real_type)]
         cfunc = _compile(expr, args)
         self.assertEqual(cfunc(1, 2.5), 8.5)
 
     def test_d(self):
         expr = Expression('Plus', Symbol('x'), MachineReal(1.5), Integer(2), Symbol('x'))
-        args = [MathicsArg('System`x', real_type)]
+        args = [CompileArg('System`x', real_type)]
         cfunc = _compile(expr, args)
         self.assertEqual(cfunc(2.5), 8.5)
 
     def _test_unary_math(self, name, fn):
         expr = Expression(name, Symbol('x'))
-        args = [MathicsArg('System`x', real_type)]
+        args = [CompileArg('System`x', real_type)]
         cfunc = _compile(expr, args)
         for _ in range(1000):
             x = random.random()
@@ -41,7 +41,7 @@ class ArithmeticTest(unittest.TestCase):
 
     def _test_binary_math(self, name, fn):
         expr = Expression(name, Symbol('x'), Symbol('y'))
-        args = [MathicsArg('System`x', real_type), MathicsArg('System`y', real_type)]
+        args = [CompileArg('System`x', real_type), CompileArg('System`y', real_type)]
         cfunc = _compile(expr, args)
         for _ in range(1000):
             x = random.random()
@@ -85,7 +85,7 @@ class ArithmeticTest(unittest.TestCase):
 
     def test_div0(self):
         expr = Expression('Power', Symbol('x'), Symbol('y'))
-        args = [MathicsArg('System`x', real_type), MathicsArg('System`y', real_type)]
+        args = [CompileArg('System`x', real_type), CompileArg('System`y', real_type)]
         cfunc = _compile(expr, args)
         self.assertEqual(cfunc(0.0, -1.5), float('+inf'))
         self.assertEqual(cfunc(0.0, -1.0), float('+inf'))
@@ -112,7 +112,7 @@ class FlowControlTest(unittest.TestCase):
 
     def test_if(self):
         expr = Expression('If', Symbol('x'), Symbol('y'), Symbol('z'))
-        args = [MathicsArg('System`x', int_type), MathicsArg('System`y', real_type), MathicsArg('System`z', real_type)]
+        args = [CompileArg('System`x', int_type), CompileArg('System`y', real_type), CompileArg('System`z', real_type)]
         cfunc = _compile(expr, args)
         self.assertEqual(cfunc(0, 3.0, 4.0), 4.0)
         self.assertEqual(cfunc(1, 3.0, 4.0), 3.0)
@@ -120,35 +120,35 @@ class FlowControlTest(unittest.TestCase):
 
     def test_if_cont(self):
         expr = Expression('Plus', Integer(1), Expression('If', Symbol('x'), Expression('Sin', Symbol('y')), Expression('Cos', Symbol('y'))))
-        args = [MathicsArg('System`x', int_type), MathicsArg('System`y', real_type)]
+        args = [CompileArg('System`x', int_type), CompileArg('System`y', real_type)]
         cfunc = _compile(expr, args)
         self.assertEqual(cfunc(0, 0.0), 2.0)
         self.assertEqual(cfunc(1, 0.0), 1.0)
 
     def test_if_eq(self):
         expr = Expression('If', Expression('Equal', Symbol('x'), Integer(1)), Integer(2), Integer(3))
-        args = [MathicsArg('System`x', int_type)]
+        args = [CompileArg('System`x', int_type)]
         cfunc = _compile(expr, args)
         self.assertEqual(cfunc(1), 2)
         self.assertEqual(cfunc(2), 3)
 
     def test_if_int_real(self):
         expr = Expression('If', Symbol('x'), Integer(2), MachineReal(3))
-        args = [MathicsArg('System`x', bool_type)]
+        args = [CompileArg('System`x', bool_type)]
         cfunc = _compile(expr, args)
         self.assertEqual(cfunc(True), 2.0)
         self.assertEqual(cfunc(False), 3.0)
 
     def test_if_real_int(self):
         expr = Expression('If', Symbol('x'), MachineReal(3), Integer(2))
-        args = [MathicsArg('System`x', bool_type)]
+        args = [CompileArg('System`x', bool_type)]
         cfunc = _compile(expr, args)
         self.assertEqual(cfunc(True), 3.0)
         self.assertEqual(cfunc(False), 2.0)
 
     def test_if_bool_bool(self):
         expr = Expression('If', Symbol('x'), Symbol('y'), Symbol('z'))
-        args = [MathicsArg('System`x', bool_type), MathicsArg('System`y', bool_type), MathicsArg('System`z', bool_type)]
+        args = [CompileArg('System`x', bool_type), CompileArg('System`y', bool_type), CompileArg('System`z', bool_type)]
         cfunc = _compile(expr, args)
         self.assertTrue(cfunc(True, True, False))
         self.assertTrue(cfunc(False, False, True))
@@ -157,34 +157,34 @@ class FlowControlTest(unittest.TestCase):
 
     def test_return(self):
         expr = Expression('Return', Symbol('x'))
-        args = [MathicsArg('System`x', int_type)]
+        args = [CompileArg('System`x', int_type)]
         cfunc = _compile(expr, args)
         self.assertEqual(cfunc(1), 1)
 
     def test_if_return1(self):
         expr = Expression('If', Symbol('x'), Expression('Return', Symbol('y')), Integer(3))
-        args = [MathicsArg('System`x', bool_type), MathicsArg('System`y', int_type)]
+        args = [CompileArg('System`x', bool_type), CompileArg('System`y', int_type)]
         cfunc = _compile(expr, args)
         self.assertEqual(cfunc(True, 1), 1)
         self.assertEqual(cfunc(False, 1), 3)
 
     def test_if_return2(self):
         expr = Expression('If', Symbol('x'), Expression('Return', Symbol('y')), Expression('Return', Integer(3)))
-        args = [MathicsArg('System`x', bool_type), MathicsArg('System`y', int_type)]
+        args = [CompileArg('System`x', bool_type), CompileArg('System`y', int_type)]
         cfunc = _compile(expr, args)
         self.assertEqual(cfunc(True, 1), 1)
         self.assertEqual(cfunc(False, 1), 3)
 
     def test_if_return3(self):
         expr = Expression('If', Symbol('x'), Symbol('y'), Expression('Return', Integer(3)))
-        args = [MathicsArg('System`x', bool_type), MathicsArg('System`y', int_type)]
+        args = [CompileArg('System`x', bool_type), CompileArg('System`y', int_type)]
         cfunc = _compile(expr, args)
         self.assertEqual(cfunc(True, 1), 1)
         self.assertEqual(cfunc(False, 1), 3)
 
     def test_expr_return(self):
         expr = Expression('Plus', Integer(3), Expression('Return', Symbol('x')))
-        args = [MathicsArg('System`x', int_type)]
+        args = [CompileArg('System`x', int_type)]
         cfunc = _compile(expr, args)
         self.assertEqual(cfunc(1), 1)
         self.assertEqual(cfunc(4), 4)
@@ -192,7 +192,7 @@ class FlowControlTest(unittest.TestCase):
 class ComparisonTest(unittest.TestCase):
     def test_int_equal(self):
         expr = Expression('Equal', Symbol('x'), Symbol('y'), Integer(3))
-        args = [MathicsArg('System`x', int_type), MathicsArg('System`y', int_type)]
+        args = [CompileArg('System`x', int_type), CompileArg('System`y', int_type)]
         cfunc = _compile(expr, args)
         self.assertTrue(cfunc(3, 3))
         self.assertFalse(cfunc(2, 2))
@@ -200,7 +200,7 @@ class ComparisonTest(unittest.TestCase):
 
     def test_int_unequal(self):
         expr = Expression('Unequal', Symbol('x'), Symbol('y'), Integer(3))
-        args = [MathicsArg('System`x', int_type), MathicsArg('System`y', int_type)]
+        args = [CompileArg('System`x', int_type), CompileArg('System`y', int_type)]
         cfunc = _compile(expr, args)
         self.assertTrue(cfunc(1, 2))
         self.assertFalse(cfunc(3, 2))
@@ -210,7 +210,7 @@ class ComparisonTest(unittest.TestCase):
 
     def test_real_equal(self):
         expr = Expression('Equal', Symbol('x'), Symbol('y'))
-        args = [MathicsArg('System`x', real_type), MathicsArg('System`y', real_type)]
+        args = [CompileArg('System`x', real_type), CompileArg('System`y', real_type)]
         cfunc = _compile(expr, args)
         self.assertTrue(cfunc(3.0, 3.0))
         self.assertFalse(cfunc(3.0, 2.0))
@@ -219,7 +219,7 @@ class ComparisonTest(unittest.TestCase):
 
     def test_int_real_equal(self):
         expr = Expression('Equal', Symbol('x'), Symbol('y'))
-        args = [MathicsArg('System`x', real_type), MathicsArg('System`y', int_type)]
+        args = [CompileArg('System`x', real_type), CompileArg('System`y', int_type)]
         cfunc = _compile(expr, args)
         self.assertTrue(cfunc(3.0, 3))
         self.assertFalse(cfunc(3.0, 2))
@@ -244,11 +244,11 @@ class ComparisonTest(unittest.TestCase):
             check = getattr(self, 'assert' + str(result))
 
             expr = Expression(head, Symbol('x'), Symbol('y'))
-            int_args = [MathicsArg('System`x', int_type), MathicsArg('System`y', int_type)]
+            int_args = [CompileArg('System`x', int_type), CompileArg('System`y', int_type)]
             cfunc = _compile(expr, int_args)
             check(cfunc(*args))
 
-            real_args = [MathicsArg('System`x', real_type), MathicsArg('System`y', real_type)]
+            real_args = [CompileArg('System`x', real_type), CompileArg('System`y', real_type)]
             cfunc = _compile(expr, real_args)
             check(cfunc(*(float(arg) for arg in args)))
 
@@ -257,7 +257,7 @@ class LogicTest(unittest.TestCase):
             check = getattr(self, 'assert' + str(result))
             arg_names = ['x%i' % i for i in range(len(args))]
             expr = Expression(head, *(Symbol(arg_name) for arg_name in arg_names))
-            bool_args = [MathicsArg('System`' + arg_name, bool_type) for arg_name in arg_names]
+            bool_args = [CompileArg('System`' + arg_name, bool_type) for arg_name in arg_names]
             cfunc = _compile(expr, bool_args)
             check(cfunc(*args))
 
@@ -306,7 +306,7 @@ class BitwiseTest(unittest.TestCase):
     def _test_bitwise(self, head, args, result):
             arg_names = ['x%i' % i for i in range(len(args))]
             expr = Expression(head, *(Symbol(arg_name) for arg_name in arg_names))
-            int_args = [MathicsArg('System`' + arg_name, int_type) for arg_name in arg_names]
+            int_args = [CompileArg('System`' + arg_name, int_type) for arg_name in arg_names]
             cfunc = _compile(expr, int_args)
             self.assertEqual(cfunc(*args), result)
 

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -84,6 +84,8 @@ class ArithmeticTest(CompileTest):
 
     def test_pow(self):
         self._test_binary_math('Power', mpmath.power)
+        # TODO 2 ^ x
+        # TODO E ^ x
 
     def test_hyperbolics(self):
         self._test_unary_math('Sinh', mpmath.sinh)

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -1,4 +1,6 @@
 import unittest
+import math
+import random
 
 from mathics.builtin.compile import _compile, MathicsArg, int_type, real_type
 from mathics.core.expression import Expression, Symbol, Integer, MachineReal
@@ -28,3 +30,67 @@ class ArithmeticTest(unittest.TestCase):
         args = [MathicsArg('System`x', real_type)]
         cfunc = _compile(expr, args)
         self.assertEqual(cfunc(2.5), 8.5)
+
+    def _test_unary_math(self, name, fn):
+        expr = Expression(name, Symbol('x'))
+        args = [MathicsArg('System`x', real_type)]
+        cfunc = _compile(expr, args)
+        for _ in range(100):
+            x = random.random()
+            self.assertEqual(cfunc(x), fn(x))
+
+    def _test_binary_math(self, name, fn):
+        expr = Expression(name, Symbol('x'), Symbol('y'))
+        args = [MathicsArg('System`x', real_type), MathicsArg('System`y', real_type)]
+        cfunc = _compile(expr, args)
+        for _ in range(100):
+            x = random.random()
+            y = random.random()
+            self.assertEqual(cfunc(x, y), fn(x, y))
+
+    def test_plus(self):
+        self._test_binary_math('Plus', lambda x, y: x + y)
+
+    def test_times(self):
+        self._test_binary_math('Times', lambda x, y: x * y)
+
+    def test_sin(self):
+        self._test_unary_math('Sin', math.sin)
+
+    def test_cos(self):
+        self._test_unary_math('Cos', math.cos)
+
+    @unittest.expectedFailure
+    def test_tan(self):
+        self._test_unary_math('Tan', math.tan)
+
+    @unittest.expectedFailure
+    def test_pow(self):
+        self._test_binary_math('Power', lambda x, y : x ** y)
+
+    @unittest.expectedFailure
+    def test_div0(self):
+        expr = Expression('Power', Symbol('x'), Symbol('y'))
+        args = [MathicsArg('System`x', real_type), MathicsArg('System`y', real_type)]
+        cfunc = _compile(expr, args)
+        self.assertEqual(cfunc(0.0, -1.5), float('+inf'))
+        self.assertEqual(cfunc(0.0, -1.0), float('+inf'))
+        self.assertEqual(cfunc(-0.0, -1.0), float('+inf'))
+        self.assertEqual(cfunc(0.0, 0.0), float('nan'))
+
+    def test_exp(self):
+        self._test_unary_math('Exp', math.exp)
+
+    def test_log(self):
+        self._test_unary_math('Log', math.log)
+
+    def test_abs(self):
+        self._test_unary_math('Abs', abs)
+
+    @unittest.expectedFailure
+    def test_max(self):
+        self._test_binary_math('Max', max)
+
+    @unittest.expectedFailure
+    def test_min(self):
+        self._test_binary_math('Min', min)

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -90,3 +90,21 @@ class ArithmeticTest(unittest.TestCase):
 
     def test_min(self):
         self._test_binary_math('Min', min)
+
+
+class FlowControlTest(unittest.TestCase):
+
+    def test_if(self):
+        expr = Expression('If', Symbol('x'), Symbol('y'), Symbol('z'))
+        args = [MathicsArg('System`x', int_type), MathicsArg('System`y', real_type), MathicsArg('System`z', real_type)]
+        cfunc = _compile(expr, args)
+        self.assertEqual(cfunc(0, 3.0, 4.0), 4.0)
+        self.assertEqual(cfunc(1, 3.0, 4.0), 3.0)
+        self.assertEqual(cfunc(2, 3.0, 4.0), 3.0)
+
+    def test_if_cont(self):
+        expr = Expression('Plus', Integer(1), Expression('If', Symbol('x'), Expression('Sin', Symbol('y')), Expression('Cos', Symbol('y'))))
+        args = [MathicsArg('System`x', int_type), MathicsArg('System`y', real_type)]
+        cfunc = _compile(expr, args)
+        self.assertEqual(cfunc(0, 0.0), 2.0)
+        self.assertEqual(cfunc(1, 0.0), 1.0)

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -24,7 +24,7 @@ class ArithmeticTest(unittest.TestCase):
         self.assertEqual(cfunc(1, 2.5), 8.5)
 
     def test_d(self):
-        expr = Expression('Plus', Symbol('x'), MachineReal(1.5))
+        expr = Expression('Plus', Symbol('x'), MachineReal(1.5), Integer(2), Symbol('x'))
         args = [MathicsArg('System`x', real_type)]
         cfunc = _compile(expr, args)
-        self.assertEqual(cfunc(2.5), 4.0)
+        self.assertEqual(cfunc(2.5), 8.5)

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -85,11 +85,24 @@ class ArithmeticTest(CompileTest):
     def test_pow_real(self):
         self._test_binary_math('Power', mpmath.power)
 
+    @unittest.expectedFailure
     def test_pow_int(self):
+        expr = Expression('Power', Symbol('x'), Symbol('y'))
+        args = [CompileArg('System`x', int_type), CompileArg('System`y', int_type)]
+        cfunc = _compile(expr, args)
+        self.assertIs(cfunc(4, 9), 4 ** 9)
+
+    def test_pow_real_int(self):
         expr = Expression('Power', MachineReal(2.5), Symbol('x'))
         args = [CompileArg('System`x', int_type)]
         cfunc = _compile(expr, args)
-        self.assertEquals(cfunc(4), 2.5 ** 4)
+        self.assertIs(cfunc(4), 2.5 ** 4)
+
+    def test_pow_int_real(self):
+        expr = Expression('Power', Symbol('x'), MachineReal(5.5))
+        args = [CompileArg('System`x', int_type)]
+        cfunc = _compile(expr, args)
+        self.assertIs(cfunc(8), 8 ** 5.5)
 
     def test_pow_2(self):
         # 2 ^ x

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -11,7 +11,7 @@ from mathics.core.expression import Expression, Symbol, Integer, MachineReal, St
 from mathics.builtin.compile import has_llvmlite
 
 if has_llvmlite:
-    from mathics.builtin.compile import _compile, CompileArg, int_type, real_type, bool_type
+    from mathics.builtin.compile import _compile, CompileArg, int_type, real_type, bool_type, CompileError
 
 
 class CompileTest(unittest.TestCase):
@@ -303,6 +303,12 @@ class FlowControlTest(CompileTest):
         cfunc = _compile(expr, args)
         self.assertTypeEqual(cfunc(1), 1)
         self.assertTypeEqual(cfunc(4), 4)
+
+    def test_if_return_error(self):
+        expr = Expression('If', Symbol('x'), Expression('Return', Symbol('y')), Expression('Return', Symbol('z')))
+        args = [CompileArg('System`x', bool_type), CompileArg('System`y', int_type), CompileArg('System`z', bool_type)]
+        with self.assertRaises(CompileError):
+            _compile(expr, args)
 
 class ComparisonTest(CompileTest):
     def test_int_equal(self):


### PR DESCRIPTION
Allows compiling simple expressions with `llvmlite`.

At the moment nothing else is aware of `CompiledFunction` so the performance benefits are marginal (most of the time is spent looking for patterns) but this has the potential to speedup plotting significantly.

```mathematica
In[1]:= cf = Compile[{{x, _Real}}, Sin[x + 2]]
Out[1]= CompiledFunction[{x}, Sin[2 + x], -CompiledCode-]

In[2]:= data = RandomReal[1, 100];
In[3]:= Map[cf, data]; // Timing
Out[3]= {0.084535, Null}

In[4]:= Map[Sin[#1 + 2]&, data]; // Timing
Out[4]= {0.120563, Null}
```

Requires a minor bugfix to llvmlite: https://github.com/numba/llvmlite/pull/205.