### PR TITLE
Add parameter for evaluated expression

### DIFF
--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -1213,7 +1213,7 @@ class StringRepeat(Builtin):
 
     #> StringRepeat["x", 0]
      : A positive integer is expected at position 2 in StringRepeat[x, 0].
-     = StringRepeat["x", 0]
+     = StringRepeat[x, 0]
     """
 
     messages = {

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -1210,33 +1210,38 @@ class StringRepeat(Builtin):
 
     >> StringRepeat["abc", 10, 7]
      = abcabca
+
+    #> StringRepeat["x", 0]
+     : A positive integer is expected at position 2 in StringRepeat[x, 0].
+     = StringRepeat["x", 0]
     """
 
     messages = {
         'intp': 'A positive integer is expected at position `1` in `2`.',
     }
 
-    def apply(self, s, n, evaluation):
+    def apply(self, s, n, expression, evaluation):
         'StringRepeat[s_String, n_]'
         py_n = n.get_int_value() if isinstance(n, Integer) else 0
         if py_n < 1:
-            evaluation.message('StringRepeat', 'intp', 2, Expression('StringRepeat', s, n))
-        return String(s.get_string_value() * py_n)
+            evaluation.message('StringRepeat', 'intp', 2, expression)
+        else:
+            return String(s.get_string_value() * py_n)
 
-    def apply_truncated(self, s, n, m, evaluation):
+    def apply_truncated(self, s, n, m, expression, evaluation):
         'StringRepeat[s_String, n_Integer, m_Integer]'
         py_n = n.get_int_value() if isinstance(n, Integer) else 0
         py_m = m.get_int_value() if isinstance(m, Integer) else 0
 
         if py_n < 1:
-            evaluation.message('StringRepeat', 'intp', 2, Expression('StringRepeat', s, n, m))
-        if py_m < 1:
-            evaluation.message('StringRepeat', 'intp', 3, Expression('StringRepeat', s, n, m))
+            evaluation.message('StringRepeat', 'intp', 2, expression)
+        elif py_m < 1:
+            evaluation.message('StringRepeat', 'intp', 3, expression)
+        else:
+            py_s = s.get_string_value()
+            py_n = min(1 + py_m // len(py_s), py_n)
 
-        py_s = s.get_string_value()
-        py_n = min(1 + py_m // len(py_s), py_n)
-
-        return String((py_s * py_n)[:py_m])
+            return String((py_s * py_n)[:py_m])
 
 
 class Characters(Builtin):

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -7,7 +7,16 @@ from __future__ import absolute_import
 from mathics.core.expression import Expression, strip_context, KeyComparable
 from mathics.core.pattern import Pattern, StopGenerator
 
-from inspect import signature
+try:
+    from inspect import signature
+
+    def _function_arguments(f):
+        return signature(f).parameters.keys()
+except ImportError:  # python2, pypy
+    from inspect import getargspec
+
+    def _function_arguments(f):
+        return getargspec(f).args
 
 
 class StopGenerator_BaseRule(StopGenerator):
@@ -110,7 +119,7 @@ class BuiltinRule(BaseRule):
     def __init__(self, pattern, function, system=False):
         super(BuiltinRule, self).__init__(pattern, system=system)
         self.function = function
-        self.pass_expression = 'expression' in signature(function).parameters.keys()
+        self.pass_expression = 'expression' in _function_arguments(function)
 
     def do_replace(self, expression, vars, options, evaluation):
         # The Python function implementing this builtin expects

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -7,16 +7,7 @@ from __future__ import absolute_import
 from mathics.core.expression import Expression, strip_context, KeyComparable
 from mathics.core.pattern import Pattern, StopGenerator
 
-try:
-    from inspect import signature
-
-    def _function_arguments(f):
-        return signature(f).parameters.keys()
-except ImportError:  # python2, pypy
-    from inspect import getargspec
-
-    def _function_arguments(f):
-        return getargspec(f).args
+from mathics.core.util import function_arguments
 
 
 class StopGenerator_BaseRule(StopGenerator):
@@ -119,7 +110,7 @@ class BuiltinRule(BaseRule):
     def __init__(self, pattern, function, system=False):
         super(BuiltinRule, self).__init__(pattern, system=system)
         self.function = function
-        self.pass_expression = 'expression' in _function_arguments(function)
+        self.pass_expression = 'expression' in function_arguments(function)
 
     def do_replace(self, expression, vars, options, evaluation):
         # The Python function implementing this builtin expects


### PR DESCRIPTION
One recurring mini-grievance when writing `Builtin`s is to construct the input `Expression` when giving out error messages, which usually results in repeated fragments of code that looks something like this:

```
def apply(self, s, n, m, evaluation):
'StringRepeat[s_String, n_Integer, m_Integer]'
    ...
    evaluation.message('StringRepeat', 'intp', 2, Expression('StringRepeat', s, n, m))
```

This PR now allows `apply` functions to specify a new parameter `expression`. If it's in the function's argument list, it will contain the expression that is being evaluated at this point. With this, the code above changes to:

```
def apply(self, s, n, m, expression, evaluation):
'StringRepeat[s_String, n_Integer, m_Integer]'
    ...evaluation.message('StringRepeat', 'intp', 3, expression)
```

The `StringRepeat` example is already changed in this PR (with an added test case that checks that the new `expression` parameter gets passed with the right information).

The most complex part of this PR is the introduction of `function_arguments` to inspect a function's arguments to detect `expression`. This is simple to implement for >= Python 3.4, but for Python 3.3 and Python 2 a number of special cases crop up in the context of Cython.