### PR TITLE
Option to use sans serif fonts for MathML

### DIFF
--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -1783,6 +1783,8 @@ class MathMLForm(Builtin):
             xml = ''
         # mathml = '<math><mstyle displaystyle="true">%s</mstyle></math>' % xml
         # #convert_box(boxes)
+        if True:  # configuration to be defined
+            xml = '<mstyle mathvariant="sans-serif">%s</mstyle>' % xml
         mathml = '<math>%s</math>' % xml  # convert_box(boxes)
         return Expression('RowBox', Expression('List', String(mathml)))
 

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -658,7 +658,7 @@ class GridBox(BoxConstruct):
      = \begin{array}{cc} a & b\\ c & d\end{array}
 
     #> MathMLForm[TableForm[{{a,b},{c,d}}]]
-     = <math><mstyle mathvariant="..."><mtable columnalign="center">
+     = <math display="block"><mstyle mathvariant="..."><mtable columnalign="center">
      . <mtr><mtd columnalign="center"><mi>a</mi></mtd><mtd columnalign="center"><mi>b</mi></mtd></mtr>
      . <mtr><mtd columnalign="center"><mi>c</mi></mtd><mtd columnalign="center"><mi>d</mi></mtd></mtr>
      . </mtable></mstyle></math>
@@ -1753,18 +1753,18 @@ class MathMLForm(Builtin):
     </dl>
 
     >> MathMLForm[HoldForm[Sqrt[a^3]]]
-     = <math><mstyle mathvariant="..."><msqrt><msup><mi>a</mi> <mn>3</mn></msup></msqrt></mstyle></math>
+     = <math display="block"><mstyle mathvariant="..."><msqrt><msup><mi>a</mi> <mn>3</mn></msup></msqrt></mstyle></math>
 
     ## Test cases for Unicode
     #> MathMLForm[\\[Mu]]
-     = <math><mstyle mathvariant="..."><mi>\u03bc</mi></mstyle></math>
+     = <math display="block"><mstyle mathvariant="..."><mi>\u03bc</mi></mstyle></math>
 
     #> MathMLForm[Graphics[Text["\u03bc"]]]
-     = <math><mstyle mathvariant="..."><mglyph width="..." height="..." src="data:image/svg+xml;base64,..."/></mstyle></math>
+     = <math display="block"><mstyle mathvariant="..."><mglyph width="..." height="..." src="data:image/svg+xml;base64,..."/></mstyle></math>
 
     ## The <mo> should contain U+2062 INVISIBLE TIMES
     #> MathMLForm[MatrixForm[{{2*a, 0},{0,0}}]]
