### PR TITLE
Fixes Import[] with XML files

### DIFF
--- a/mathics/autoload/formats/XML/Import.m
+++ b/mathics/autoload/formats/XML/Import.m
@@ -9,7 +9,7 @@ ImportExport`RegisterImport[
     {
         "XMLObject" :> XML`XMLObjectImport,
         "Plaintext" :> XML`PlaintextImport,
-        "Tags" :> XML`TagsImport,
+        "Tags" :> XML`TagsImport
     },
     {},
 	AvailableElements -> {"Plaintext", "Tags", "XMLObject"},

--- a/mathics/autoload/formats/XML/Import.m
+++ b/mathics/autoload/formats/XML/Import.m
@@ -9,7 +9,8 @@ ImportExport`RegisterImport[
     {
         "XMLObject" :> XML`XMLObjectImport,
         "Plaintext" :> XML`PlaintextImport,
-        "Tags" :> XML`TagsImport
+        "Tags" :> XML`TagsImport,
+        XML`XMLObjectImport
     },
     {},
 	AvailableElements -> {"Plaintext", "Tags", "XMLObject"},


### PR DESCRIPTION
Fixes e.g. `Import["http://ota.ox.ac.uk/text/5700.xml"]`, which was somehow broken.