### PR TITLE
Information

### DIFF
--- a/mathics/builtin/assignment.py
+++ b/mathics/builtin/assignment.py
@@ -2,12 +2,13 @@
 # -*- coding: utf-8 -*-
 
 
-
+import mathics.builtin
 from mathics.builtin.base import (
     Builtin, BinaryOperator, PostfixOperator, PrefixOperator)
 from mathics.core.expression import (Expression, Symbol, valid_context_name,
-                                     system_symbols)
-from mathics.core.rules import Rule
+                                     system_symbols, String)
+from mathics.core.rules import Rule, BuiltinRule
+from mathics.builtin.patterns import RuleDelayed
 from mathics.builtin.lists import walk_parts
 from mathics.core.evaluation import MAX_RECURSION_DEPTH, set_python_recursion_limit
 
@@ -707,6 +708,7 @@ class Definition(Builtin):
     """
 
     attributes = ('HoldAll',)
+    precedence = 670
 
     def format_definition(self, symbol, evaluation, grid=True):
         'StandardForm,TraditionalForm,OutputForm: Definition[symbol_]'
@@ -787,8 +789,199 @@ class Definition(Builtin):
 
     def format_definition_input(self, symbol, evaluation):
         'InputForm: Definition[symbol_]'
-
         return self.format_definition(symbol, evaluation, grid=False)
+
+
+def _get_usage_string(symbol, evaluation, htmlout=False):
+    '''
+    Returns a python string with the documentation associated to a given symbol.
+    '''
+    builtins = mathics.builtin.builtins
+    # from mathics.builtin import builtins
+
+    definition = evaluation.definitions.get_definition(symbol.name)
+    ruleusage = definition.get_values_list('messages')
+    usagetext = None
+    import re
+    bio = builtins.get(definition.name)
+
+    if bio is not None:
+        from mathics.doc.doc import Doc
+        if htmlout:
+            usagetext = Doc(bio.__class__.__doc__).text(0)
+        else:
+            usagetext = Doc(bio.__class__.__doc__).text(0)
+        usagetext = re.sub(r'\$([0-9a-zA-Z]*)\$', r'\1', usagetext)
+
+    # Looks for the "usage" message. For built-in symbols, if there is an "usage" chain, overwrite the __doc__ information.
+    for rulemsg in ruleusage:
+        if rulemsg.pattern.expr.leaves[1].__str__() == "\"usage\"":
+            usagetext = rulemsg.replace.value
+    return usagetext
+
+
+class Information(PrefixOperator):
+    """
+    <dl>
+    <dt>'Information[$symbol$]'
+        <dd>Prints information about a $symbol$
+    </dl>
+    'Information' does not print information for 'ReadProtected' symbols.
+    'Information' uses 'InputForm' to format values.
+
+    >> a = 2;
+    >> Information[a]
+     = a = 2
+
+
+    >> f[x_] := x ^ 2
+    >> g[f] ^:= 2
+    >> f::usage = "f[x] returns the square of x";
+    >> Information[f]
+     = f[x] returns the square of x
+     .
+     . f[x_] = x ^ 2
+     .
+     . g[f] ^= 2
+
+    >> ? Table
+     = 
+     .   'Table[expr, {i, n}]'
+     .     evaluates expr with i ranging from 1 to n, returning
+     . a list of the results.
+     .   'Table[expr, {i, start, stop, step}]'
+     .     evaluates expr with i ranging from start to stop,
+     . incrementing by step.
+     .   'Table[expr, {i, {e1, e2, ..., ei}}]'
+     .     evaluates expr with i taking on the values e1, e2,
+     . ..., ei.
+     .      
+
+    >> Information[Table]
+     = 
+     .   'Table[expr, {i, n}]'
+     .     evaluates expr with i ranging from 1 to n, returning
+     . a list of the results.
+     .   'Table[expr, {i, start, stop, step}]'
+     .     evaluates expr with i ranging from start to stop,
+     . incrementing by step.
+     .   'Table[expr, {i, {e1, e2, ..., ei}}]'
+     .     evaluates expr with i taking on the values e1, e2,
+     . ..., ei.
+     .
+     . Attributes[Table] = {HoldAll, Protected}
+     .
+    """
+
+    operator = "??"
+    precedence = 670
+    attributes = ('HoldAll', 'SequenceHold', 'Protect', 'ReadProtect')
+    messages = {'notfound': 'Expression `1` is not a symbol'}
+    options = {'LongForm': 'True', }
+
+    def format_definition(self, symbol, evaluation, options, grid=True):
+        'StandardForm,TraditionalForm,OutputForm: Information[symbol_, OptionsPattern[Information]]'
+        from mathics.core.expression import from_python
+        lines = []
+
+        if isinstance(symbol, String):
+            evaluation.print_out(symbol)
+            evaluation.evaluate(Expression('Information', Symbol('System`String')))
+            return
+
+        if not isinstance(symbol, Symbol):
+            evaluation.message('Information', 'notfound', symbol)
+            return Symbol('Null')
+
+        # Print the "usage" message if available.
+        usagetext = _get_usage_string(symbol, evaluation)
+        if usagetext is not None:
+            lines.append(String(usagetext))
+
+        if self.get_option(options, 'LongForm', evaluation).to_python():
+            self.show_definitions(symbol, evaluation, lines)
+
+        if grid:
+            if lines:
+                return Expression(
+                    'Grid', Expression(
+                        'List', *(Expression('List', line) for line in lines)),
+                    Expression(
+                        'Rule', Symbol('ColumnAlignments'), Symbol('Left')))
+            else:
+                return Symbol('Null')
+        else:
+            for line in lines:
+                evaluation.print_out(Expression('InputForm', line))
+            return Symbol('Null')
+
+        # It would be deserable to call here the routine inside Definition, but for some reason it fails...
+        # Instead, I just copy the code from Definition
+
+    def show_definitions(self, symbol, evaluation, lines):
+        def print_rule(rule, up=False, lhs=lambda l: l, rhs=lambda r: r):
+            evaluation.check_stopped()
+            if isinstance(rule, Rule):
+                r = rhs(rule.replace.replace_vars(
+                        {'System`Definition': Expression('HoldForm', Symbol('Definition'))}))
+                lines.append(Expression('HoldForm', Expression(
+                    up and 'UpSet' or 'Set', lhs(rule.pattern.expr), r)))
+
+        name = symbol.get_name()
+        if not name:
+            evaluation.message('Definition', 'sym', symbol, 1)
+            return
+        attributes = evaluation.definitions.get_attributes(name)
+        definition = evaluation.definitions.get_user_definition(
+            name, create=False)
+        all = evaluation.definitions.get_definition(name)
+        if attributes:
+            attributes = list(attributes)
+            attributes.sort()
+            lines.append(Expression(
+                'HoldForm', Expression(
+                    'Set', Expression('Attributes', symbol), Expression(
+                        'List',
+                        *(Symbol(attribute) for attribute in attributes)))))
+
+        if definition is not None and 'System`ReadProtected' not in attributes:
+            for rule in definition.ownvalues:
+                print_rule(rule)
+            for rule in definition.downvalues:
+                print_rule(rule)
+            for rule in definition.subvalues:
+                print_rule(rule)
+            for rule in definition.upvalues:
+                print_rule(rule, up=True)
+            for rule in definition.nvalues:
+                print_rule(rule)
+            formats = sorted(definition.formatvalues.items())
+            for format, rules in formats:
+                for rule in rules:
+                    def lhs(expr):
+                        return Expression('Format', expr, Symbol(format))
+
+                    def rhs(expr):
+                        if expr.has_form('Infix', None):
+                            expr = Expression(Expression(
+                                'HoldForm', expr.head), *expr.leaves)
+                        return Expression('InputForm', expr)
+                    print_rule(rule, lhs=lhs, rhs=rhs)
+        for rule in all.defaultvalues:
+            print_rule(rule)
+        if all.options:
+            options = sorted(all.options.items())
+            lines.append(
+                Expression('HoldForm', Expression(
+                    'Set', Expression('Options', symbol),
+                    Expression('List', *(
+                        Expression('Rule', Symbol(name), value)
+                        for name, value in options)))))
+        return
+
+    def format_definition_input(self, symbol, evaluation, options):
+        'InputForm: Information[symbol_, OptionsPattern[Information]]'
+        return self.format_definition(symbol, evaluation, options, grid=False)
 
 
 class Clear(Builtin):

--- a/mathics/core/parser/operators.py
+++ b/mathics/core/parser/operators.py
@@ -16,6 +16,8 @@ prefix_ops = {
     'Exists': 240,
     'NotExists': 240,
     'Not': 230,
+    'Information': 670,
+    'Definition': 670,
 }
 
 postfix_ops = {

--- a/mathics/core/parser/parser.py
+++ b/mathics/core/parser/parser.py
@@ -467,6 +467,20 @@ class Parser(object):
         q = prefix_ops['PreDecrement']
         return Node('PreDecrement', self.parse_exp(q))
 
+    def p_PatternTest(self, token):
+        self.consume()
+        q = prefix_ops['Definition']
+        child = self.parse_exp(q)
+        return Node('Information', child, Node('Rule', Symbol("LongForm"), Symbol("False")))
+
+    def p_Information(self, token):
+        self.consume()
+        q = prefix_ops['Information']
+        child = self.parse_exp(q)
+        if child.__class__ is not Symbol:
+            raise InvalidSyntaxError()
+        return Node('Information', child, Node('Rule', Symbol("LongForm"), Symbol("True")))
+
     # E methods
     #
     # e_xxx methods are called from parse_e.

--- a/mathics/core/parser/tokeniser.py
+++ b/mathics/core/parser/tokeniser.py
@@ -30,6 +30,9 @@ filename_pattern = r'''
 '''
 
 tokens = [
+    ('Definition', r'\? '),
+    ('Information', r'\?\? '),
+
     ('Number', number_pattern),
     ('String', r'"'),
     ('Pattern', pattern_pattern),
@@ -68,6 +71,7 @@ tokens = [
     ('SqrtBox', r' \\\@ '),
     ('FormBox', r' \\\` '),
 
+    ('Information', r'\?\?'),
     ('PatternTest', r' \? '),
     ('Increment', r' \+\+ '),
     ('Decrement', r' \-\- '),
@@ -231,7 +235,7 @@ literal_tokens = {
     '<': ['RawLeftAssociation', 'UndirectedEdge', 'Get', 'StringJoin', 'LessEqual', 'Less'],
     '=': ['SameQ', 'UnsameQ', 'Equal', 'Unset', 'Set'],
     '>': ['PutAppend', 'Put', 'GreaterEqual', 'Greater'],
-    '?': ['PatternTest'],
+    '?': ['Information', 'PatternTest'],
     '@': ['ApplyList', 'Apply', 'Composition', 'Prefix'],
     '[': ['RawLeftBracket'],
     '\\': ['LeftRowBox', 'RightRowBox', 'InterpretedBox', 'SuperscriptBox',

--- a/mathics/doc/doc.py
+++ b/mathics/doc/doc.py
@@ -850,6 +850,21 @@ class Doc(object):
     def __str__(self):
         return '\n'.join(str(item) for item in self.items)
 
+    def text(self, detail_level):
+        # used for introspection
+        # TODO parse XML and pretty print
+        # HACK
+        item = str(self.items[0])
+        item = '\n'.join(line.strip() for line in item.split('\n'))
+        item = item.replace('<dl>', '')
+        item = item.replace('</dl>', '')
+        item = item.replace('<dt>', '  ')
+        item = item.replace('</dt>', '')
+        item = item.replace('<dd>', '    ')
+        item = item.replace('</dd>', '')
+        item = '\n'.join(line for line in item.split('\n') if not line.isspace())
+        return item
+
     def get_tests(self):
         tests = []
         for item in self.items:

--- a/test/test_parser/test_parser.py
+++ b/test/test_parser/test_parser.py
@@ -468,6 +468,14 @@ class GeneralTests(ParserTests):
         self.check('a < b <= c > d >= e != f == g',
                    'Inequality[a, Less, b, LessEqual, c, Greater, d, GreaterEqual, e,  Unequal, f, Equal, g]')
 
+    def testInformation(self):
+        self.check('??a', 'Information[a, LongForm -> True]')
+        self.check('a ?? b', 'a Information[b, LongForm -> True]')
+        self.invalid_error('a ?? + b')
+        self.check('a + ?? b', 'a + Information[b, LongForm -> True]')
+        self.check('??a + b', 'Information[a, LongForm -> True] + b')
+        self.check('??a * b', 'Information[a, Rule[LongForm, True]]*b')
+
 
 class BoxTests(ParserTests):
     def testSqrt(self):

--- a/test/test_parser/test_tokeniser.py
+++ b/test/test_parser/test_tokeniser.py
@@ -137,3 +137,7 @@ class TokeniserTest(unittest.TestCase):
         
     def testAssociation(self):
         self.assertEqual(self.tokens('<|x -> m|>'), [Token('RawLeftAssociation', '<|', 0), Token('Symbol', "x", 2), Token('Rule', '->', 4), Token('Symbol', "m", 7), Token('RawRightAssociation', '|>', 8)])
+
+    def testInformation(self):
+        self.assertEqual(self.tokens('??Sin'), [Token('Information', '??', 0), Token('Symbol', 'Sin', 2)])
+        self.assertEqual(self.tokens('? ?Sin'), [Token('PatternTest', '?', 0), Token('PatternTest', '?', 2), Token('Symbol', 'Sin', 3)])


### PR DESCRIPTION
Finally, I could add the prefix operators ? and ?? with its standard mea ning in mma: ? F is equivalent to Definition[F] and ??F calls Information[F].
I also added the command Information, which for built in symbols, shows the **doc** string of the correspondent class, and for user symbols, looks to the message ::usage.

Something that is missing is to show inside Information the output of Definition, but for some reason it didn't work. Anyway, I think the basic functionality is implemented.
