### PR TITLE
Fix unicode decode problems

### DIFF
--- a/mathics/builtin/files.py
+++ b/mathics/builtin/files.py
@@ -662,7 +662,10 @@ class Read(Builtin):
             while True:
                 word = ''
                 while True:
-                    tmp = stream.read(1)
+                    try:
+                        tmp = stream.read(1)
+                    except UnicodeDecodeError:
+                        tmp = ' '  # ignore
 
                     if tmp == '':
                         if word == '':

--- a/mathics/builtin/files.py
+++ b/mathics/builtin/files.py
@@ -666,6 +666,7 @@ class Read(Builtin):
                         tmp = stream.read(1)
                     except UnicodeDecodeError:
                         tmp = ' '  # ignore
+                        evaluation.message('General', 'ucdec')
 
                     if tmp == '':
                         if word == '':

--- a/mathics/builtin/importexport.py
+++ b/mathics/builtin/importexport.py
@@ -456,6 +456,8 @@ class Import(Builtin):
      = {Data, Lines, Plaintext, String, Words}
     >> Import["ExampleData/ExampleData.txt", "Lines"]
      = ...
+    #> Import["ExampleData/Middlemarch.txt"];
+     : An invalid unicode sequence was encountered and ignored.
 
     ## JSON
     >> Import["ExampleData/colors.json"]

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -1619,6 +1619,7 @@ class General(Builtin):
                   "which is not a valid list of replacement rules."),
         'write': "Tag `1` in `2` is Protected.",
         'wrsym': "Symbol `1` is Protected.",
+        'ucdec': "An invalid unicode sequence was encountered and ignored.",
 
         # Self-defined messages
         # 'rep': "`1` is not a valid replacement rule.",

