### PR TITLE
Fixes a crash with Module[]

### DIFF
--- a/mathics/builtin/assignment.py
+++ b/mathics/builtin/assignment.py
@@ -722,7 +722,7 @@ class Definition(Builtin):
             evaluation.check_stopped()
             if isinstance(rule, Rule):
                 r = rhs(rule.replace.replace_vars(
-                        {'System`Definition': Expression('HoldForm', Symbol('Definition'))}))
+                        {'System`Definition': Expression('HoldForm', Symbol('Definition'))}, evaluation))
                 lines.append(Expression('HoldForm', Expression(
                     up and 'UpSet' or 'Set', lhs(rule.pattern.expr), r)))
 

--- a/mathics/builtin/functional.py
+++ b/mathics/builtin/functional.py
@@ -88,7 +88,7 @@ class Function(PostfixOperator):
         else:
             vars = dict(list(zip((
                 var.get_name() for var in vars), args[:len(vars)])))
-            return body.replace_vars(vars)
+            return body.replace_vars(vars, evaluation)
 
 
 class Slot(Builtin):

--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -1219,7 +1219,7 @@ class Condition(BinaryOperator, PatternObject):
         # for new_vars, rest in self.pattern.match(expression, vars,
         # evaluation):
         def yield_match(new_vars, rest):
-            test_expr = self.test.replace_vars(new_vars)
+            test_expr = self.test.replace_vars(new_vars, evaluation)
             test_result = test_expr.evaluate(evaluation)
             if test_result.is_true():
                 yield_func(new_vars, rest)

--- a/mathics/builtin/scoping.py
+++ b/mathics/builtin/scoping.py
@@ -194,7 +194,7 @@ class Module(Builtin):
             if new_def is not None:
                 evaluation.definitions.set_ownvalue(new_name, new_def)
             replace[name] = Symbol(new_name)
-        new_expr = expr.replace_vars(replace, in_scoping=False)
+        new_expr = expr.replace_vars(replace, evaluation, in_scoping=False)
         result = new_expr.evaluate(evaluation)
         return result
 

--- a/mathics/builtin/scoping.py
+++ b/mathics/builtin/scoping.py
@@ -167,6 +167,10 @@ class Module(Builtin):
      = a
     >> Module[{a}, Block[{}, a]]
      = a$5
+
+    #> Module[{n = 3}, Module[{b = n * 5}, b * 7]]
+     = 105
+
     """
 
     attributes = ('HoldAll',)

--- a/mathics/core/convert.py
+++ b/mathics/core/convert.py
@@ -73,7 +73,7 @@ class SympyExpression(BasicSympy):
         old, new = from_sympy(old), from_sympy(new)
         old_name = old.get_name()
         if old_name:
-            new_expr = self.expr.replace_vars({old_name: new})
+            new_expr = self.expr.replace_vars({old_name: new}, None)
             return SympyExpression(new_expr)
         return self
 

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -1146,16 +1146,14 @@ class Expression(BaseExpression):
                 expr = Expression(head, *expr.leaves)
             return expr, new_applied[0]
 
-
-    def replace_vars(self, vars, options=None,
-                     in_scoping=True, in_function=True):
+    def replace_vars(self, vars, evaluation, options=None, in_scoping=True, in_function=True):
         from mathics.builtin.scoping import get_scoping_vars
 
         if not in_scoping:
             if (self.head.get_name() in ('System`Module', 'System`Block', 'System`With') and
                 len(self.leaves) > 0):  # nopep8
 
-                scoping_vars = set(name for name, new_def in get_scoping_vars(self.leaves[0]))
+                scoping_vars = set(name for name, new_def in get_scoping_vars(self.leaves[0], evaluation=evaluation))
                 """for var in new_vars:
                     if var in scoping_vars:
                         del new_vars[var]"""
@@ -1177,7 +1175,7 @@ class Expression(BaseExpression):
                     body = self.leaves[1]
                     replacement = {name: Symbol(name + '$') for name in func_params}
                     func_params = [Symbol(name + '$') for name in func_params]
-                    body = body.replace_vars(replacement, options, in_scoping)
+                    body = body.replace_vars(replacement, evaluation, options, in_scoping)
                     leaves = [Expression('List', *func_params), body] + \
                         self.leaves[2:]
 
@@ -1186,8 +1184,8 @@ class Expression(BaseExpression):
 
         return Expression(
             self.head.replace_vars(
-                vars, options=options, in_scoping=in_scoping),
-            *[leaf.replace_vars(vars, options=options, in_scoping=in_scoping)
+                vars, evaluation, options=options, in_scoping=in_scoping),
+            *[leaf.replace_vars(vars, evaluation, options=options, in_scoping=in_scoping)
               for leaf in leaves])
 
     def replace_slots(self, slots, evaluation):
@@ -1325,7 +1323,7 @@ class Atom(BaseExpression):
     def __repr__(self):
         return '<%s: %s>' % (self.get_atom_name(), self)
 
-    def replace_vars(self, vars, options=None, in_scoping=True):
+    def replace_vars(self, vars, evaluation, options=None, in_scoping=True):
         return self
 
     def replace_slots(self, slots, evaluation):
@@ -1424,7 +1422,7 @@ class Symbol(Atom):
     def same(self, other):
         return isinstance(other, Symbol) and self.name == other.name
 
-    def replace_vars(self, vars, options={}, in_scoping=True):
+    def replace_vars(self, vars, evaluation, options={}, in_scoping=True):
         assert all(fully_qualified_symbol_name(v) for v in vars)
         var = vars.get(self.name, None)
         if var is None:

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -89,7 +89,7 @@ class Rule(BaseRule):
         self.replace = replace
 
     def do_replace(self, vars, options, evaluation):
-        new = self.replace.replace_vars(vars)
+        new = self.replace.replace_vars(vars, evaluation)
         new.options = options
 
         # if options is a non-empty dict, we need to ensure reevaluation of the whole expression, since 'new' will


### PR DESCRIPTION
Without this PR, this code crashes Mathics:

```
test[x_] := Module[{n = 1 + x}, Module[{b = 2 * n}, b * 2]];
test[1]
```

The reason is that `replace_vars` loses its evaluation. This PR fixes this such that the expression above evaluates properly.