-     = <math><mstyle mathvariant="..."><mrow><mo>(</mo> <mtable columnalign="center">
+     = <math display="block"><mstyle mathvariant="..."><mrow><mo>(</mo> <mtable columnalign="center">
      . <mtr><mtd columnalign="center"><mrow><mn>2</mn> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mi>a</mi></mrow></mtd><mtd columnalign="center"><mn>0</mn></mtd></mtr>
      . <mtr><mtd columnalign="center"><mn>0</mn></mtd><mtd columnalign="center"><mn>0</mn></mtd></mtr>
      . </mtable> <mo>)</mo></mrow></mstyle></math>
@@ -1785,7 +1785,7 @@ class MathMLForm(Builtin):
         # #convert_box(boxes)
         if True:  # configuration to be defined
             xml = '<mstyle mathvariant="sans-serif">%s</mstyle>' % xml
-        mathml = '<math>%s</math>' % xml  # convert_box(boxes)
+        mathml = '<math display="block">%s</math>' % xml  # convert_box(boxes)
         return Expression('RowBox', Expression('List', String(mathml)))
 
 

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -658,10 +658,10 @@ class GridBox(BoxConstruct):
      = \begin{array}{cc} a & b\\ c & d\end{array}
 
     #> MathMLForm[TableForm[{{a,b},{c,d}}]]
-     = <math><mtable columnalign="center">
+     = <math><mstyle mathvariant="..."><mtable columnalign="center">
      . <mtr><mtd columnalign="center"><mi>a</mi></mtd><mtd columnalign="center"><mi>b</mi></mtd></mtr>
      . <mtr><mtd columnalign="center"><mi>c</mi></mtd><mtd columnalign="center"><mi>d</mi></mtd></mtr>
-     . </mtable></math>
+     . </mtable></mstyle></math>
     """
 
     options = {
@@ -1753,21 +1753,21 @@ class MathMLForm(Builtin):
     </dl>
 
     >> MathMLForm[HoldForm[Sqrt[a^3]]]
-     = <math><msqrt><msup><mi>a</mi> <mn>3</mn></msup></msqrt></math>
+     = <math><mstyle mathvariant="..."><msqrt><msup><mi>a</mi> <mn>3</mn></msup></msqrt></mstyle></math>
 
     ## Test cases for Unicode
     #> MathMLForm[\\[Mu]]
-     = <math><mi>\u03bc</mi></math>
+     = <math><mstyle mathvariant="..."><mi>\u03bc</mi></mstyle></math>
 
     #> MathMLForm[Graphics[Text["\u03bc"]]]
-     = <math><mglyph width="..." height="..." src="data:image/svg+xml;base64,..."/></math>
+     = <math><mstyle mathvariant="..."><mglyph width="..." height="..." src="data:image/svg+xml;base64,..."/></mstyle></math>
 
     ## The <mo> should contain U+2062 INVISIBLE TIMES
     #> MathMLForm[MatrixForm[{{2*a, 0},{0,0}}]]
-     = <math><mrow><mo>(</mo> <mtable columnalign="center">
+     = <math><mstyle mathvariant="..."><mrow><mo>(</mo> <mtable columnalign="center">
      . <mtr><mtd columnalign="center"><mrow><mn>2</mn> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mi>a</mi></mrow></mtd><mtd columnalign="center"><mn>0</mn></mtd></mtr>
      . <mtr><mtd columnalign="center"><mn>0</mn></mtd><mtd columnalign="center"><mn>0</mn></mtd></mtr>
-     . </mtable> <mo>)</mo></mrow></math>
+     . </mtable> <mo>)</mo></mrow></mstyle></math>
     """
 
     def apply_mathml(self, expr, evaluation):

--- a/mathics/doc/documentation/1-Manual.mdoc
+++ b/mathics/doc/documentation/1-Manual.mdoc
@@ -710,14 +710,14 @@ You can cause a much bigger mess by overriding 'MakeBoxes' than by sticking to '
  = <not closed
 However, this will not affect formatting of expressions involving 'c':
 >> c + 1 // MathMLForm
- = <math><mrow><mn>1</mn> <mo>+</mo> <mi>c</mi></mrow></math>
+ = <math><mstyle mathvariant="..."><mrow><mn>1</mn> <mo>+</mo> <mi>c</mi></mrow></mstyle></math>
 That\'s because 'MathMLForm' will, when not overridden for a special case, call 'StandardForm' first.
 'Format' will produce escaped output:
 >> Format[d, MathMLForm] = "<not closed";
 >> d // MathMLForm
- = <math><mtext>&lt;not&nbsp;closed</mtext></math>
+ = <math><mstyle mathvariant="..."><mtext>&lt;not&nbsp;closed</mtext></mstyle></math>
 >> d + 1 // MathMLForm
- = <math><mrow><mn>1</mn> <mo>+</mo> <mtext>&lt;not&nbsp;closed</mtext></mrow></math>
+ = <math><mstyle mathvariant="..."><mrow><mn>1</mn> <mo>+</mo> <mtext>&lt;not&nbsp;closed</mtext></mrow></mstyle></math>
  
 For instance, you can override 'MakeBoxes' to format lists in a different way:
 >> MakeBoxes[{items___}, StandardForm] := RowBox[{"[", Sequence @@ Riffle[MakeBoxes /@ {items}, " "], "]"}]

--- a/mathics/doc/documentation/1-Manual.mdoc
+++ b/mathics/doc/documentation/1-Manual.mdoc
@@ -710,7 +710,7 @@ You can cause a much bigger mess by overriding 'MakeBoxes' than by sticking to '
  = <not closed
 However, this will not affect formatting of expressions involving 'c':
 >> c + 1 // MathMLForm
- = <math><mstyle mathvariant="..."><mrow><mn>1</mn> <mo>+</mo> <mi>c</mi></mrow></mstyle></math>
+ = <math display="block"><mstyle mathvariant="..."><mrow><mn>1</mn> <mo>+</mo> <mi>c</mi></mrow></mstyle></math>
 That\'s because 'MathMLForm' will, when not overridden for a special case, call 'StandardForm' first.
 'Format' will produce escaped output:
 >> Format[d, MathMLForm] = "<not closed";

--- a/mathics/doc/documentation/1-Manual.mdoc
+++ b/mathics/doc/documentation/1-Manual.mdoc
@@ -715,9 +715,9 @@ That\'s because 'MathMLForm' will, when not overridden for a special case, call 
 'Format' will produce escaped output:
 >> Format[d, MathMLForm] = "<not closed";
 >> d // MathMLForm
- = <math><mstyle mathvariant="..."><mtext>&lt;not&nbsp;closed</mtext></mstyle></math>
+ = <math display="block"><mstyle mathvariant="..."><mtext>&lt;not&nbsp;closed</mtext></mstyle></math>
 >> d + 1 // MathMLForm
- = <math><mstyle mathvariant="..."><mrow><mn>1</mn> <mo>+</mo> <mtext>&lt;not&nbsp;closed</mtext></mrow></mstyle></math>
+ = <math display="block"><mstyle mathvariant="..."><mrow><mn>1</mn> <mo>+</mo> <mtext>&lt;not&nbsp;closed</mtext></mrow></mstyle></math>
  
 For instance, you can override 'MakeBoxes' to format lists in a different way:
 >> MakeBoxes[{items___}, StandardForm] := RowBox[{"[", Sequence @@ Riffle[MakeBoxes /@ {items}, " "], "]"}]


### PR DESCRIPTION
I recently found that I like sans serif MathML fonts much better as they match the general Jupyter theme I use:

![jupyter1](https://cloud.githubusercontent.com/assets/11859538/18812701/8fd6ceec-82dc-11e6-8ae6-93150eb61531.png)
![jupyter2](https://cloud.githubusercontent.com/assets/11859538/18812703/939bcb9a-82dc-11e6-99b3-24a74b207205.png)

Maybe this is also interesting for https://github.com/mathics/Mathics/pull/574, as this seems to use sans serif fonts for the code input? Here's what it looks like in the non-spiffified `mathicsserver`:

![mathicsserver](https://cloud.githubusercontent.com/assets/11859538/18812706/bfcfbd48-82dc-11e6-9f1c-a41340207099.png)

I wonder where this should be configured;`settings.py` doesn't seem a good place to me.
