### PR TITLE
Faster TerminalOutput

### DIFF
--- a/mathics/main.py
+++ b/mathics/main.py
@@ -177,6 +177,9 @@ class TerminalShell(LineFeeder):
 
 
 class TerminalOutput(Output):
+    def max_stored_size(self, settings):
+        return None
+
     def __init__(self, shell):
         self.shell = shell
 


### PR DESCRIPTION
This sets `max_stored_size` to return `None`, so the check for pickle size that runs at the end of each evaluation in `Evaluation.get_stored_result()` will not be invoked, which saves time.