### PR TITLE
Roughly constant time expression timestamp checks

### DIFF
--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -266,8 +266,8 @@ class Plus(BinaryOperator, SympyFunction):
                     leaves.append(last_item)
                 else:
                     if last_item.has_form('Times', None):
-                        last_item.leaves.insert(0, from_sympy(last_count))
-                        leaves.append(last_item)
+                        leaves.append(Expression(
+                            'Times', from_sympy(last_count), *last_item.leaves))
                     else:
                         leaves.append(Expression(
                             'Times', from_sympy(last_count), last_item))
@@ -281,7 +281,7 @@ class Plus(BinaryOperator, SympyFunction):
                     for leaf in item.leaves:
                         if isinstance(leaf, Number):
                             count = leaf.to_sympy()
-                            rest = item.leaves[:]
+                            rest = item.get_mutable_leaves()
                             rest.remove(leaf)
                             if len(rest) == 1:
                                 rest = rest[0]
@@ -590,8 +590,8 @@ class Times(BinaryOperator, SympyFunction):
             elif (leaves and item.has_form('Power', 2) and
                   leaves[-1].has_form('Power', 2) and
                   item.leaves[0].same(leaves[-1].leaves[0])):
-                leaves[-1].leaves[1] = Expression(
-                    'Plus', item.leaves[1], leaves[-1].leaves[1])
+                leaves[-1] = Expression('Power', leaves[-1].leaves[0], Expression(
+                    'Plus', item.leaves[1], leaves[-1].leaves[1]))
             elif (leaves and item.has_form('Power', 2) and
                   item.leaves[0].same(leaves[-1])):
                 leaves[-1] = Expression(
@@ -626,8 +626,9 @@ class Times(BinaryOperator, SympyFunction):
         elif number.is_zero:
             return number
         elif number.same(Integer(-1)) and leaves and leaves[0].has_form('Plus', None):
-            leaves[0].leaves = [Expression('Times', Integer(-1), leaf)
-                                for leaf in leaves[0].leaves]
+            leaves[0] = Expression(
+                leaves[0].get_head(),
+                *[Expression('Times', Integer(-1), leaf) for leaf in leaves[0].leaves])
             number = None
 
         for leaf in leaves:

--- a/mathics/builtin/assignment.py
+++ b/mathics/builtin/assignment.py
@@ -1051,7 +1051,7 @@ def get_symbol_values(symbol, func_name, position, evaluation):
         definition = evaluation.definitions.get_definition(name)
     else:
         definition = evaluation.definitions.get_user_definition(name)
-    result = Expression('List')
+    leaves = []
     for rule in definition.get_values_list(position):
         if isinstance(rule, Rule):
             pattern = rule.pattern
@@ -1059,9 +1059,9 @@ def get_symbol_values(symbol, func_name, position, evaluation):
                 pattern = pattern.expr
             else:
                 pattern = Expression('HoldPattern', pattern.expr)
-            result.leaves.append(Expression(
+            leaves.append(Expression(
                 'RuleDelayed', pattern, rule.replace))
-    return result
+    return Expression('List', *leaves)
 
 
 class DownValues(Builtin):

--- a/mathics/builtin/combinatorial.py
+++ b/mathics/builtin/combinatorial.py
@@ -93,13 +93,13 @@ class Multinomial(Builtin):
         'Multinomial[values___]'
 
         values = values.get_sequence()
-        result = Expression('Times')
+        leaves = []
         total = []
         for value in values:
             total.append(value)
-            result.leaves.append(Expression(
+            leaves.append(Expression(
                 'Binomial', Expression('Plus', *total), value))
-        return result
+        return Expression('Times', *leaves)
 
 
 class _NoBoolVector(Exception):

--- a/mathics/builtin/files.py
+++ b/mathics/builtin/files.py
@@ -26,6 +26,8 @@ import six
 from six.moves import range
 from six import unichr
 
+from itertools import chain
+
 from mathics.core.expression import (Expression, Real, Complex, String, Symbol,
                                      from_python, Integer, BoxError,
                                      MachineReal, Number, valid_context_name)
@@ -1475,17 +1477,17 @@ class BinaryWrite(Builtin):
             elif t.startswith('Character'):
                 if isinstance(x, Integer):
                     x = [String(char) for char in str(x.get_int_value())]
-                    pyb = pyb[:i] + x + pyb[i + 1:]
+                    pyb = list(chain(pyb[:i], x, pyb[i + 1:]))
                     x = pyb[i]
                 if isinstance(x, String) and len(x.get_string_value()) > 1:
                     x = [String(char) for char in x.get_string_value()]
-                    pyb = pyb[:i] + x + pyb[i + 1:]
+                    pyb = list(chain(pyb[:i], x, pyb[i + 1:]))
                     x = pyb[i]
                 x = x.get_string_value()
             elif t == 'Byte' and isinstance(x, String):
                 if len(x.get_string_value()) > 1:
                     x = [String(char) for char in x.get_string_value()]
-                    pyb = pyb[:i] + x + pyb[i + 1:]
+                    pyb = list(chain(pyb[:i], x, pyb[i + 1:]))
                     x = pyb[i]
                 x = ord(x.get_string_value())
             else:

--- a/mathics/builtin/functional.py
+++ b/mathics/builtin/functional.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 
 from six.moves import zip
+from itertools import chain
 
 from mathics.builtin.base import Builtin, PostfixOperator
 from mathics.core.expression import Expression
@@ -70,8 +71,7 @@ class Function(PostfixOperator):
     def apply_slots(self, body, args, evaluation):
         'Function[body_][args___]'
 
-        args = args.get_sequence()
-        args.insert(0, Expression('Function', body))
+        args = list(chain([Expression('Function', body)], args.get_sequence()))
         return body.replace_slots(args, evaluation)
 
     def apply_named(self, vars, body, args, evaluation):

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -273,11 +273,11 @@ def set_part(list, indices, new):
                 raise PartDepthError
             try:
                 if pos > 0:
-                    cur.leaves[pos - 1] = new
+                    cur.set_leaves(pos - 1, new)
                 elif pos == 0:
-                    cur.head = new
+                    cur.set_head(new)
                 else:
-                    cur.leaves[pos] = new
+                    cur.set_leaves(pos, new)
             except IndexError:
                 raise PartRangeError
 
@@ -384,8 +384,7 @@ def _list_parts(items, selectors, assignment):
 
             if unwrap is None:
                 expr = item.shallow_copy()
-                expr.leaves = picked
-                expr.last_evaluated = None
+                expr.set_leaves(slice(len(expr.leaves)), picked)
 
                 if assignment:
                     expr.original = None
@@ -1082,7 +1081,7 @@ class ReplacePart(Builtin):
             position = replacement.leaves[0]
             replace = replacement.leaves[1]
             if position.has_form('List', None):
-                position = position.leaves
+                position = position.get_mutable_leaves()
             else:
                 position = [position]
             for index, pos in enumerate(position):
@@ -1132,7 +1131,7 @@ def _take_span_selector(seq):
 
 def _drop_span_selector(seq):
     def sliced(x, s):
-        y = x[:]
+        y = list(x[:])
         del y[s]
         return y
 
@@ -2217,7 +2216,7 @@ class Prepend(Builtin):
             return evaluation.message('Prepend', 'normal')
 
         return Expression(expr.get_head(),
-                          *([item] + expr.get_leaves()))
+            *list(chain([item], expr.get_leaves())))
 
 
 def get_tuples(items):

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -1939,7 +1939,7 @@ class Array(Builtin):
         'Array[f_, dimsexpr_, origins_:1, head_:List]'
 
         if dimsexpr.has_form('List', None):
-            dims = dimsexpr.leaves[:]
+            dims = dimsexpr.get_mutable_leaves()
         else:
             dims = [dimsexpr]
         for index, dim in enumerate(dims):
@@ -1952,7 +1952,7 @@ class Array(Builtin):
             if len(origins.leaves) != len(dims):
                 evaluation.message('Array', 'plen', dimsexpr, origins)
                 return
-            origins = origins.leaves[:]
+            origins = origins.get_mutable_leaves()
         else:
             origins = [origins] * len(dims)
         for index, origin in enumerate(origins):
@@ -2136,8 +2136,8 @@ class Append(Builtin):
         if expr.is_atom():
             return evaluation.message('Append', 'normal')
 
-        return Expression(expr.get_head(),
-                          *(expr.get_leaves() + [item]))
+        return Expression(
+            expr.get_head(), *list(chain(expr.get_leaves(), [item])))
 
 
 class AppendTo(Builtin):
@@ -3488,7 +3488,7 @@ class Median(_Rectangular):
             except _NotRectangularException:
                 evaluation.message('Median', 'rectn', Expression('Median', l))
         elif all(leaf.is_numeric() for leaf in l.leaves):
-            v = l.leaves[:]  # copy needed for introselect
+            v = l.get_mutable_leaves()  # copy needed for introselect
             n = len(v)
             if n % 2 == 0:  # even number of elements?
                 i = n // 2
@@ -3527,7 +3527,7 @@ class RankedMin(Builtin):
         elif py_n > len(l.leaves):
             evaluation.message('RankedMin', 'rank', py_n, len(l.leaves))
         else:
-            return introselect(l.leaves[:], py_n - 1)
+            return introselect(l.get_mutable_leaves(), py_n - 1)
 
 
 class RankedMax(Builtin):
@@ -3555,7 +3555,7 @@ class RankedMax(Builtin):
         elif py_n > len(l.leaves):
             evaluation.message('RankedMax', 'rank', py_n, len(l.leaves))
         else:
-            return introselect(l.leaves[:], len(l.leaves) - py_n)
+            return introselect(l.get_mutable_leaves(), len(l.leaves) - py_n)
 
 
 class Quantile(Builtin):
@@ -3585,7 +3585,7 @@ class Quantile(Builtin):
         '''Quantile[l_List, qs_List, {{a_, b_}, {c_, d_}}]'''
 
         n = len(l.leaves)
-        partially_sorted = l.leaves[:]
+        partially_sorted = l.get_mutable_leaves()
 
         def ranked(i):
             return introselect(partially_sorted, min(max(0, i - 1), n - 1))

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -321,7 +321,7 @@ def _parts_span_selector(pspec):
 
 
 def _parts_sequence_selector(pspec):
-    if not isinstance(pspec, list):
+    if not isinstance(pspec, (tuple, list)):
         indices = [pspec]
     else:
         indices = pspec
@@ -2365,11 +2365,11 @@ class Reap(Builtin):
             result = expr.evaluate(evaluation)
             items = []
             for pattern, tags in sown:
-                list = Expression('List')
+                leaves = []
                 for tag, elements in tags:
-                    list.leaves.append(Expression(
+                    leaves.append(Expression(
                         f, tag, Expression('List', *elements)))
-                items.append(list)
+                items.append(Expression('List', *leaves))
             return Expression('List', result, Expression('List', *items))
         finally:
             evaluation.remove_listener('sow', listener)

--- a/mathics/builtin/numeric.py
+++ b/mathics/builtin/numeric.py
@@ -223,7 +223,7 @@ class N(Builtin):
             else:
                 eval_range = range(len(expr.leaves))
             head = Expression('N', expr.head, prec).evaluate(evaluation)
-            leaves = expr.leaves[:]
+            leaves = expr.get_mutable_leaves()
             for index in eval_range:
                 leaves[index] = Expression(
                     'N', leaves[index], prec).evaluate(evaluation)

--- a/mathics/builtin/structure.py
+++ b/mathics/builtin/structure.py
@@ -965,10 +965,9 @@ class Flatten(Builtin):
         expr, depth = walk_levels(expr, callback=callback, include_pos=True)
 
         # build new tree inserting nodes as needed
-        result = Expression(h)
         leaves = sorted(six.iteritems(new_indices))
 
-        def insert_leaf(expr, leaves):
+        def insert_leaf(leaves):
             # gather leaves into groups with the same leading index
             # e.g. [((0, 0), a), ((0, 1), b), ((1, 0), c), ((1, 1), d)]
             # -> [[(0, a), (1, b)], [(0, c), (1, d)]]
@@ -982,15 +981,17 @@ class Flatten(Builtin):
                     grouped_leaves.append([(index[1:], leaf)])
             # for each group of leaves we either insert them into the current level
             # or make a new level and recurse
+            new_leaves = []
             for group in grouped_leaves:
                 if len(group[0][0]) == 0:   # bottom level leaf
                     assert len(group) == 1
-                    expr.leaves.append(group[0][1])
+                    new_leaves.append(group[0][1])
                 else:
-                    expr.leaves.append(Expression(h))
-                    insert_leaf(expr.leaves[-1], group)
-        insert_leaf(result, leaves)
-        return result
+                    new_leaves.append(Expression(h, *insert_leaf(group)))
+
+            return new_leaves
+
+        return Expression(h, *insert_leaf(leaves))
 
     def apply(self, expr, n, h, evaluation):
         'Flatten[expr_, n_, h_]'
@@ -1234,7 +1235,7 @@ class Operate(Builtin):
         # Otherwise, if we get here, e.head points to the head we need
         # to apply p to. Python's reference semantics mean that this
         # assignment modifies expr as well.
-        e.head = Expression(p, e.head)
+        e.set_head(Expression(p, e.head))
 
         return expr
 

--- a/mathics/builtin/tensors.py
+++ b/mathics/builtin/tensors.py
@@ -280,17 +280,17 @@ class Inner(Builtin):
         def rec(i_cur, j_cur, i_rest, j_rest):
             evaluation.check_stopped()
             if i_rest:
-                new = Expression(head)
+                leaves = []
                 for i in range(1, i_rest[0] + 1):
-                    new.leaves.append(
+                    leaves.append(
                         rec(i_cur + [i], j_cur, i_rest[1:], j_rest))
-                return new
+                return Expression(head, *leaves)
             elif j_rest:
-                new = Expression(head)
+                leaves = []
                 for j in range(1, j_rest[0] + 1):
-                    new.leaves.append(
+                    leaves.append(
                         rec(i_cur, j_cur + [j], i_rest, j_rest[1:]))
-                return new
+                return Expression(head, *leaves)
             else:
                 def summand(i):
                     return Expression(f, get_part(list1, i_cur + [i]),

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -515,7 +515,7 @@ class Expression(BaseExpression):
 
     @head.setter
     def head(self, value):
-        raise ValueError('Expression.head is write protected')
+        raise ValueError('Expression.head is write protected. Use set_head().')
 
     @property
     def leaves(self):
@@ -523,7 +523,7 @@ class Expression(BaseExpression):
 
     @leaves.setter
     def leaves(self, value):
-        raise ValueError('Expression.leaves is write protected')
+        raise ValueError('Expression.leaves is write protected. Use set_leaves().')
 
     def sequences(self):
         seq = self._sequences
@@ -638,10 +638,10 @@ class Expression(BaseExpression):
     def get_leaves(self):
         return self._leaves
 
-    def get_mutable_leaves(self):
+    def get_mutable_leaves(self):  # shallow, mutable copy of the leaves array
         return list(self._leaves)
 
-    def set_leaves(self, index, value):
+    def set_leaves(self, index, value):  # leaves are removed, added or replaced
         leaves = list(self._leaves)
         leaves[index] = value
         self._leaves = tuple(leaves)
@@ -649,7 +649,7 @@ class Expression(BaseExpression):
         self._sequences = None
         self.last_evaluated = None
 
-    def set_reordered_leaves(self, leaves):
+    def set_reordered_leaves(self, leaves):  # same leaves, but in a different order
         self._leaves = tuple(leaves)
         self._sequences = None
         self.last_evaluated = None

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -557,7 +557,7 @@ class Expression(BaseExpression):
             expr.options = self.options
         return expr
 
-    def symbols(self):
+    def symbols(self, intermediate=False):
         sym = self.sym
         if sym is None:
             list_of_symbols = [self.get_head_name()]
@@ -566,9 +566,21 @@ class Expression(BaseExpression):
                 if isinstance(leaf, Symbol):
                     list_of_symbols.append(leaf.get_name())
                 elif isinstance(leaf, Expression):
-                    list_of_symbols.extend(list(leaf.symbols()))
+                    list_of_symbols.extend(list(leaf.symbols(True)))
 
-            sym = set(list_of_symbols)
+            # converting the symbols list to a set is slow. by default,
+            # we only do this for the final expression returned to
+            # not_changed(), but not for intermediate ones. this yields
+            # better benchmarks.
+
+            if intermediate:
+                sym = list_of_symbols
+            else:
+                sym = set(list_of_symbols)
+
+            self.sym = sym
+        elif not intermediate and isinstance(sym, list):
+            sym = set(sym)
             self.sym = sym
 
         return sym

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -77,9 +77,9 @@ class ExpressionPointer(object):
 
     def replace(self, new):
         if self.position == 0:
-            self.parent.head = new
+            self.parent.set_head(new)
         else:
-            self.parent.leaves[self.position - 1] = new
+            self.parent.set_leaves(self.position - 1, new)
 
     def __str__(self):
         return '%s[[%s]]' % (self.parent, self.position)
@@ -504,10 +504,18 @@ class Expression(BaseExpression):
         if isinstance(head, six.string_types):
             head = Symbol(head)
         self.head = head
-        self.leaves = [from_python(leaf) for leaf in leaves]
+        self._leaves = tuple(from_python(leaf) for leaf in leaves)
         self._sequences = None
         self._symbols = None
         return self
+
+    @property
+    def leaves(self):
+        return self._leaves
+
+    @leaves.setter
+    def leaves(self, value):
+        raise ValueError('Expression.leaves is write protected')
 
     def sequences(self):
         seq = self._sequences
@@ -599,7 +607,7 @@ class Expression(BaseExpression):
         # this is a minimal, shallow copy: head, leaves are shared with
         # the original, only the Expression instance is new.
         expr = Expression(self.head)
-        expr.leaves = self.leaves
+        expr._leaves = self._leaves
         expr._sequences = self._sequences
         expr._symbols = self._symbols
         expr.options = self.options
@@ -615,8 +623,28 @@ class Expression(BaseExpression):
     def get_head(self):
         return self.head
 
+    def set_head(self, head):
+        self.head = head
+        self._symbols = None
+
     def get_leaves(self):
-        return self.leaves
+        return self._leaves
+
+    def get_mutable_leaves(self):
+        return list(self._leaves)
+
+    def set_leaves(self, index, value):
+        leaves = list(self._leaves)
+        leaves[index] = value
+        self._leaves = tuple(leaves)
+        self._leaves_changed()
+
+    def _leaves_changed(self):
+        self._symbols = None
+        self._sequences = None
+
+    def _leaves_reordered(self):
+        self._sequences = None
 
     def get_lookup_name(self):
         return self.head.get_lookup_name()
@@ -858,7 +886,7 @@ class Expression(BaseExpression):
                 return self
             head = self.head.evaluate(evaluation)
             attributes = head.get_attributes(evaluation.definitions)
-            leaves = self.leaves[:]
+            leaves = self.get_mutable_leaves()
 
             def rest_range(indices):
                 if 'System`HoldAllComplete' not in attributes:
@@ -897,16 +925,18 @@ class Expression(BaseExpression):
                 leaf.unevaluated = False
 
             if 'System`HoldAllComplete' not in attributes:
-                dirty_new = False
+                dirty_leaves = None
 
                 for index, leaf in enumerate(leaves):
                     if leaf.has_form('Unevaluated', 1):
-                        leaves[index] = leaf.leaves[0]
-                        leaves[index].unevaluated = True
-                        dirty_new = True
+                        if dirty_leaves is None:
+                            dirty_leaves = list(leaves)
+                        dirty_leaves[index] = leaf.leaves[0]
+                        dirty_leaves[index].unevaluated = True
 
-                if dirty_new:
-                    new = Expression(head, *leaves)
+                if dirty_leaves:
+                    new = Expression(head, *dirty_leaves)
+                    leaves = new.leaves
 
             def flatten_callback(new_leaves, old):
                 for leaf in new_leaves:
@@ -955,11 +985,17 @@ class Expression(BaseExpression):
                     else:
                         return result.evaluate(evaluation)
 
+            dirty_leaves = None
+
             # Expression did not change, re-apply Unevaluated
             for index, leaf in enumerate(new.leaves):
                 if leaf.unevaluated:
-                    new.leaves[index] = Expression('Unevaluated', leaf)
-                    new._symbols = None
+                    if dirty_leaves is None:
+                        dirty_leaves = list(new.leaves)
+                    dirty_leaves[index] = Expression('Unevaluated', leaf)
+
+            if dirty_leaves:
+                new = Expression(head, *dirty_leaves)
 
             new.unformatted = self.unformatted
             new.last_evaluated = evaluation.definitions.now
@@ -1178,11 +1214,13 @@ class Expression(BaseExpression):
 
     def sort(self, pattern=False):
         " Sort the leaves according to internal ordering. "
-
+        leaves = list(self._leaves)
         if pattern:
-            self.leaves.sort(key=lambda e: e.get_sort_key(pattern_sort=True))
+            leaves.sort(key=lambda e: e.get_sort_key(pattern_sort=True))
         else:
-            self.leaves.sort()
+            leaves.sort()
+        self._leaves = tuple(leaves)
+        self._leaves_reordered()
 
     def filter_leaves(self, head_name):
         # TODO: should use sorting
@@ -1261,8 +1299,7 @@ class Expression(BaseExpression):
                     replacement = {name: Symbol(name + '$') for name in func_params}
                     func_params = [Symbol(name + '$') for name in func_params]
                     body = body.replace_vars(replacement, options, in_scoping)
-                    leaves = [Expression('List', *func_params), body] + \
-                        self.leaves[2:]
+                    leaves = chain([Expression('List', *func_params), body], self.leaves[2:])
 
         if not vars:  # might just be a symbol set via Set[] we looked up here
             return self.shallow_copy()
@@ -1346,9 +1383,9 @@ class Expression(BaseExpression):
                 if _prec is None or leaf_prec < _prec:
                     _prec = leaf_prec
         if _prec is not None:
-            new_leaves = self.leaves[:]
-            for index in range(len(self.leaves)):
-                leaf = self.leaves[index]
+            new_leaves = self.get_mutable_leaves()
+            for index in range(len(new_leaves)):
+                leaf = new_leaves[index]
                 # Don't "numerify" numbers: they should be numerified
                 # automatically by the processing function,
                 # and we don't want to lose exactness in e.g. 1.0+I.

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -503,11 +503,19 @@ class Expression(BaseExpression):
         self = super(Expression, cls).__new__(cls)
         if isinstance(head, six.string_types):
             head = Symbol(head)
-        self.head = head
+        self._head = head
         self._leaves = tuple(from_python(leaf) for leaf in leaves)
         self._sequences = None
         self._symbols = None
         return self
+
+    @property
+    def head(self):
+        return self._head
+
+    @head.setter
+    def head(self, value):
+        raise ValueError('Expression.head is write protected')
 
     @property
     def leaves(self):
@@ -621,10 +629,10 @@ class Expression(BaseExpression):
             leaf.set_positions(ExpressionPointer(self, index + 1))
 
     def get_head(self):
-        return self.head
+        return self._head
 
     def set_head(self, head):
-        self.head = head
+        self._head = head
         self._symbols = None
 
     def get_leaves(self):
@@ -639,10 +647,12 @@ class Expression(BaseExpression):
         self._leaves = tuple(leaves)
         self._symbols = None
         self._sequences = None
+        self.last_evaluated = None
 
     def set_reordered_leaves(self, leaves):
-        self._leaves = leaves
+        self._leaves = tuple(leaves)
         self._sequences = None
+        self.last_evaluated = None
 
     def get_lookup_name(self):
         return self.head.get_lookup_name()
@@ -761,7 +771,7 @@ class Expression(BaseExpression):
                     pattern += 20
             if pattern > 0:
                 return [2, pattern, 1, 1, 0, self.head.get_sort_key(True),
-                        [leaf.get_sort_key(True) for leaf in self.leaves], 1]
+                        tuple(leaf.get_sort_key(True) for leaf in self.leaves), 1]
 
             if name == 'System`PatternTest':
                 if len(self.leaves) != 2:
@@ -810,7 +820,7 @@ class Expression(BaseExpression):
                 # precedence
                 return [
                     2, 0, 1, 1, 0, self.head.get_sort_key(True),
-                    [leaf.get_sort_key(True) for leaf in self.leaves] + [[4]],
+                    tuple(chain((leaf.get_sort_key(True) for leaf in self.leaves), ([4],))),
                     1]
         else:
             exps = {}

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -506,7 +506,7 @@ class Expression(BaseExpression):
         self.head = head
         self.leaves = [from_python(leaf) for leaf in leaves]
         self._sequences = None
-        self.sym = None
+        self._symbols = None
         return self
 
     def sequences(self):
@@ -558,7 +558,7 @@ class Expression(BaseExpression):
         return expr
 
     def symbols(self, intermediate=False):
-        sym = self.sym
+        sym = self._symbols
         if sym is None:
             list_of_symbols = [self.get_head_name()]
 
@@ -578,10 +578,10 @@ class Expression(BaseExpression):
             else:
                 sym = set(list_of_symbols)
 
-            self.sym = sym
+            self._symbols = sym
         elif not intermediate and isinstance(sym, list):
             sym = set(sym)
-            self.sym = sym
+            self._symbols = sym
 
         return sym
 
@@ -589,7 +589,7 @@ class Expression(BaseExpression):
         result = Expression(
             self.head.copy(), *[leaf.copy() for leaf in self.leaves])
         result._sequences = self._sequences
-        result.sym = self.sym
+        result._symbols = self._symbols
         result.options = self.options
         result.original = self
         # result.last_evaluated = self.last_evaluated
@@ -601,7 +601,7 @@ class Expression(BaseExpression):
         expr = Expression(self.head)
         expr.leaves = self.leaves
         expr._sequences = self._sequences
-        expr.sym = self.sym
+        expr._symbols = self._symbols
         expr.options = self.options
         expr.last_evaluated = self.last_evaluated
         return expr

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -506,6 +506,7 @@ class Expression(BaseExpression):
         self.head = head
         self.leaves = [from_python(leaf) for leaf in leaves]
         self._sequences = None
+        self.sym = None
         return self
 
     def sequences(self):
@@ -556,10 +557,27 @@ class Expression(BaseExpression):
             expr.options = self.options
         return expr
 
+    def symbols(self):
+        sym = self.sym
+        if sym is None:
+            list_of_symbols = [self.get_head_name()]
+
+            for leaf in self.leaves:
+                if isinstance(leaf, Symbol):
+                    list_of_symbols.append(leaf.get_name())
+                elif isinstance(leaf, Expression):
+                    list_of_symbols.extend(list(leaf.symbols()))
+
+            sym = set(list_of_symbols)
+            self.sym = sym
+
+        return sym
+
     def copy(self):
         result = Expression(
             self.head.copy(), *[leaf.copy() for leaf in self.leaves])
         result._sequences = self._sequences
+        result.sym = self.sym
         result.options = self.options
         result.original = self
         # result.last_evaluated = self.last_evaluated
@@ -571,6 +589,7 @@ class Expression(BaseExpression):
         expr = Expression(self.head)
         expr.leaves = self.leaves
         expr._sequences = self._sequences
+        expr.sym = self.sym
         expr.options = self.options
         expr.last_evaluated = self.last_evaluated
         return expr
@@ -823,7 +842,7 @@ class Expression(BaseExpression):
             evaluation.options = self.options
         try:
             # changed before last evaluated
-            if self.last_evaluated is not None and evaluation.definitions.last_changed(self) <= self.last_evaluated:
+            if evaluation.definitions.not_changed(self, self.last_evaluated):
                 return self
             head = self.head.evaluate(evaluation)
             attributes = head.get_attributes(evaluation.definitions)
@@ -928,6 +947,7 @@ class Expression(BaseExpression):
             for index, leaf in enumerate(new.leaves):
                 if leaf.unevaluated:
                     new.leaves[index] = Expression('Unevaluated', leaf)
+                    new.sym = None
 
             new.unformatted = self.unformatted
             new.last_evaluated = evaluation.definitions.now

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -637,13 +637,11 @@ class Expression(BaseExpression):
         leaves = list(self._leaves)
         leaves[index] = value
         self._leaves = tuple(leaves)
-        self._leaves_changed()
-
-    def _leaves_changed(self):
         self._symbols = None
         self._sequences = None
 
-    def _leaves_reordered(self):
+    def set_reordered_leaves(self, leaves):
+        self._leaves = leaves
         self._sequences = None
 
     def get_lookup_name(self):
@@ -1219,8 +1217,7 @@ class Expression(BaseExpression):
             leaves.sort(key=lambda e: e.get_sort_key(pattern_sort=True))
         else:
             leaves.sort()
-        self._leaves = tuple(leaves)
-        self._leaves_reordered()
+        self.set_reordered_leaves(leaves)
 
     def filter_leaves(self, head_name):
         # TODO: should use sorting

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -959,7 +959,7 @@ class Expression(BaseExpression):
             for index, leaf in enumerate(new.leaves):
                 if leaf.unevaluated:
                     new.leaves[index] = Expression('Unevaluated', leaf)
-                    new.sym = None
+                    new._symbols = None
 
             new.unformatted = self.unformatted
             new.last_evaluated = evaluation.definitions.now

--- a/mathics/core/pattern.py
+++ b/mathics/core/pattern.py
@@ -9,6 +9,7 @@ from mathics.core.expression import (Expression, system_symbols,
                                      ensure_context)
 from mathics.core.util import subsets, subranges, permutations
 from six.moves import range
+from itertools import chain
 
 # from mathics.core.pattern_nocython import (
 #    StopGenerator #, Pattern #, ExpressionPattern)
@@ -451,11 +452,11 @@ class ExpressionPattern(Pattern):
                 if next_rest is None:
                     yield_func(
                         next_vars,
-                        (rest_expression[0] + items_rest[0], []))
+                        (list(chain(rest_expression[0], items_rest[0])), []))
                 else:
                     yield_func(
                         next_vars,
-                        (rest_expression[0] + items_rest[0], next_rest[1]))
+                        (list(chain(rest_expression[0], items_rest[0])), next_rest[1]))
 
             def match_yield(new_vars, _):
                 if rest_leaves:

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -6,9 +6,9 @@ from __future__ import absolute_import
 
 from mathics.core.expression import Expression, strip_context, KeyComparable
 from mathics.core.pattern import Pattern, StopGenerator
-
 from mathics.core.util import function_arguments
 
+from itertools import chain
 
 class StopGenerator_BaseRule(StopGenerator):
     pass
@@ -42,8 +42,8 @@ class BaseRule(KeyComparable):
             if new_expression is None:
                 new_expression = expression
             if rest[0] or rest[1]:
-                result = Expression(expression.get_head(), *(
-                    rest[0] + [new_expression] + rest[1]))
+                result = Expression(expression.get_head(), *list(
+                    chain(rest[0], [new_expression], rest[1])))
             else:
                 result = new_expression
 

--- a/mathics/core/util.py
+++ b/mathics/core/util.py
@@ -10,6 +10,7 @@ from six import unichr
 
 import re
 import sys
+from itertools import chain
 
 FORMAT_RE = re.compile(r'\`(\d*)\`')
 
@@ -75,10 +76,10 @@ def subsets(items, min, max, included=None, less_first=False):
         if count < 0 or len(rest) < count:
             return
         if count == 0:
-            yield chosen, not_chosen + rest
+            yield chosen, list(chain(not_chosen, rest))
         elif len(rest) == count:
             if included is None or all(item in included for item in rest):
-                yield chosen + rest, not_chosen
+                yield list(chain(chosen, rest)), not_chosen
         elif rest:
             item = rest[0]
             if included is None or item in included:


### PR DESCRIPTION
Currently, `Definitions.last_changed` does a full tree traversal each time the expression timestamp is checked. This is bad if the expression is huge and deep, as caching speed is dependent on the expression size.

This PR introduces a set of symbols that can be efficiently checked without the need for a full tree traversal; usually the number of symbols even in a big nested list is small and thus can be regarded a small constant.

The main target for this PR is faster operations with big lists, e.g. using `list = Nest[Partition[#, 2]&, Range[2 ^ 14], 14]`:

without this PR:
```In[2]:= Timing[Length[list]]
Out[2]= {0.334763, 1}```

with this PR:
```In[2]:= Timing[Length[list]]
Out[2]= {0.209859, 1}```

The remaining runtime stems not from `Definitions.last_changed` but from other effects that are targeted in a separate PR.

Apart from this targeted effect, this PR seems to improve the overall benchmarks (see attached files).

[opt5-before.txt](https://github.com/mathics/Mathics/files/488866/opt5-before.txt)

[opt5-after.txt](https://github.com/mathics/Mathics/files/488867/opt5-after.txt)
