### PR TITLE
a faster walk_parts

### DIFF
--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -385,6 +385,7 @@ def _list_parts(items, selectors, assignment):
             if unwrap is None:
                 expr = item.shallow_copy()
                 expr.leaves = picked
+                expr.last_evaluated = None
 
                 if assignment:
                     expr.original = None
@@ -412,6 +413,8 @@ def walk_parts(list_of_list, indices, evaluation, assign_list=None):
 
         walk_list = walk_list.copy()
         walk_list.set_positions()
+
+    indices = [index.evaluate(evaluation) for index in indices]
 
     try:
         result = _parts(

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -367,6 +367,9 @@ def walk_parts(list_of_list, indices, evaluation, assign_list=None):
         else:
             raise MessageException('Part', 'pspec', index)
 
+        if any(item.is_atom() for item in items):
+            raise MessageException('Part', 'partd')
+
         return [select(item, rest_indices) for item in items]
 
     try:
@@ -407,7 +410,8 @@ def walk_parts(list_of_list, indices, evaluation, assign_list=None):
         process_level(result, assign_list)
         result = list_of_list[0]
 
-    result.last_evaluated = None
+        result.last_evaluated = None
+
     return result
 
 

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -348,7 +348,7 @@ def walk_parts(list_of_list, indices, evaluation, assign_list=None):
 
     def one(f):
         def g(x, indices):
-            return pick(list(f(x))[0], indices)
+            return pick(list(f(x)), indices)[0]
         return g
 
     def pick(items, indices):


### PR DESCRIPTION
This PR reorganizes `walk_parts` and changes it to a pure functional (and read only) implementation. I hope it's also a bit cleaner as the variable scoping is more defined.

The targeted optimization is achieving runtime with `Parts[]` with big lists. Using `list = Nest[Partition[#, 10]&, Range[10 ^ 5], 5]`:

Without this PR:
```
In[2]:= Timing[Part[list, 1, 1, 1, 1, 1]]
Out[2]= {4.10712, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}}
```

With this PR:
```
In[8]:= Timing[Part[list, 1, 1, 1, 1, 1]]
Out[8]= {0.985205, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}}
```

~~~As far as I see, the `assign_list` parameter in `walk_parts` is never used in a call, so I didn't test the code there with the new changes; maybe this is some preparatory code for a feature to come but not there yet?~~~ **EDIT** assign_list is used and works now.

This PR seems to give improvements in other areas as well:

[wp-before.txt](https://github.com/mathics/Mathics/files/488896/wp-before.txt)

[wp-after.txt](https://github.com/mathics/Mathics/files/488895/wp-after.txt)

