### PR TITLE
Update of $OutputSizeLimit

### DIFF
--- a/mathics/builtin/evaluation.py
+++ b/mathics/builtin/evaluation.py
@@ -408,10 +408,10 @@ class OutputSizeLimit(Predefined):
 
     >> $OutputSizeLimit = 100;
     >> Table[i, {i, 1, 100}]
-     = {1, 2, 3, 4, 5, <<91>>, 97, 98, 99, 100}
+     = {1, 2, 3, 4, 5, <<90>>, 96, 97, 98, 99, 100}
     >> $OutputSizeLimit = 10;
     >> Table[i, {i, 1, 100}]
-     = {1, <<99>>}
+     = {1, <<98>>, 100}
     >> $OutputSizeLimit = Infinity;
     """
 

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -1775,7 +1775,9 @@ class MathMLForm(Builtin):
 
         boxes = MakeBoxes(expr).evaluate(evaluation)
         try:
-            xml = boxes.boxes_to_xml(evaluation=evaluation, output_size_limit=evaluation.output_size_limit)
+            xml = boxes.boxes_to_xml(
+                evaluation=evaluation,
+                output_size_limit=evaluation.boxes_strategy.capacity())
         except BoxError:
             evaluation.message(
                 'General', 'notboxes',
@@ -1811,7 +1813,9 @@ class TeXForm(Builtin):
 
         boxes = MakeBoxes(expr).evaluate(evaluation)
         try:
-            tex = boxes.boxes_to_tex(evaluation=evaluation, output_size_limit=evaluation.output_size_limit)
+            tex = boxes.boxes_to_tex(
+                evaluation=evaluation,
+                output_size_limit=evaluation.boxes_strategy.capacity())
 
             # Replace multiple newlines by a single one e.g. between asy-blocks
             tex = MULTI_NEWLINE_RE.sub('\n', tex)

--- a/mathics/core/evaluation.py
+++ b/mathics/core/evaluation.py
@@ -14,24 +14,12 @@ from threading import Thread
 import itertools
 
 from mathics import settings
-from mathics.core.expression import ensure_context, KeyComparable
+from mathics.core.expression import ensure_context, KeyComparable, make_boxes_strategy
 
 FORMATS = ['StandardForm', 'FullForm', 'TraditionalForm',
            'OutputForm', 'InputForm',
            'TeXForm', 'MathMLForm',
            'MatrixForm', 'TableForm']
-
-
-def _interleave(*gens):  # interleaves over n generators of even or uneven lengths
-    active = [gen for gen in gens]
-    while len(active) > 0:
-        i = 0
-        while i < len(active):
-            try:
-                yield next(active[i])
-                i += 1
-            except StopIteration:
-                del active[i]
 
 
 class EvaluationInterrupt(Exception):
@@ -190,7 +178,7 @@ class Evaluation(object):
 
         self.quiet_all = False
         self.format = format
-        self.output_size_limit = None
+        self.boxes_strategy = make_boxes_strategy(None, self)
         self.catch_interrupt = catch_interrupt
 
     def parse(self, query):
@@ -335,9 +323,11 @@ class Evaluation(object):
 
         from mathics.core.expression import Expression, BoxError
 
-        orig_output_size_limit = self.output_size_limit
+        old_boxes_strategy = self.boxes_strategy
         try:
-            self.output_size_limit = self.definitions.get_config_value('System`$OutputSizeLimit')
+            capacity = self.definitions.get_config_value('System`$OutputSizeLimit')
+            self.boxes_strategy = make_boxes_strategy(capacity, self)
+
             options = {}
 
             if format == 'text':
@@ -347,7 +337,7 @@ class Evaluation(object):
                 # which must, in these cases, not apply additional clipping, as this would clip
                 # already clipped string material. for OutputForm, on the other hand, the call to
                 # result.boxes_to_text is the only place we have to apply output size limits.
-                options['output_size_limit'] = self.output_size_limit
+                options['output_size_limit'] = capacity
             elif format == 'xml':
                 result = Expression(
                     'StandardForm', expr).format(self, 'System`MathMLForm')
@@ -364,7 +354,7 @@ class Evaluation(object):
                              Expression('FullForm', result).evaluate(self))
                 boxes = None
         finally:
-            self.output_size_limit = orig_output_size_limit
+            self.boxes_strategy = old_boxes_strategy
 
         return boxes
 
@@ -386,64 +376,7 @@ class Evaluation(object):
         return value.leaves
 
     def make_boxes(self, items, form, segment=None):
-        from mathics.core.expression import Expression, Omitted
-
-        if self.output_size_limit is None or len(items) < 1:
-            if segment is not None:
-                segment.extend((False, 0, 0))
-            return [Expression('MakeBoxes', item, form) for item in items]
-
-        old_capacity = self.output_size_limit
-        capacity = old_capacity
-
-        left_leaves = []
-        right_leaves = []
-
-        middle = len(items) // 2
-        # note that we use generator expressions, not list comprehensions, here, since we
-        # might quit early in the loop below, and copying all leaves might prove inefficient.
-        from_left = ((leaf, left_leaves.append) for leaf in items[:middle])
-        from_right = ((leaf, right_leaves.append) for leaf in reversed(items[middle:]))
-
-        try:
-            for item, push in _interleave(from_left, from_right):
-                self.output_size_limit = capacity
-
-                # calling evaluate() here is a serious difference to the implementation
-                # without $OutputSizeLimit. here, we evaluate MakeBoxes bottom up, i.e.
-                # the leaves get evaluated first, since we need to estimate their size
-                # here.
-                #
-                # without $OutputSizeLimit, on the other hand, the expression
-                # gets evaluates from the top down, i.e. first MakeBoxes is wrapped around
-                # each expression, then we call evaluate on the root node. assuming that
-                # there are no rules like MakeBoxes[x_, MakeBoxes[y_]], both approaches
-                # should be identical.
-                #
-                # we could work around this difference by pushing the unevaluated
-                # expression here (see "push(box)" below), instead of the evaluated.
-                # this would be very inefficient though, since we would get quadratic
-                # runtime (quadratic in the depth of the tree).
-                box = Expression('MakeBoxes', item, form).evaluate(self)
-
-                cost = len(box.boxes_to_xml(evaluation=self))  # evaluate len as XML
-                if capacity < cost:
-                    break
-                capacity -= cost
-                push(box)
-        finally:
-            self.output_size_limit = old_capacity
-
-        ellipsis_size = len(items) - (len(left_leaves) + len(right_leaves))
-        ellipsis = [Omitted('<<%d>>' % ellipsis_size)] if ellipsis_size > 0 else []
-
-        if segment is not None:
-            if ellipsis_size > 0:
-                segment.extend((True, len(left_leaves), len(items) - len(right_leaves)))
-            else:
-                segment.extend((False, 0, 0))
-
-        return list(itertools.chain(left_leaves, ellipsis, reversed(right_leaves)))
+        return self.boxes_strategy.make(items, form, segment)
 
     def message(self, symbol, tag, *args):
         from mathics.core.expression import (String, Symbol, Expression,


### PR DESCRIPTION
This is a cleaned up, faster and better version of `$OutputSizeLimit`.

It now lives in its own class based on `_MakeBoxesStrategy` and makes the state more clean by using a dedicated class `_LimitedMakeBoxesState `. The whole code is now in `expression.py` to avoid the ugly in procedure imports needed for `Expression` until now.

There are two functional differences from the current code:

(1) The very first and the very last elements in a tree are now always output; e.g. `Nest[Partition[#, 2]&, Range[2 ^7], 7]` now yields `{{{{{{{{1, <<1>>}, <<1>>}, <<1>>}, <<1>>}, <<1>>}, <<1>>}, {<<1>>, {<<1>>, {<<1>>, {<<1>>, {<<1>>, {<<1>>, 128}}}}}}}}` (it yields a lame `{<<1>>}` with the current implementation).
(2) Every output that has been calculated using `MakeBoxes` is now always output and never thrown away.

(2) is a relaxation from the strict limit given by `$OutputSizeLimit`. The effect of this is a big speedup, since it no longer retries different parts of the expression to fit the remaining capacity, but simply outputs one and then stops. Try setting `x=Nest[Partition[#, 2]&, Range[2 ^10], 10]` and then outputting `x` several times; the current code is very sluggish (> 2s on my machine), this new code is fast (<.5 s).