### PR TITLE
OutputSizeLimit terminal enhancements 

### DIFF
--- a/mathics/builtin/evaluation.py
+++ b/mathics/builtin/evaluation.py
@@ -412,6 +412,8 @@ class OutputSizeLimit(Predefined):
     >> $OutputSizeLimit = 10;
     >> Table[i, {i, 1, 100}]
      = {1, <<98>>, 100}
+    #> {}
+     = {}
     >> $OutputSizeLimit = Infinity;
     """
 

--- a/mathics/builtin/evaluation.py
+++ b/mathics/builtin/evaluation.py
@@ -421,6 +421,3 @@ class OutputSizeLimit(Predefined):
     rules = {
         '$OutputSizeLimit': str(value),
     }
-
-    def evaluate(self, evaluation):
-        return Integer(self.value)

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -2409,6 +2409,7 @@ class _LimitedMakeBoxesStrategy(_MakeBoxesStrategy):
             delay_break = 0
 
         depth = state.depth
+
         sum_of_costs = 0
 
         for i, (item, push) in enumerate(_interleave(*from_sides)):
@@ -2465,11 +2466,11 @@ class _LimitedMakeBoxesStrategy(_MakeBoxesStrategy):
 
             box = Expression('MakeBoxes', item, form).evaluate(self._evaluation)
 
-            # estimate the cost of the output related to box. always calling boxes_to_xml here is
+            # estimate the cost of the output related to box. always calling boxes_to_text here is
             # the simple solution; the problem is that it's redundant, as for {{{a}, b}, c}, we'd
-            # call boxes_to_xml first on {a}, then on {{a}, b}, then on {{{a}, b}, c}. a good fix
+            # call boxes_to_text first on {a}, then on {{a}, b}, then on {{{a}, b}, c}. a good fix
             # is not simple though, so let's keep it this way for now.
-            cost = len(box.boxes_to_xml(evaluation=self._evaluation))  # evaluate len as XML
+            cost = len(box.boxes_to_text(evaluation=self._evaluation))
 
             return box, cost
         finally:

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -2379,7 +2379,7 @@ class _LimitedMakeBoxesStrategy(_MakeBoxesStrategy):
         capacity = state.capacity
 
         if capacity is None or len(items) < 1:
-            return self._unlimited(items, form, segment)
+            return self._unlimited.make(items, form, segment)
 
         left_leaves = []
         right_leaves = []


### PR DESCRIPTION
Cleans up `$OutputSizeLimit` and also uses `boxes_to_text` over `boxes_to_xml` when using the terminal interface. Fixes some problems I was having with #571.

On second thought I decided to just use `boxes_to_text` everywhere since otherwise images etc. get hidden.