### PR TITLE
Faster Partition[]

### DIFF
--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -874,12 +874,12 @@ class Partition(Builtin):
     def apply_no_overlap(self, l, n, evaluation):
         'Partition[l_List, n_Integer]'
         # TODO: Error checking
-        return Expression('List', *list(l.partition(n.get_int_value(), n.get_int_value())))
+        return l.restructure('List', list(l.partition(n.get_int_value(), n.get_int_value())))
 
     def apply(self, l, n, d, evaluation):
         'Partition[l_List, n_Integer, d_Integer]'
         # TODO: Error checking
-        return Expression('List', *list(l.partition(n.get_int_value(), d.get_int_value())))
+        return l.restructure('List', list(l.partition(n.get_int_value(), d.get_int_value())))
 
 
 class Extract(Builtin):

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -19,6 +19,7 @@ from mathics.builtin.scoping import dynamic_scoping
 from mathics.builtin.base import MessageException, NegativeIntegerException, CountableInteger
 from mathics.core.expression import Expression, String, Symbol, Integer, Number, Real, strip_context, from_python
 from mathics.core.expression import min_prec, machine_precision
+from mathics.core.expression import Structure
 from mathics.core.evaluation import BreakInterrupt, ContinueInterrupt, ReturnInterrupt
 from mathics.core.rules import Pattern
 from mathics.core.convert import from_sympy
@@ -871,15 +872,36 @@ class Partition(Builtin):
         'Parition[list_, n_, d_, k]': 'Partition[list, n, d, {k, k}]',
     }
 
+    def _partition(self, expr, n, d, evaluation):
+        assert n > 0 and d > 0
+
+        inner = Structure('List', expr, evaluation)
+        outer = Structure('List', inner, evaluation)
+
+        make_slice = inner.from_slice
+
+        def slices():
+            leaves = expr.leaves
+            for lower in range(0, len(leaves), d):
+                upper = lower + n
+
+                chunk = leaves[lower:upper]
+                if len(chunk) != n:
+                    continue
+
+                yield make_slice(expr, lower, upper)
+
+        return outer.from_leaves(list(slices()))
+
     def apply_no_overlap(self, l, n, evaluation):
         'Partition[l_List, n_Integer]'
         # TODO: Error checking
-        return l.restructure('List', list(l.partition(n.get_int_value(), n.get_int_value())))
+        return self._partition(l, n.get_int_value(), n.get_int_value(), evaluation)
 
     def apply(self, l, n, d, evaluation):
         'Partition[l_List, n_Integer, d_Integer]'
         # TODO: Error checking
-        return l.restructure('List', list(l.partition(n.get_int_value(), d.get_int_value())))
+        return self._partition(l, n.get_int_value(), d.get_int_value(), evaluation)
 
 
 class Extract(Builtin):
@@ -975,6 +997,11 @@ class Most(Builtin):
     >> Most[x]
      : Nonatomic expression expected.
      = Most[x]
+
+    #> A[x__] := 7 /; Length[{x}] == 3;
+    #> Most[A[1, 2, 3, 4]]
+     = 7
+    #> ClearAll[A];
     """
 
     def apply(self, expr, evaluation):
@@ -983,7 +1010,7 @@ class Most(Builtin):
         if expr.is_atom():
             evaluation.message('Most', 'normal')
             return
-        return expr.restructure(expr.head, expr.leaves[:-1])
+        return expr.slice(0, -1, evaluation)
 
 
 class Rest(Builtin):
@@ -1010,7 +1037,7 @@ class Rest(Builtin):
         if expr.is_atom():
             evaluation.message('Rest', 'normal')
             return
-        return expr.restructure(expr.head, expr.leaves[1:])
+        return expr.slice(1, len(expr.leaves), evaluation)
 
 
 class ReplacePart(Builtin):
@@ -1275,18 +1302,20 @@ class Select(Builtin):
      = Select[a, True]
     """
 
-    def apply(self, list, expr, evaluation):
-        'Select[list_, expr_]'
+    def apply(self, items, expr, evaluation):
+        'Select[items_, expr_]'
 
-        if list.is_atom():
+        if items.is_atom():
             evaluation.message('Select', 'normal')
             return
-        new_leaves = []
-        for leaf in list.leaves:
-            test = Expression(expr, leaf)
-            if test.evaluate(evaluation).is_true():
-                new_leaves.append(leaf)
-        return Expression(list.head, *new_leaves)
+
+        def leaves():
+            for leaf in items.leaves:
+                test = Expression(expr, leaf)
+                if test.evaluate(evaluation).is_true():
+                    yield leaf
+
+        return Structure(items.head, items, evaluation).from_leaves(list(leaves()))
 
 
 class Split(Builtin):
