### PR TITLE
Faster flatten for Sequence symbols

### DIFF
--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -531,7 +531,7 @@ class Expression(BaseExpression):
         return seq
 
     def _flatten_sequence(self, sequence):
-        indices = self.seq
+        indices = self.sequences()
         if not indices:
             return self
 

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -574,6 +574,7 @@ class Expression(BaseExpression):
     def copy(self):
         result = Expression(
             self.head.copy(), *[leaf.copy() for leaf in self.leaves])
+        result.seq = self.seq
         result.options = self.options
         result.original = self
         # result.last_evaluated = self.last_evaluated
@@ -584,6 +585,7 @@ class Expression(BaseExpression):
         # the original, only the Expression instance is new.
         expr = Expression(self.head)
         expr.leaves = self.leaves
+        expr.seq = self.seq
         expr.options = self.options
         expr.last_evaluated = self.last_evaluated
         return expr

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -536,14 +536,12 @@ class Expression(BaseExpression):
         flattened = []
         extend = flattened.extend
 
-        last = 0
+        k = 0
         for i in indices:
-            next = indices[i]
-            extend(leaves[last:next])
-            extend(sequence(next))
-            last = next + 1
-
-        extend(leaves[last:])
+            extend(leaves[k:i])
+            extend(sequence(leaves[i]))
+            k = i + 1
+        extend(leaves[k:])
 
         return Expression(self.head, *flattened)
 

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -1527,9 +1527,6 @@ class Symbol(Atom):
         return (self.name, self.sympy_dummy)
 
 
-SEQUENCE = Symbol('Sequence')
-
-
 class Number(Atom):
     def __str__(self):
         return str(self.value)

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -520,11 +520,15 @@ class Expression(BaseExpression):
             head = Symbol(head)
         self.head = head
         self.leaves = [from_python(leaf) for leaf in leaves]
-        self.seq = list(_sequences(self.leaves))
+        self.seq = None
         return self
 
     def sequences(self):
-        return self.seq
+        seq = self.seq
+        if seq is None:
+            seq = list(_sequences(self.leaves))
+            self.seq = seq
+        return seq
 
     def _flatten_sequence(self, sequence):
         indices = self.seq

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -520,14 +520,14 @@ class Expression(BaseExpression):
             head = Symbol(head)
         self.head = head
         self.leaves = [from_python(leaf) for leaf in leaves]
-        self.seq = None
+        self._sequences = None
         return self
 
     def sequences(self):
-        seq = self.seq
+        seq = self._sequences
         if seq is None:
             seq = list(_sequences(self.leaves))
-            self.seq = seq
+            self._sequences = seq
         return seq
 
     def _flatten_sequence(self, sequence):
@@ -574,7 +574,7 @@ class Expression(BaseExpression):
     def copy(self):
         result = Expression(
             self.head.copy(), *[leaf.copy() for leaf in self.leaves])
-        result.seq = self.seq
+        result._sequences = self._sequences
         result.options = self.options
         result.original = self
         # result.last_evaluated = self.last_evaluated
@@ -585,7 +585,7 @@ class Expression(BaseExpression):
         # the original, only the Expression instance is new.
         expr = Expression(self.head)
         expr.leaves = self.leaves
-        expr.seq = self.seq
+        expr._sequences = self._sequences
         expr.options = self.options
         expr.last_evaluated = self.last_evaluated
         return expr

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -148,6 +148,9 @@ class BaseExpression(KeyComparable):
     def flatten_sequence(self):
         return self
 
+    def flatten_pattern_sequence(self):
+        return self
+
     def get_attributes(self, definitions):
         return set()
 

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -4,7 +4,7 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
-from mathics.core.expression import Expression, SEQUENCE, strip_context, KeyComparable
+from mathics.core.expression import Expression, strip_context, KeyComparable
 from mathics.core.pattern import Pattern, StopGenerator
 
 

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -46,17 +46,7 @@ class BaseRule(KeyComparable):
                 result = new_expression
 
             # Flatten out sequences (important for Rule itself!)
-
-            def flatten(expr):
-                new_expr = expr.flatten(SEQUENCE, pattern_only=True)
-                if not new_expr.is_atom():
-                    for index, leaf in enumerate(new_expr.leaves):
-                        new_expr.leaves[index] = flatten(leaf)
-                if hasattr(expr, 'options'):
-                    new_expr.options = expr.options
-                return new_expr
-
-            result = flatten(result)
+            result = result.flatten_pattern_sequence()
             if return_list:
                 result_list.append(result)
                 # count += 1


### PR DESCRIPTION
This PR introduces a special case for flattening sequences as it's an operation/border case deeply embedded into the rules and evaluation engine and executed nearly each time a rule is resolved.

The main advantage of the new approach is that symbols are now tracked during `Expression` construction, such that all paths leading to a symbol can be efficiently identified in any part of an `Expression` tree without having to revert to full tree traversals. In that way, all sub trees of an `Expression` not containing sequences don't have to be checked.

The original optimization targeted with this PR was faster handling of huge lists. E.g., using `list = Nest[Partition[#, 2]&, Range[2 ^ 14], 14]`:

Without this PR:
```
In[2]:= Timing[Length[list]]
Out[2]= {0.330744, 1}
```

With this PR:
```
In[2]:= Timing[Length[list]]
Out[2]= {0.165357, 1}
```

In addition to this targeted case, this PR yields notable performance improvements across the board (see attached files, esp. `Random`).

[opt4-before.txt](https://github.com/mathics/Mathics/files/488876/opt4-before.txt)

[opt4-after.txt](https://github.com/mathics/Mathics/files/488877/opt4-after.txt)
