### PR TITLE
Adds a cache for do_format

### DIFF
--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -522,7 +522,7 @@ class Expression(BaseExpression):
         self.head = head
         self.leaves = [from_python(leaf) for leaf in leaves]
         self._sequences = None
-        self._cache = None
+        self._format_cache = None
         return self
 
     def sequences(self):
@@ -573,27 +573,18 @@ class Expression(BaseExpression):
             expr.options = self.options
         return expr
 
-    def _cached(self, evaluation, key, f):
-        cache = self._cache
+    def do_format(self, evaluation, form):
+        if self._format_cache is None:
+            self._format_cache = {}
 
-        if cache is None:
-            cache = {}
-            self._cache = cache
-        else:
-            last_evaluated, expr = cache.get(key, (None, None))
+        last_evaluated, expr = self._format_cache.get(form, (None, None))
+        if last_evaluated is not None and evaluation.definitions.last_changed(self) <= last_evaluated:
+            return expr
 
-            if last_evaluated is not None and evaluation.definitions.last_changed(self) <= last_evaluated:
-                return expr
-
-        expr = f()
-        cache[key] = (evaluation.definitions.now, expr)
+        expr = super(Expression, self).do_format(evaluation, form)
+        self._format_cache[form] = (evaluation.definitions.now, expr)
 
         return expr
-
-    def do_format(self, evaluation, form):
-        return self._cached(
-            evaluation, ('do_format', form),
-            lambda: super(Expression, self).do_format(evaluation, form))
 
     def copy(self):
         result = Expression(
@@ -602,7 +593,7 @@ class Expression(BaseExpression):
         result.options = self.options
         result.original = self
         # result.last_evaluated = self.last_evaluated
-        result._cache = self._cache
+        result._format_cache = self._format_cache
         return result
 
     def shallow_copy(self):
@@ -613,7 +604,7 @@ class Expression(BaseExpression):
         expr._sequences = self._sequences
         expr.options = self.options
         expr.last_evaluated = self.last_evaluated
-        expr._cache = self._cache
+        expr._format_cache = self._format_cache
         return expr
 
     def set_positions(self, position=None):

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -604,7 +604,6 @@ class Expression(BaseExpression):
         expr._sequences = self._sequences
         expr.options = self.options
         expr.last_evaluated = self.last_evaluated
-        expr._format_cache = self._format_cache
         return expr
 
     def set_positions(self, position=None):


### PR DESCRIPTION
Outputting parts of a list recomputes the format for everything each time an output happens.

Thus, outputting `x=Partition[Range[10000], 5]`, `x`, `Drop[x]` always calls `do_format` on each node of the whole tree.

For XML data of a few KB `do_format` alone takes 1 to 2 s on my machine.

This PR caches `do_format` for trees and sub trees that were already output once. This depends on https://github.com/mathics/Mathics/pull/575 as without it, a whole tree traversal is needed to check the cache, which invalidates the benefit.