@@ -1337,19 +1366,22 @@ class Split(Builtin):
             evaluation.message('Select', 'normal', 1, expr)
             return
 
-        if len(mlist.leaves) == 0:
-            result = []
-        else:
-            result = [[mlist.leaves[0]]]
-            for leaf in mlist.leaves[1:]:
-                applytest = Expression(test, result[-1][-1], leaf)
-                if applytest.evaluate(evaluation).is_true():
-                    result[-1].append(leaf)
-                else:
-                    result.append([leaf])
+        if not mlist.leaves:
+            return Expression(mlist.head)
 
-        return Expression(mlist.head, *[Expression('List', *l)
-                                        for l in result])
+        result = [[mlist.leaves[0]]]
+        for leaf in mlist.leaves[1:]:
+            applytest = Expression(test, result[-1][-1], leaf)
+            if applytest.evaluate(evaluation).is_true():
+                result[-1].append(leaf)
+            else:
+                result.append([leaf])
+
+        inner = Structure('List', mlist, evaluation)
+        outer = Structure(mlist.head, inner, evaluation)
+
+        make_inner = inner.from_leaves
+        return outer.from_leaves([make_inner(l) for l in result])
 
 
 class SplitBy(Builtin):
@@ -1436,13 +1468,13 @@ class Pick(Builtin):
      = {a, b, d}
     """
 
-    def _do(self, items0, sel0, match):
+    def _do(self, items0, sel0, match, evaluation):
         def pick(items, sel):
             for x, s in zip(items, sel):
                 if match(s):
                     yield x
                 elif not x.is_atom() and not s.is_atom():
-                    yield Expression(x.get_head(), *list(pick(x.leaves, s.leaves)))
+                    yield Structure(x.get_head(), x, evaluation).from_leaves(list(pick(x.leaves, s.leaves)))
 
         r = list(pick([items0], [sel0]))
         if not r:
@@ -1452,13 +1484,13 @@ class Pick(Builtin):
 
     def apply(self, items, sel, evaluation):
         'Pick[items_, sel_]'
-        return self._do(items, sel, lambda s: s.is_true())
+        return self._do(items, sel, lambda s: s.is_true(), evaluation)
 
     def apply_pattern(self, items, sel, pattern, evaluation):
         'Pick[items_, sel_, pattern_]'
         from mathics.builtin.patterns import Matcher
         match = Matcher(pattern).match
-        return self._do(items, sel, lambda s: match(s, evaluation))
+        return self._do(items, sel, lambda s: match(s, evaluation), evaluation)
 
 
 class Cases(Builtin):
@@ -1568,7 +1600,13 @@ class DeleteCases(Builtin):
 
         from mathics.builtin.patterns import Matcher
         match = Matcher(pattern).match
-        return Expression('List', *[leaf for leaf in items.leaves if not match(leaf, evaluation)])
+
+        def indices():
+            for index, leaf in enumerate(items.leaves):
+                if not match(leaf, evaluation):
+                    yield index
+
+        return items.pick('List', indices(), evaluation)
 
 
 class Count(Builtin):
@@ -2055,7 +2093,9 @@ class Join(Builtin):
 
         result = []
         head = None
-        for list in lists.get_sequence():
+        sequence = lists.get_sequence()
+
+        for list in sequence:
             if list.is_atom():
                 return
             if head is not None and list.get_head() != head:
@@ -2065,7 +2105,7 @@ class Join(Builtin):
             result.extend(list.leaves)
 
         if result:
-            return Expression(head, *result)
+            return Structure(head, sequence, evaluation).from_leaves(result)
         else:
             return Expression('List')
 
@@ -2130,8 +2170,7 @@ class Append(Builtin):
         if expr.is_atom():
             return evaluation.message('Append', 'normal')
 
-        return Expression(expr.get_head(),
-                          *(expr.get_leaves() + [item]))
+        return Structure(expr.get_head(), (expr, item), evaluation).from_leaves(expr.get_leaves() + [item])
 
 
 class AppendTo(Builtin):
@@ -3073,20 +3112,25 @@ class Reverse(Builtin):
     }
 
     @staticmethod
-    def _reverse(expr, level, levels):  # depth >= 1, levels are expected to be unique and sorted
+    def _reverse(expr, level, levels, evaluation):  # depth >= 1, levels are expected to be unique and sorted
         if not isinstance(expr, Expression):
             return expr
+
         if levels[0] == level:
-            new_leaves = reversed(expr.leaves)
+            expr = Structure(expr.head, expr, evaluation).from_leaves(reversed(expr.leaves))
+
             if len(levels) > 1:
-                new_leaves = (Reverse._reverse(leaf, level + 1, levels[1:]) for leaf in new_leaves)
+                expr = Structure(expr.head, expr, evaluation).from_leaves(
+                    [Reverse._reverse(leaf, level + 1, levels[1:], evaluation) for leaf in expr.leaves])
         else:
-            new_leaves = (Reverse._reverse(leaf, level + 1, levels) for leaf in expr.leaves)
-        return Expression(expr.get_head(), *new_leaves)
+            expr = Structure(expr.head, expr, evaluation).from_leaves(
+                [Reverse._reverse(leaf, level + 1, levels, evaluation) for leaf in expr.leaves])
+
+        return expr
 
     def apply_top_level(self, expr, evaluation):
         'Reverse[expr_]'
-        return Reverse._reverse(expr, 1, (1,))
+        return Reverse._reverse(expr, 1, (1,), evaluation)
 
     def apply(self, expr, levels, evaluation):
         'Reverse[expr_, levels_]'
@@ -3107,7 +3151,7 @@ class Reverse(Builtin):
         if py_levels is None:
             evaluation.message('Reverse', 'ilsmp', Expression('Reverse', expr, levels))
         else:
-            return Reverse._reverse(expr, 1, py_levels)
+            return Reverse._reverse(expr, 1, py_levels, evaluation)
 
 
 class CentralMoment(Builtin):  # see https://en.wikipedia.org/wiki/Central_moment
@@ -3364,7 +3408,7 @@ class _Rotate(Builtin):
         'rspec': '`` should be an integer or a list of integers.'
     }
 
-    def _rotate(self, expr, n):
+    def _rotate(self, expr, n, evaluation):
         if not isinstance(expr, Expression):
             return expr
 
@@ -3376,13 +3420,13 @@ class _Rotate(Builtin):
         new_leaves = chain(leaves[index:], leaves[:index])
 
         if len(n) > 1:
-            new_leaves = [self._rotate(item, n[1:]) for item in new_leaves]
+            new_leaves = [self._rotate(item, n[1:], evaluation) for item in new_leaves]
 
-        return Expression(expr.get_head(), *new_leaves)
+        return Structure(expr.get_head(), expr, evaluation).from_leaves(new_leaves)
 
     def apply_one(self, expr, evaluation):
         '%(name)s[expr_]'
-        return self._rotate(expr, [1])
+        return self._rotate(expr, [1], evaluation)
 
     def apply(self, expr, n, evaluation):
         '%(name)s[expr_, n_]'
@@ -3396,7 +3440,7 @@ class _Rotate(Builtin):
             evaluation.message(self.get_name(), 'rspec', n)
             return
 
-        return self._rotate(expr, py_cycles)
+        return self._rotate(expr, py_cycles, evaluation)
 
 
 class RotateLeft(_Rotate):
@@ -3720,7 +3764,7 @@ class _RankedTake(Builtin):
             else:
                 result = self._get_n(py_n, heap)
 
-            return Expression('List', *[x[leaf_pos] for x in result])
+            return Structure('List', l, evaluation).from_leaves([x[leaf_pos] for x in result])
 
 
 class _RankedTakeSmallest(_RankedTake):
@@ -4551,6 +4595,8 @@ class Permutations(Builtin):
         if rs is None:
             rs = range(py_n + 1)
 
-        return Expression('List', *[Expression('List', *p)
-                                    for r in rs
-                                    for p in permutations(l.leaves, r)])
+        inner = Structure('List', l, evaluation)
+        outer = Structure('List', inner, evaluation)
+
+        make_inner = inner.from_leaves
+        return outer.from_leaves([make_inner(p) for r in rs for p in permutations(l.leaves, r)])

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -983,7 +983,7 @@ class Most(Builtin):
         if expr.is_atom():
             evaluation.message('Most', 'normal')
             return
-        return Expression(expr.head, *expr.leaves[:-1])
+        return expr.restructure(expr.head, expr.leaves[:-1])
 
 
 class Rest(Builtin):
@@ -1010,7 +1010,7 @@ class Rest(Builtin):
         if expr.is_atom():
             evaluation.message('Rest', 'normal')
             return
-        return Expression(expr.head, *expr.leaves[1:])
+        return expr.restructure(expr.head, expr.leaves[1:])
 
 
 class ReplacePart(Builtin):

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -871,21 +871,15 @@ class Partition(Builtin):
         'Parition[list_, n_, d_, k]': 'Partition[list, n, d, {k, k}]',
     }
 
-    def chunks(self, l, n, d):
-        assert n > 0 and d > 0
-        return [x for x in [l[i:i + n] for i in range(0, len(l), d)] if len(x) == n]
-
     def apply_no_overlap(self, l, n, evaluation):
         'Partition[l_List, n_Integer]'
         # TODO: Error checking
-        return Expression('List', *self.chunks(
-            l.get_leaves(), n.get_int_value(), n.get_int_value()))
+        return Expression('List', *list(l.partition(n.get_int_value(), n.get_int_value())))
 
     def apply(self, l, n, d, evaluation):
         'Partition[l_List, n_Integer, d_Integer]'
         # TODO: Error checking
-        return Expression('List', *self.chunks(
-            l.get_leaves(), n.get_int_value(), d.get_int_value()))
+        return Expression('List', *list(l.partition(n.get_int_value(), d.get_int_value())))
 
 
 class Extract(Builtin):

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -2294,40 +2294,57 @@ def print_parenthesizes(precedence, outer_precedence=None,
             outer_precedence == precedence and parenthesize_when_equal)))
 
 
-class Structure:  # Select?
+def _is_safe_head(head, cache, evaluation):
+    if not isinstance(head, Symbol):
+        return False
+
+    head_name = head.get_name()
+
+    if cache:
+        r = cache.get(head_name)
+        if r is not None:
+            return r
+
+    definitions = evaluation.definitions
+
+    definition = definitions.get_definition(head_name, only_if_exists=True)
+    if definition is None:
+        r = True
+    else:
+        r = all(len(definition.get_values_list(x)) == 0 for x in ('up', 'sub', 'down', 'own'))
+
+    if cache:
+        cache[head_name] = r
+
+    return r
+
+
+class Structure:
     # performance test case: x = Range[50000]; First[Timing[Partition[x, 15, 1]]]
 
-    def __init__(self, head, orig, evaluation):
+    def __init__(self, head, orig, evaluation, cache=None):
         if isinstance(head, six.string_types):
             head = Symbol(head)
         self.head = head
 
-        if isinstance(head, Symbol):
-            definitions = evaluation.definitions
-
-            definition = definitions.get_definition(head.get_name(), only_if_exists=True)
-            if definition is None:
-                safe = True
-            else:
-                safe = all(len(definition.get_values_list(x)) == 0 for x in ('up', 'sub', 'down', 'own'))
-        else:
-            safe = False
-
-        if safe:  # no definitions for head
-            if isinstance(orig, (list, tuple)):
+        if isinstance(orig, (Expression, Structure)):
+            last_evaluated = orig.last_evaluated
+            if last_evaluated is not None and not _is_safe_head(head, cache, evaluation):
+                last_evaluated = None
+        elif isinstance(orig, (list, tuple)):
+            if _is_safe_head(head, cache, evaluation):
+                definitions = evaluation.definitions
                 last_evaluated = definitions.now
                 for expr in orig:
                     if expr.last_evaluated is None or definitions.last_changed(expr) > expr.last_evaluated:
                         last_evaluated = None
                         break
-            elif isinstance(orig, (Expression, Structure)):
-                last_evaluated = orig.last_evaluated
             else:
-                raise ValueError('expected Expression, Structure, tuple or list as orig param')
-
-            self.last_evaluated = last_evaluated
+                last_evaluated = None
         else:
-            self.last_evaluated = None
+            raise ValueError('expected Expression, Structure, tuple or list as orig param')
+
+        self.last_evaluated = last_evaluated
 
     def from_leaves(self, leaves):
         # IMPORTANT: caller guarantees that leaves originate from orig.leaves or its sub trees!

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -525,6 +525,13 @@ class Expression(BaseExpression):
         self._sequences = None
         return self
 
+    def restructure(self, head, leaves):
+        # NOTE: leaves must originate from self.leaves or its sub trees!
+        expr = Expression(head)
+        expr.leaves = leaves
+        expr.last_evaluated = self.last_evaluated
+        return expr
+
     def partition(self, n, d):
         assert n > 0 and d > 0
 
@@ -534,7 +541,7 @@ class Expression(BaseExpression):
         # (O3) if self has been evaluated, there's no need to
         # reevaluate any partition of self.
 
-        # performance test case: First[Timing[Partition[Range[50000], 15, 1]]]
+        # performance test case: x = Range[50000]; First[Timing[Partition[x, 15, 1]]]
 
         leaves = self.leaves
         head = Symbol('List')
@@ -550,10 +557,8 @@ class Expression(BaseExpression):
             a = bisect_left(seq, lower)  # all(val >= i for val in seq[a:])
             b = bisect_left(seq, upper)  # all(val >= j for val in seq[b:])
 
-            expr = Expression(head)  # (O1)
-            expr.leaves = chunk  # (O1)
+            expr = self.restructure(head, chunk)  # (O1), (O3)
             expr._sequences = tuple(x - lower for x in seq[a:b])  # (O2)
-            expr.last_evaluated = self.last_evaluated  # (O3)
 
             yield expr
 

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -526,12 +526,24 @@ class Expression(BaseExpression):
         return self
 
     def slice(self, head, py_slice, evaluation):
+        # faster equivalent to: Expression(head, *self.leaves[py_slice])
         return Structure(head, self, evaluation).slice(self, py_slice)
 
     def filter(self, head, cond, evaluation):
+        # faster equivalent to: Expression(head, [leaf in self.leaves if cond(leaf)])
         return Structure(head, self, evaluation).filter(self, cond)
 
     def restructure(self, head, leaves, evaluation, cache=None, deps=None):
+        # faster equivalent to: Expression(head, *leaves)
+
+        # the caller guarantees that _all_ elements in leaves are either from
+        # self.leaves (or its sub trees) or from one of the expression given
+        # in the tuple "deps" (or its sub trees).
+
+        # if this method is called repeatedly, and the caller guarantees
+        # that no definitions change between subsequent calls, then cache
+        # may be passed an initially empty dict to speed up calls.
+
         if deps is None:
             deps = self
         s = Structure(head, deps, evaluation, cache=cache)

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -525,8 +525,23 @@ class Expression(BaseExpression):
         self._sequences = None
         return self
 
-    def slice(self, lower, upper, evaluation):
-        return Structure(self.head, self, evaluation).from_slice(self, lower, upper)
+    def slice(self, lower, upper, evaluation, head=None):
+        if head is None:
+            head = self.head
+        return Structure(head, self, evaluation).slice(self, lower, upper)
+
+    def filter(self, cond, evaluation, head=None):
+        if head is None:
+            head = self.head
+        return Structure(head, self, evaluation).filter(self, cond)
+
+    def restructure(self, leaves, evaluation, head=None, cache=None, deps=None):
+        if head is None:
+            head = self.head
+        if deps is None:
+            deps = self
+        s = Structure(head, deps, evaluation, cache=cache)
+        return s(list(leaves))
 
     def sequences(self):
         seq = self._sequences
@@ -2346,7 +2361,7 @@ class Structure:
 
         self.last_evaluated = last_evaluated
 
-    def from_leaves(self, leaves):
+    def __call__(self, leaves):  # create from leaves
         # IMPORTANT: caller guarantees that leaves originate from orig.leaves or its sub trees!
 
         expr = Expression(self.head)
@@ -2354,16 +2369,16 @@ class Structure:
         expr.last_evaluated = self.last_evaluated
         return expr
 
-    def from_condition(self, expr, cond):
+    def filter(self, expr, cond):
         # IMPORTANT: caller guarantees that expr is from origins!
-        return self.from_leaves([leaf for leaf in expr.leaves if cond(leaf)])
+        return self([leaf for leaf in expr.leaves if cond(leaf)])
 
-    def from_slice(self, expr, lower, upper):
+    def slice(self, expr, lower, upper):
         # IMPORTANT: caller guarantees that expr is from origins!
 
         leaves = expr.leaves
         lower, upper, _ = slice(lower, upper).indices(len(leaves))
-        expr = self.from_leaves(leaves[lower:upper])
+        expr = self(leaves[lower:upper])
 
         seq = expr._sequences
         if seq:


### PR DESCRIPTION
Speeds up Partition[] by a factor 2 (using `First[Timing[Partition[Range[50000], 15, 1]]]`, goes from roughly 14s to 7s). If merged together with https://github.com/mathics/Mathics/pull/575, it's a factor 8, as it then the `last_evaluated` optimization really works).