### PR TITLE
revert $OutputSizeLimit

### DIFF
--- a/mathics/builtin/assignment.py
+++ b/mathics/builtin/assignment.py
@@ -172,13 +172,6 @@ class _SetOperator(object):
                 # TODO: Message
                 return False
             ignore_protection = True
-        elif lhs_name == 'System`$OutputSizeLimit':
-            if rhs.to_python() == float('inf'):
-                rhs = Symbol('System`Infinity')
-            elif rhs_int_value is None or rhs_int_value <= 0:
-                evaluation.message(lhs_name, 'intnn', rhs)
-                return False
-            ignore_protection = True
         elif lhs_name == 'System`$ModuleNumber':
             if not rhs_int_value or rhs_int_value <= 0:
                 evaluation.message('$ModuleNumber', 'set', rhs)

--- a/mathics/builtin/evaluation.py
+++ b/mathics/builtin/evaluation.py
@@ -392,35 +392,3 @@ class Out(Builtin):
         '    f:StandardForm|TraditionalForm|InputForm|OutputForm]':
         r'"%%" <> ToString[k]',
     }
-
-
-class OutputSizeLimit(Predefined):
-    """
-    <dl>
-    <dt>'$OutputSizeLimit'
-        <dd>specifies the maximum amount of data output that gets
-        displayed before the output gets truncated. The amount of
-        output is measured as the number of bytes of MathML XML
-        that has been generated to represent the output data.
-
-        To set no limit on output size, use $OutputSizeLimit = Infinity.
-    </dl>
-
-    >> $OutputSizeLimit = 100;
-    >> Table[i, {i, 1, 100}]
-     = {1, 2, 3, 4, 5, <<90>>, 96, 97, 98, 99, 100}
-    >> $OutputSizeLimit = 10;
-    >> Table[i, {i, 1, 100}]
-     = {1, <<98>>, 100}
-    >> $OutputSizeLimit = Infinity;
-    """
-
-    name = '$OutputSizeLimit'
-    value = 1000
-
-    rules = {
-        '$OutputSizeLimit': str(value),
-    }
-
-    def evaluate(self, evaluation):
-        return Integer(self.value)

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -21,10 +21,9 @@ from mathics.builtin.lists import list_boxes
 from mathics.builtin.options import options_to_rules
 from mathics.core.expression import (
     Expression, String, Symbol, Integer, Rational, Real, Complex, BoxError,
-    from_python, MachineReal, PrecisionReal, Omitted)
+    from_python, MachineReal, PrecisionReal)
 from mathics.core.numbers import (
     dps, prec, convert_base, machine_precision, reconstruct_digits)
-from mathics.builtin.lists import riffle
 
 MULTI_NEWLINE_RE = re.compile(r"\n{2,}")
 
@@ -81,22 +80,11 @@ def parenthesize(precedence, leaf, leaf_boxes, when_equal):
     return leaf_boxes
 
 
-def make_boxes_infix(leaves, ops, precedence, grouping, form, evaluation):
-    segment = []
-    boxes = evaluation.make_boxes(leaves, form, segment)
-
-    seg_shortened, seg_l, seg_r = segment
-    if seg_shortened:
-        leaves = leaves[:seg_l] + [Symbol('Null')] + leaves[seg_r:]
-        ops = ops[:seg_l] + ops[seg_r - 1:]  # ellipsis item gets rightmost operator from ellipsed chunk
-
+def make_boxes_infix(leaves, ops, precedence, grouping, form):
     result = []
-    for index, leaf_box in enumerate(zip(leaves, boxes)):
-        leaf, box = leaf_box
-
+    for index, leaf in enumerate(leaves):
         if index > 0:
             result.append(ops[index - 1])
-
         parenthesized = False
         if grouping == 'System`NonAssociative':
             parenthesized = True
@@ -105,10 +93,8 @@ def make_boxes_infix(leaves, ops, precedence, grouping, form, evaluation):
         elif grouping == 'System`Right' and index == 0:
             parenthesized = True
 
-        if seg_shortened and index == seg_l:
-            leaf = box  # ellipsis item, do not parenthesize
-        else:
-            leaf = parenthesize(precedence, leaf, box, parenthesized)
+        leaf_boxes = MakeBoxes(leaf, form)
+        leaf = parenthesize(precedence, leaf, leaf_boxes, parenthesized)
 
         result.append(leaf)
     return Expression('RowBox', Expression('List', *result))
