### PR TITLE
Speedups by avoiding inner classes

### DIFF
--- a/mathics/builtin/combinatorial.py
+++ b/mathics/builtin/combinatorial.py
@@ -102,11 +102,13 @@ class Multinomial(Builtin):
         return result
 
 
+class _NoBoolVector(Exception):
+    pass
+
+
 class _BooleanDissimilarity(Builtin):
     @staticmethod
     def _to_bool_vector(u):
-        class NoBoolVector(Exception):
-            pass
 
         def generate():
             for leaf in u.leaves:
@@ -115,7 +117,7 @@ class _BooleanDissimilarity(Builtin):
                     if val in (0, 1):
                         yield val
                     else:
-                        raise NoBoolVector
+                        raise _NoBoolVector
                 elif isinstance(leaf, Symbol):
                     name = leaf.name
                     if name == 'System`True':
@@ -123,13 +125,13 @@ class _BooleanDissimilarity(Builtin):
                     elif name == 'System`False':
                         yield 0
                     else:
-                        raise NoBoolVector
+                        raise _NoBoolVector
                 else:
-                    raise NoBoolVector
+                    raise _NoBoolVector
 
         try:
             return [x for x in generate()]
-        except NoBoolVector:
+        except _NoBoolVector:
             return None
 
     def apply(self, u, v, evaluation):

--- a/mathics/builtin/exptrig.py
+++ b/mathics/builtin/exptrig.py
@@ -1025,6 +1025,10 @@ class AnglePathFold(Fold):
             yield x, y, phi
 
 
+class _IllegalStepSpecification(Exception):
+    pass
+
+
 class AnglePath(Builtin):
     """
     <dl>
@@ -1072,28 +1076,25 @@ class AnglePath(Builtin):
         if not steps:
             return Expression('List')
 
-        class IllegalStepSpecification(Exception):
-            pass
-
         if steps[0].get_head_name() == 'System`List':
             def parse(step):
                 if step.get_head_name() != 'System`List':
-                    raise IllegalStepSpecification
+                    raise _IllegalStepSpecification
                 arguments = step.leaves
                 if len(arguments) != 2:
-                    raise IllegalStepSpecification
+                    raise _IllegalStepSpecification
                 return arguments
         else:
             def parse(step):
                 if step.get_head_name() == 'System`List':
-                    raise IllegalStepSpecification
+                    raise _IllegalStepSpecification
                 return None, step
 
         try:
             fold = AnglePathFold(parse)
             leaves = [Expression('List', x, y) for x, y, _ in fold.fold((x0, y0, phi0), steps)]
             return Expression('List', *leaves)
-        except IllegalStepSpecification:
+        except _IllegalStepSpecification:
             evaluation.message('AnglePath', 'steps', Expression('List', *steps))
 
     def apply(self, steps, evaluation):

--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -1340,19 +1340,19 @@ class _StopGeneratorBaseExpressionIsFree(StopGenerator):
     pass
 
 
-def is_free(expr, form, evaluation):
+def item_is_free(item, form, evaluation):
     # for vars, rest in form.match(self, {}, evaluation, fully=False):
     def yield_match(vars, rest):
         raise _StopGeneratorBaseExpressionIsFree(False)
         # return False
 
     try:
-        form.match(yield_match, expr, {}, evaluation, fully=False)
+        form.match(yield_match, item, {}, evaluation, fully=False)
     except _StopGeneratorBaseExpressionIsFree as exc:
         return exc.value
 
-    if expr.is_atom():
+    if item.is_atom():
         return True
     else:
-        return expr.head.is_free(form, evaluation) and all(
-            leaf.is_free(form, evaluation) for leaf in expr.leaves)
+        return item_is_free(item.head, form, evaluation) and all(
+            item_is_free(leaf, form, evaluation) for leaf in item.leaves)

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -1592,6 +1592,10 @@ class ToCharacterCode(Builtin):
         return from_python(codes)
 
 
+class _InvalidCodepointError(ValueError):
+    pass
+
+
 class FromCharacterCode(Builtin):
     """
     <dl>
@@ -1667,9 +1671,6 @@ class FromCharacterCode(Builtin):
         "FromCharacterCode[n_]"
         exp = Expression('FromCharacterCode', n)
 
-        class InvalidCodepointError(ValueError):
-            pass
-
         def convert_codepoint_list(l, encoding=None):
             if encoding is not None:
                 raise NotImplementedError
@@ -1681,7 +1682,7 @@ class FromCharacterCode(Builtin):
                     evaluation.message(
                         'FromCharacterCode', 'notunicode',
                         Expression('List', *l), Integer(i + 1))
-                    raise InvalidCodepointError
+                    raise _InvalidCodepointError
                 s += unichr(pyni)
 
             return s
@@ -1710,7 +1711,7 @@ class FromCharacterCode(Builtin):
                     return evaluation.message(
                         'FromCharacterCode', 'intnm', exp, Integer(1))
                 return String(convert_codepoint_list([n]))
-        except InvalidCodepointError:
+        except _InvalidCodepointError:
             return
 
         assert False, "can't get here"

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -312,24 +312,8 @@ class BaseExpression(KeyComparable):
         return result
 
     def is_free(self, form, evaluation):
-        from mathics.core.pattern import StopGenerator
-
-        class StopGenerator_BaseExpression_is_free(StopGenerator):
-            pass
-
-        # for vars, rest in form.match(self, {}, evaluation, fully=False):
-        def yield_match(vars, rest):
-            raise StopGenerator_BaseExpression_is_free(False)
-            # return False
-        try:
-            form.match(yield_match, self, {}, evaluation, fully=False)
-        except StopGenerator_BaseExpression_is_free as exc:
-            return exc.value
-        if self.is_atom():
-            return True
-        else:
-            return self.head.is_free(form, evaluation) and all(
-                leaf.is_free(form, evaluation) for leaf in self.leaves)
+        from mathics.builtin.patterns import item_is_free
+        return item_is_free(self, form, evaluation)
 
     def is_inexact(self):
         return self.get_precision() is not None


### PR DESCRIPTION
Turns out that, at least in CPython, declaring `class`es inside functions is quite slow.

Running `x = Range[50000]; First[Timing[Position[x, 10000]]]` without this PR gives `1.16326`, with this PR, it gives `0.461211`. This is only due to one inner `class` definition.

Running the profiler, one actually sees Python's class build function popping up. So this PR moves inner classes out of functions at several places.