--- a/mathics/data/ExampleData/Middlemarch.txt
+++ b/mathics/data/ExampleData/Middlemarch.txt
@@ -1,0 +1,296 @@
+CHAPTER LXXV.
+
+    "Le sentiment de la fausseté des plaisirs présents, et
+    l'ignorance de la vanité des plaisirs absents causent
+    l'inconstance."--PASCAL.
+
+
+Rosamond had a gleam of returning cheerfulness when the house was freed
+from the threatening figure, and when all the disagreeable creditors
+were paid.  But she was not joyous: her married life had fulfilled none
+of her hopes, and had been quite spoiled for her imagination.  In this
+brief interval of calm, Lydgate, remembering that he had often been
+stormy in his hours of perturbation, and mindful of the pain Rosamond
+had had to bear, was carefully gentle towards her; but he, too, had
+lost some of his old spirit, and he still felt it necessary to refer to
+an economical change in their way of living as a matter of course,
+trying to reconcile her to it gradually, and repressing his anger when
+she answered by wishing that he would go to live in London.  When she
+did not make this answer, she listened languidly, and wondered what she
+had that was worth living for.  The hard and contemptuous words which
+had fallen from her husband in his anger had deeply offended that
+vanity which he had at first called into active enjoyment; and what she
+regarded as his perverse way of looking at things, kept up a secret
+repulsion, which made her receive all his tenderness as a poor
+substitute for the happiness he had failed to give her.  They were at a
+disadvantage with their neighbors, and there was no longer any outlook
+towards Quallingham--there was no outlook anywhere except in an
+occasional letter from Will Ladislaw.  She had felt stung and
+disappointed by Will's resolution to quit Middlemarch, for in spite of
+what she knew and guessed about his admiration for Dorothea, she
+secretly cherished the belief that he had, or would necessarily come to
+have, much more admiration for herself; Rosamond being one of those
+women who live much in the idea that each man they meet would have
+preferred them if the preference had not been hopeless.  Mrs. Casaubon
+was all very well; but Will's interest in her dated before he knew Mrs.
+Lydgate.  Rosamond took his way of talking to herself, which was a
+mixture of playful fault-finding and hyperbolical gallantry, as the
+disguise of a deeper feeling; and in his presence she felt that
+agreeable titillation of vanity and sense of romantic drama which
+Lydgate's presence had no longer the magic to create.  She even
+fancied--what will not men and women fancy in these matters?--that
+Will exaggerated his admiration for Mrs. Casaubon in order to pique
+herself.  In this way poor Rosamond's brain had been busy before Will's
+departure.  He would have made, she thought, a much more suitable
+husband for her than she had found in Lydgate.  No notion could have
+been falser than this, for Rosamond's discontent in her marriage was
+due to the conditions of marriage itself, to its demand for
+self-suppression and tolerance, and not to the nature of her husband;
+but the easy conception of an unreal Better had a sentimental charm
+which diverted her ennui.  She constructed a little romance which was
+to vary the flatness of her life: Will Ladislaw was always to be a
+bachelor and live near her, always to be at her command, and have an
+understood though never fully expressed passion for her, which would be
+sending out lambent flames every now and then in interesting scenes.
+His departure had been a proportionate disappointment, and had sadly
+increased her weariness of Middlemarch; but at first she had the
+alternative dream of pleasures in store from her intercourse with the
+family at Quallingham.  Since then the troubles of her married life had
+deepened, and the absence of other relief encouraged her regretful
+rumination over that thin romance which she had once fed on.  Men and
+women make sad mistakes about their own symptoms, taking their vague
+uneasy longings, sometimes for genius, sometimes for religion, and
+oftener still for a mighty love.  Will Ladislaw had written chatty
+letters, half to her and half to Lydgate, and she had replied: their
+separation, she felt, was not likely to be final, and the change she
+now most longed for was that Lydgate should go to live in London;
+everything would be agreeable in London; and she had set to work with
+quiet determination to win this result, when there came a sudden,
+delightful promise which inspirited her.
+
+It came shortly before the memorable meeting at the town-hall, and was
+nothing less than a letter from Will Ladislaw to Lydgate, which turned
+indeed chiefly on his new interest in plans of colonization, but
+mentioned incidentally, that he might find it necessary to pay a visit
+to Middlemarch within the next few weeks--a very pleasant necessity, he
+said, almost as good as holidays to a schoolboy.  He hoped there was
+his old place on the rug, and a great deal of music in store for him.
+But he was quite uncertain as to the time.  While Lydgate was reading
+the letter to Rosamond, her face looked like a reviving flower--it grew
+prettier and more blooming.  There was nothing unendurable now: the
+debts were paid, Mr. Ladislaw was coming, and Lydgate would be
+persuaded to leave Middlemarch and settle in London, which was "so
+different from a provincial town."
+
+That was a bright bit of morning.  But soon the sky became black over
+poor Rosamond.  The presence of a new gloom in her husband, about which
+he was entirely reserved towards her--for he dreaded to expose his
+lacerated feeling to her neutrality and misconception--soon received a
+painfully strange explanation, alien to all her previous notions of
+what could affect her happiness.  In the new gayety of her spirits,
+thinking that Lydgate had merely a worse fit of moodiness than usual,
+causing him to leave her remarks unanswered, and evidently to keep out
+of her way as much as possible, she chose, a few days after the
+meeting, and without speaking to him on the subject, to send out notes
+of invitation for a small evening party, feeling convinced that this
+was a judicious step, since people seemed to have been keeping aloof
+from them, and wanted restoring to the old habit of intercourse.  When
+the invitations had been accepted, she would tell Lydgate, and give him
+a wise admonition as to how a medical man should behave to his
+neighbors; for Rosamond had the gravest little airs possible about
+other people's duties.  But all the invitations were declined, and the
+last answer came into Lydgate's hands.
+
+"This is Chichely's scratch.  What is he writing to you about?" said
+Lydgate, wonderingly, as he handed the note to her.  She was obliged to
+let him see it, and, looking at her severely, he said--
+
+"Why on earth have you been sending out invitations without telling me,
+Rosamond?  I beg, I insist that you will not invite any one to this
+house.  I suppose you have been inviting others, and they have refused
+too."  She said nothing.
+
+"Do you hear me?" thundered Lydgate.
+
+"Yes, certainly I hear you," said Rosamond, turning her head aside with
+the movement of a graceful long-necked bird.
+
+Lydgate tossed his head without any grace and walked out of the room,
+feeling himself dangerous.  Rosamond's thought was, that he was getting
+more and more unbearable--not that there was any new special reason for
+this peremptoriness.  His indisposition to tell her anything in which
+he was sure beforehand that she would not be interested was growing
+into an unreflecting habit, and she was in ignorance of everything
+connected with the thousand pounds except that the loan had come from
+her uncle Bulstrode.  Lydgate's odious humors and their neighbors'
+apparent avoidance of them had an unaccountable date for her in their
+relief from money difficulties.  If the invitations had been accepted
+she would have gone to invite her mamma and the rest, whom she had seen
+nothing of for several days; and she now put on her bonnet to go and
+inquire what had become of them all, suddenly feeling as if there were
+a conspiracy to leave her in isolation with a husband disposed to
+offend everybody.  It was after the dinner hour, and she found her
+father and mother seated together alone in the drawing-room. They
+greeted her with sad looks, saying "Well, my dear!" and no more.  She
+had never seen her father look so downcast; and seating herself near
+him she said--
+
+"Is there anything the matter, papa?"
+
+He did not answer, but Mrs. Vincy said, "Oh, my dear, have you heard
+nothing?  It won't be long before it reaches you."
+
+"Is it anything about Tertius?" said Rosamond, turning pale.  The idea
+of trouble immediately connected itself with what had been
+unaccountable to her in him.
+
+"Oh, my dear, yes.  To think of your marrying into this trouble.  Debt
+was bad enough, but this will be worse."
+
+"Stay, stay, Lucy," said Mr. Vincy.  "Have you heard nothing about your
+uncle Bulstrode, Rosamond?"
+
+"No, papa," said the poor thing, feeling as if trouble were not
+anything she had before experienced, but some invisible power with an
+iron grasp that made her soul faint within her.
+
+Her father told her everything, saying at the end, "It's better for you
+to know, my dear.  I think Lydgate must leave the town.  Things have
+gone against him.  I dare say he couldn't help it.  I don't accuse him
+of any harm," said Mr. Vincy.  He had always before been disposed to
+find the utmost fault with Lydgate.
+
+The shock to Rosamond was terrible.  It seemed to her that no lot could
+be so cruelly hard as hers to have married a man who had become the
+centre of infamous suspicions.  In many cases it is inevitable that the
+shame is felt to be the worst part of crime; and it would have required
+a great deal of disentangling reflection, such as had never entered
+into Rosamond's life, for her in these moments to feel that her trouble
+was less than if her husband had been certainly known to have done
+something criminal.  All the shame seemed to be there.  And she had
+innocently married this man with the belief that he and his family were
+a glory to her!  She showed her usual reticence to her parents, and
+only said, that if Lydgate had done as she wished he would have left
+Middlemarch long ago.
+
+"She bears it beyond anything," said her mother when she was gone.
+
+"Ah, thank God!" said Mr. Vincy, who was much broken down.
+
+But Rosamond went home with a sense of justified repugnance towards her
+husband.  What had he really done--how had he really acted?  She did
+not know.  Why had he not told her everything?  He did not speak to her
+on the subject, and of course she could not speak to him.  It came into
+her mind once that she would ask her father to let her go home again;
+but dwelling on that prospect made it seem utter dreariness to her: a
+married woman gone back to live with her parents--life seemed to have
+no meaning for her in such a position: she could not contemplate
+herself in it.
+
+The next two days Lydgate observed a change in her, and believed that
+she had heard the bad news.  Would she speak to him about it, or would
+she go on forever in the silence which seemed to imply that she
+believed him guilty?  We must remember that he was in a morbid state of
+mind, in which almost all contact was pain.  Certainly Rosamond in this
+case had equal reason to complain of reserve and want of confidence on
+his part; but in the bitterness of his soul he excused himself;--was
+he not justified in shrinking from the task of telling her, since now
+she knew the truth she had no impulse to speak to him?  But a
+deeper-lying consciousness that he was in fault made him restless, and
+the silence between them became intolerable to him; it was as if they
+were both adrift on one piece of wreck and looked away from each other.
+
+He thought, "I am a fool.  Haven't I given up expecting anything?  I
+have married care, not help."  And that evening he said--
+
+"Rosamond, have you heard anything that distresses you?"
+
+"Yes," she answered, laying down her work, which she had been carrying
+on with a languid semi-consciousness, most unlike her usual self.
+
+"What have you heard?"
+
+"Everything, I suppose.  Papa told me."
+
+"That people think me disgraced?"
+
+"Yes," said Rosamond, faintly, beginning to sew again automatically.
+
+There was silence.  Lydgate thought, "If she has any trust in me--any
+notion of what I am, she ought to speak now and say that she does not
+believe I have deserved disgrace."
+
+But Rosamond on her side went on moving her fingers languidly.
+Whatever was to be said on the subject she expected to come from
+Tertius.  What did she know?  And if he were innocent of any wrong, why
+did he not do something to clear himself?
+
+This silence of hers brought a new rush of gall to that bitter mood in
+which Lydgate had been saying to himself that nobody believed in
+him--even Farebrother had not come forward.  He had begun to question
+her with the intent that their conversation should disperse the chill
+fog which had gathered between them, but he felt his resolution checked
+by despairing resentment.  Even this trouble, like the rest, she seemed
+to regard as if it were hers alone.  He was always to her a being
+apart, doing what she objected to.  He started from his chair with an
+angry impulse, and thrusting his hands in his pockets, walked up and
+down the room.  There was an underlying consciousness all the while
+that he should have to master this anger, and tell her everything, and
+convince her of the facts.  For he had almost learned the lesson that
+he must bend himself to her nature, and that because she came short in
+her sympathy, he must give the more.  Soon he recurred to his intention
+of opening himself: the occasion must not be lost.  If he could bring
+her to feel with some solemnity that here was a slander which must be
+met and not run away from, and that the whole trouble had come out of
+his desperate want of money, it would be a moment for urging powerfully
+on her that they should be one in the resolve to do with as little
+money as possible, so that they might weather the bad time and keep
+themselves independent.  He would mention the definite measures which
+he desired to take, and win her to a willing spirit.  He was bound to
+try this--and what else was there for him to do?
+
+He did not know how long he had been walking uneasily backwards and
+forwards, but Rosamond felt that it was long, and wished that he would
+sit down.  She too had begun to think this an opportunity for urging on
+Tertius what he ought to do.  Whatever might be the truth about all
+this misery, there was one dread which asserted itself.
+
+Lydgate at last seated himself, not in his usual chair, but in one
+nearer to Rosamond, leaning aside in it towards her, and looking at her
+gravely before he reopened the sad subject.  He had conquered himself
+so far, and was about to speak with a sense of solemnity, as on an
+occasion which was not to be repeated.  He had even opened his lips,
+when Rosamond, letting her hands fall, looked at him and said--
+
+"Surely, Tertius--"
+
+"Well?"
+
+"Surely now at last you have given up the idea of staying in
+Middlemarch.  I cannot go on living here.  Let us go to London.  Papa,
+and every one else, says you had better go.  Whatever misery I have to
+put up with, it will be easier away from here."
+
+Lydgate felt miserably jarred.  Instead of that critical outpouring for
+which he had prepared himself with effort, here was the old round to be
+gone through again.  He could not bear it.  With a quick change of
+countenance he rose and went out of the room.
+
+Perhaps if he had been strong enough to persist in his determination to
+be the more because she was less, that evening might have had a better
+issue.  If his energy could have borne down that check, he might still
+have wrought on Rosamond's vision and will.  We cannot be sure that any
+natures, however inflexible or peculiar, will resist this effect from a
+more massive being than their own.  They may be taken by storm and for
+the moment converted, becoming part of the soul which enwraps them in
+the ardor of its movement.  But poor Lydgate had a throbbing pain
+within him, and his energy had fallen short of its task.
+
+The beginning of mutual understanding and resolve seemed as far off as
+ever; nay, it seemed blocked out by the sense of unsuccessful effort.
+They lived on from day to day with their thoughts still apart, Lydgate
+going about what work he had in a mood of despair, and Rosamond
+feeling, with some justification, that he was behaving cruelly.  It was
+of no use to say anything to Tertius; but when Will Ladislaw came, she
+was determined to tell him everything.  In spite of her general
+reticence, she needed some one who would recognize her wrongs.

--- a/mathics/data/ExampleData/copyright.csv
+++ b/mathics/data/ExampleData/copyright.csv
@@ -13,3 +13,4 @@ colors.json	GNU Free Documentation License 1.2	Own Work	Created Manually By Angu
 Testosterone.svg	Public Domain	http://en.wikipedia.org/wiki/File:Testosteron.svg	Taken from http://en.wikipedia.org/wiki/Testosterone on 2013/03/03
 InventionNo1.xml	GNU Free Documentation License	http://openmusicscore.org/index.php?option=com_content&view=article&id=125:invention-no-1-bwv-772-bach-johann-sebastian&catid=84&Itemid=531
 Namespaces.xml	CC BY-NC-SA License	http://edutechwiki.unige.ch/en/XML_namespace	"A larger example of namespace scoping" with comments removed
+Middlemarch.txt The Project Gutenberg License   https://archive.org/details/middlemarch00145gut Chapter 75 of George Eliot's novel Middlemarch in ISO Latin 1 (8859-1) encoding


### PR DESCRIPTION
Using `Import` on a text file with wrong unicode sequences currently crashes Mathics. This works around the problem, allowing the file to be imported with the problematic characters being replaced by whitespace.