@@ -316,6 +302,13 @@ def number_form(expr, n, f, evaluation, options):
 
 class MakeBoxes(Builtin):
     """
+    <dl>
+    <dt>'MakeBoxes[$expr$]'
+        <dd>is a low-level formatting primitive that converts $expr$
+        to box form, without evaluating it.
+    <dt>'\( ... \)'
+        <dd>directly inputs box objects.
+    </dl>
 
     String representation of boxes
     >> \(x \^ 2\)
@@ -486,13 +479,16 @@ class MakeBoxes(Builtin):
             result = [head_boxes, String(left)]
 
             if len(leaves) > 1:
+                row = []
                 if f_name in ('System`InputForm', 'System`OutputForm',
                               'System`FullForm'):
                     sep = ', '
                 else:
                     sep = ','
-                boxes = evaluation.make_boxes(leaves, f)
-                row = riffle(boxes, String(sep))
+                for index, leaf in enumerate(leaves):
+                    if index > 0:
+                        row.append(String(sep))
+                    row.append(MakeBoxes(leaf, f))
                 result.append(RowBox(Expression('List', *row)))
             elif len(leaves) == 1:
                 result.append(MakeBoxes(leaves[0], f))
@@ -563,7 +559,7 @@ class MakeBoxes(Builtin):
                 ops = [get_op(op) for op in h.leaves]
             else:
                 ops = [get_op(h)] * (len(leaves) - 1)
-            return make_boxes_infix(leaves, ops, precedence, grouping, f, evaluation)
+            return make_boxes_infix(leaves, ops, precedence, grouping, f)
         elif len(leaves) == 1:
             return MakeBoxes(leaves[0], f)
         else:
@@ -796,21 +792,13 @@ class Grid(Builtin):
         '''MakeBoxes[Grid[array_?MatrixQ, OptionsPattern[Grid]],
             f:StandardForm|TraditionalForm|OutputForm]'''
 
-        lengths = [len(row.leaves) for row in array.leaves]
-        segment = []
-        boxes = evaluation.make_boxes([item for row in array.leaves for item in row.leaves], f, segment)
-        if segment[0]:  # too long?
-            return Omitted('<<%d>>' % sum(lengths))
-        else:
-            rows = []
-            i = 0
-            for l in lengths:
-                rows.append(Expression('List', *boxes[i:i + l]))
-                i += l
-            return Expression(
-                'GridBox',
-                Expression('List', *rows),
-                *options_to_rules(options))
+        return Expression(
+            'GridBox',
+            Expression('List', *(
+                Expression('List', *(
+                    Expression('MakeBoxes', item, f) for item in row.leaves))
+                for row in array.leaves)),
+            *options_to_rules(options))
 
 
 class TableForm(Builtin):
@@ -963,7 +951,7 @@ class Subscript(Builtin):
 
         y = y.get_sequence()
         return Expression(
-            'SubscriptBox', Expression('MakeBoxes', x, f), *list_boxes(y, f, evaluation))
+            'SubscriptBox', Expression('MakeBoxes', x, f), *list_boxes(y, f))
 
 
 class SubscriptBox(Builtin):
@@ -1775,9 +1763,7 @@ class MathMLForm(Builtin):
 
         boxes = MakeBoxes(expr).evaluate(evaluation)
         try:
-            xml = boxes.boxes_to_xml(
-                evaluation=evaluation,
-                output_size_limit=evaluation.boxes_strategy.capacity())
+            xml = boxes.boxes_to_xml(evaluation=evaluation)
         except BoxError:
             evaluation.message(
                 'General', 'notboxes',
@@ -1813,9 +1799,7 @@ class TeXForm(Builtin):
 
         boxes = MakeBoxes(expr).evaluate(evaluation)
         try:
-            tex = boxes.boxes_to_tex(
-                evaluation=evaluation,
-                output_size_limit=evaluation.boxes_strategy.capacity())
+            tex = boxes.boxes_to_tex(evaluation=evaluation)
 
             # Replace multiple newlines by a single one e.g. between asy-blocks
             tex = MULTI_NEWLINE_RE.sub('\n', tex)

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -60,7 +60,7 @@ class List(Builtin):
 
         items = items.get_sequence()
         return Expression(
-            'RowBox', Expression('List', *list_boxes(items, f, evaluation, "{", "}")))
+            'RowBox', Expression('List', *list_boxes(items, f, "{", "}")))
 
 
 class ListQ(Test):
@@ -93,8 +93,8 @@ class NotListQ(Test):
         return expr.get_head_name() != 'System`List'
 
 
-def list_boxes(items, f, evaluation, open=None, close=None):
-    result = evaluation.make_boxes(items, f)
+def list_boxes(items, f, open=None, close=None):
+    result = [Expression('MakeBoxes', item, f) for item in items]
     if f.get_name() in ('System`OutputForm', 'System`InputForm'):
         sep = ", "
     else:
@@ -827,7 +827,7 @@ class Part(Builtin):
             open, close = "[[", "]]"
         else:
             open, close = "\u301a", "\u301b"
-        indices = list_boxes(i, f, evaluation, open, close)
+        indices = list_boxes(i, f, open, close)
         result = Expression('RowBox', Expression('List', list, *indices))
         return result
 

--- a/mathics/test.py
+++ b/mathics/test.py
@@ -14,7 +14,7 @@ import six
 from six.moves import zip
 
 import mathics
-from mathics.core.definitions import Definitions, Symbol
+from mathics.core.definitions import Definitions
 from mathics.core.evaluation import Evaluation, Output
 from mathics.core.parser import SingleLineFeeder
 from mathics.builtin import builtins
@@ -29,10 +29,6 @@ class TestOutput(Output):
     def max_stored_size(self, settings):
         return None
 
-
-def reset_user_definitions():
-    definitions.reset_user_definitions()
-    definitions.set_ownvalue('System`$OutputSizeLimit', Symbol('Infinity'))  # no limit
 
 sep = '-' * 70 + '\n'
 
@@ -107,7 +103,7 @@ def test_case(test, tests, index=0, quiet=False):
 
 
 def test_tests(tests, index, quiet=False, stop_on_failure=False, start_at=0):
-    reset_user_definitions()
+    definitions.reset_user_definitions()
     count = failed = skipped = 0
     failed_symbols = set()
     for test in tests.tests:
@@ -126,7 +122,7 @@ def test_tests(tests, index, quiet=False, stop_on_failure=False, start_at=0):
 
 def create_output(tests, output_xml, output_tex):
     for format, output in [('xml', output_xml), ('tex', output_tex)]:
-        reset_user_definitions()
+        definitions.reset_user_definitions()
         for test in tests.tests:
             key = test.key
             evaluation = Evaluation(definitions, format=format, catch_interrupt=False, output=TestOutput())


### PR DESCRIPTION
In the interest of getting 1.0 out I've decided to revert the `$OutputSizeLimit` changes introduced in #385 and #581. I'd like to add them back in eventually as it can really speed up large expressions (especially all the nice optimisations done by @poke1024).