### PR TITLE
Fix quadratic runtimes in Mathics

### DIFF
--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -266,8 +266,8 @@ class Plus(BinaryOperator, SympyFunction):
                     leaves.append(last_item)
                 else:
                     if last_item.has_form('Times', None):
-                        last_item.leaves.insert(0, from_sympy(last_count))
-                        leaves.append(last_item)
+                        leaves.append(Expression(
+                            'Times', from_sympy(last_count), *last_item.leaves))
                     else:
                         leaves.append(Expression(
                             'Times', from_sympy(last_count), last_item))
@@ -281,7 +281,7 @@ class Plus(BinaryOperator, SympyFunction):
                     for leaf in item.leaves:
                         if isinstance(leaf, Number):
                             count = leaf.to_sympy()
-                            rest = item.leaves[:]
+                            rest = item.get_mutable_leaves()
                             rest.remove(leaf)
                             if len(rest) == 1:
                                 rest = rest[0]
@@ -590,8 +590,8 @@ class Times(BinaryOperator, SympyFunction):
             elif (leaves and item.has_form('Power', 2) and
                   leaves[-1].has_form('Power', 2) and
                   item.leaves[0].same(leaves[-1].leaves[0])):
-                leaves[-1].leaves[1] = Expression(
-                    'Plus', item.leaves[1], leaves[-1].leaves[1])
+                leaves[-1] = Expression('Power', leaves[-1].leaves[0], Expression(
+                    'Plus', item.leaves[1], leaves[-1].leaves[1]))
             elif (leaves and item.has_form('Power', 2) and
                   item.leaves[0].same(leaves[-1])):
                 leaves[-1] = Expression(
@@ -626,8 +626,9 @@ class Times(BinaryOperator, SympyFunction):
         elif number.is_zero:
             return number
         elif number.same(Integer(-1)) and leaves and leaves[0].has_form('Plus', None):
-            leaves[0].leaves = [Expression('Times', Integer(-1), leaf)
-                                for leaf in leaves[0].leaves]
+            leaves[0] = Expression(
+                leaves[0].get_head(),
+                *[Expression('Times', Integer(-1), leaf) for leaf in leaves[0].leaves])
             number = None
 
         for leaf in leaves:

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -632,7 +632,7 @@ class Times(BinaryOperator, SympyFunction):
             number = None
 
         for leaf in leaves:
-            leaf.clear_token()
+            leaf.clear_cache()
 
         if number is not None:
             leaves.insert(0, number)

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -632,7 +632,7 @@ class Times(BinaryOperator, SympyFunction):
             number = None
 
         for leaf in leaves:
-            leaf.last_evaluated = None
+            leaf.clear_token()
 
         if number is not None:
             leaves.insert(0, number)

--- a/mathics/builtin/assignment.py
+++ b/mathics/builtin/assignment.py
@@ -1056,7 +1056,7 @@ def get_symbol_values(symbol, func_name, position, evaluation):
         definition = evaluation.definitions.get_definition(name)
     else:
         definition = evaluation.definitions.get_user_definition(name)
-    result = Expression('List')
+    leaves = []
     for rule in definition.get_values_list(position):
         if isinstance(rule, Rule):
             pattern = rule.pattern
@@ -1064,9 +1064,9 @@ def get_symbol_values(symbol, func_name, position, evaluation):
                 pattern = pattern.expr
             else:
                 pattern = Expression('HoldPattern', pattern.expr)
-            result.leaves.append(Expression(
+            leaves.append(Expression(
                 'RuleDelayed', pattern, rule.replace))
-    return result
+    return Expression('List', *leaves)
 
 
 class DownValues(Builtin):

--- a/mathics/builtin/combinatorial.py
+++ b/mathics/builtin/combinatorial.py
@@ -93,13 +93,13 @@ class Multinomial(Builtin):
         'Multinomial[values___]'
 
         values = values.get_sequence()
-        result = Expression('Times')
+        leaves = []
         total = []
         for value in values:
             total.append(value)
-            result.leaves.append(Expression(
+            leaves.append(Expression(
                 'Binomial', Expression('Plus', *total), value))
-        return result
+        return Expression('Times', *leaves)
 
 
 class _NoBoolVector(Exception):

--- a/mathics/builtin/files.py
+++ b/mathics/builtin/files.py
@@ -26,6 +26,8 @@ import six
 from six.moves import range
 from six import unichr
 
+from itertools import chain
+
 from mathics.core.expression import (Expression, Real, Complex, String, Symbol,
                                      from_python, Integer, BoxError,
                                      MachineReal, Number, valid_context_name)
@@ -1475,17 +1477,17 @@ class BinaryWrite(Builtin):
             elif t.startswith('Character'):
                 if isinstance(x, Integer):
                     x = [String(char) for char in str(x.get_int_value())]
-                    pyb = pyb[:i] + x + pyb[i + 1:]
+                    pyb = list(chain(pyb[:i], x, pyb[i + 1:]))
                     x = pyb[i]
                 if isinstance(x, String) and len(x.get_string_value()) > 1:
                     x = [String(char) for char in x.get_string_value()]
-                    pyb = pyb[:i] + x + pyb[i + 1:]
+                    pyb = list(chain(pyb[:i], x, pyb[i + 1:]))
                     x = pyb[i]
                 x = x.get_string_value()
             elif t == 'Byte' and isinstance(x, String):
                 if len(x.get_string_value()) > 1:
                     x = [String(char) for char in x.get_string_value()]
-                    pyb = pyb[:i] + x + pyb[i + 1:]
+                    pyb = list(chain(pyb[:i], x, pyb[i + 1:]))
                     x = pyb[i]
                 x = ord(x.get_string_value())
             else:

--- a/mathics/builtin/functional.py
+++ b/mathics/builtin/functional.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 
 from six.moves import zip
+from itertools import chain
 
 from mathics.builtin.base import Builtin, PostfixOperator
 from mathics.core.expression import Expression
@@ -70,8 +71,7 @@ class Function(PostfixOperator):
     def apply_slots(self, body, args, evaluation):
         'Function[body_][args___]'
 
-        args = args.get_sequence()
-        args.insert(0, Expression('Function', body))
+        args = list(chain([Expression('Function', body)], args.get_sequence()))
         return body.replace_slots(args, evaluation)
 
     def apply_named(self, vars, body, args, evaluation):

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -273,11 +273,11 @@ def set_part(list, indices, new):
                 raise PartDepthError
             try:
                 if pos > 0:
-                    cur.leaves[pos - 1] = new
+                    cur.set_leaves(pos - 1, new)
                 elif pos == 0:
-                    cur.head = new
+                    cur.set_head(new)
                 else:
-                    cur.leaves[pos] = new
+                    cur.set_leaves(pos, new)
             except IndexError:
                 raise PartRangeError
 
@@ -384,8 +384,7 @@ def _list_parts(items, selectors, assignment):
 
             if unwrap is None:
                 expr = item.shallow_copy()
-                expr.leaves = picked
-                expr.last_evaluated = None
+                expr.set_leaves(slice(len(expr.leaves)), picked)
 
                 if assignment:
                     expr.original = None
@@ -1082,7 +1081,7 @@ class ReplacePart(Builtin):
             position = replacement.leaves[0]
             replace = replacement.leaves[1]
             if position.has_form('List', None):
-                position = position.leaves
+                position = position.get_mutable_leaves()
             else:
                 position = [position]
             for index, pos in enumerate(position):
@@ -1132,7 +1131,7 @@ def _take_span_selector(seq):
 
 def _drop_span_selector(seq):
     def sliced(x, s):
-        y = x[:]
+        y = list(x[:])
         del y[s]
         return y
 
@@ -2217,7 +2216,7 @@ class Prepend(Builtin):
             return evaluation.message('Prepend', 'normal')
 
         return Expression(expr.get_head(),
-                          *([item] + expr.get_leaves()))
+            *list(chain([item], expr.get_leaves())))
 
 
 def get_tuples(items):

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -19,7 +19,7 @@ from mathics.builtin.scoping import dynamic_scoping
 from mathics.builtin.base import MessageException, NegativeIntegerException, CountableInteger
 from mathics.core.expression import Expression, String, Symbol, Integer, Number, Real, strip_context, from_python
 from mathics.core.expression import min_prec, machine_precision
-from mathics.core.expression import Structure
+from mathics.core.expression import structure
 from mathics.core.evaluation import BreakInterrupt, ContinueInterrupt, ReturnInterrupt
 from mathics.core.rules import Pattern
 from mathics.core.convert import from_sympy
@@ -452,7 +452,7 @@ def walk_parts(list_of_list, indices, evaluation, assign_list=None):
         process_level(result, assign_list)
 
         result = list_of_list[0]
-        result.clear_token()
+        result.clear_cache()
 
     return result
 
@@ -876,8 +876,8 @@ class Partition(Builtin):
     def _partition(self, expr, n, d, evaluation):
         assert n > 0 and d > 0
 
-        inner = Structure('List', expr, evaluation)
-        outer = Structure('List', inner, evaluation)
+        inner = structure('List', expr, evaluation)
+        outer = structure('List', inner, evaluation)
 
         make_slice = inner.slice
 
@@ -1301,6 +1301,11 @@ class Select(Builtin):
     >> Select[a, True]
      : Nonatomic expression expected.
      = Select[a, True]
+
+    #> A[x__] := 31415 /; Length[{x}] == 3;
+    #> Select[A[5, 2, 7, 1], OddQ]
+     = 31415
+    #> ClearAll[A];
     """
 
     def apply(self, items, expr, evaluation):
@@ -1346,6 +1351,11 @@ class Split(Builtin):
 
     #> Split[{}]
      = {}
+
+    #> A[x__] := 321 /; Length[{x}] == 5;
+    #> Split[A[x, x, x, y, x, y, y, z]]
+     = 321
+    #> ClearAll[A];
     """
 
     rules = {
@@ -1376,8 +1386,8 @@ class Split(Builtin):
             else:
                 result.append([leaf])
 
-        inner = Structure('List', mlist, evaluation)
-        outer = Structure(mlist.head, inner, evaluation)
+        inner = structure('List', mlist, evaluation)
+        outer = structure(mlist.head, inner, evaluation)
         return outer([inner(l) for l in result])
 
 
@@ -1428,8 +1438,8 @@ class SplitBy(Builtin):
                 result.append([leaf])
             prev = curr
 
-        inner = Structure('List', mlist, evaluation)
-        outer = Structure(mlist.head, inner, evaluation)
+        inner = structure('List', mlist, evaluation)
+        outer = structure(mlist.head, inner, evaluation)
         return outer([inner(l) for l in result])
 
     def apply_multiple(self, mlist, funcs, evaluation):
@@ -4603,7 +4613,7 @@ class Permutations(Builtin):
         if rs is None:
             rs = range(py_n + 1)
 
-        inner = Structure('List', l, evaluation)
-        outer = Structure('List', inner, evaluation)
+        inner = structure('List', l, evaluation)
+        outer = structure('List', inner, evaluation)
 
         return outer([inner(p) for r in rs for p in permutations(l.leaves, r)])

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -274,11 +274,11 @@ def set_part(list, indices, new):
                 raise PartDepthError
             try:
                 if pos > 0:
-                    cur.set_leaves(pos - 1, new)
+                    cur.set_leaf(pos - 1, new)
                 elif pos == 0:
                     cur.set_head(new)
                 else:
-                    cur.set_leaves(pos, new)
+                    cur.set_leaf(pos, new)
             except IndexError:
                 raise PartRangeError
 

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -452,7 +452,7 @@ def walk_parts(list_of_list, indices, evaluation, assign_list=None):
         process_level(result, assign_list)
 
         result = list_of_list[0]
-        result.last_evaluated = None
+        result.clear_token()
 
     return result
 

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -870,21 +870,15 @@ class Partition(Builtin):
         'Parition[list_, n_, d_, k]': 'Partition[list, n, d, {k, k}]',
     }
 
-    def chunks(self, l, n, d):
-        assert n > 0 and d > 0
-        return [x for x in [l[i:i + n] for i in range(0, len(l), d)] if len(x) == n]
-
     def apply_no_overlap(self, l, n, evaluation):
         'Partition[l_List, n_Integer]'
         # TODO: Error checking
-        return Expression('List', *self.chunks(
-            l.get_leaves(), n.get_int_value(), n.get_int_value()))
+        return Expression('List', *list(l.partition(n.get_int_value(), n.get_int_value())))
 
     def apply(self, l, n, d, evaluation):
         'Partition[l_List, n_Integer, d_Integer]'
         # TODO: Error checking
-        return Expression('List', *self.chunks(
-            l.get_leaves(), n.get_int_value(), d.get_int_value()))
+        return Expression('List', *list(l.partition(n.get_int_value(), d.get_int_value())))
 
 
 class Extract(Builtin):

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -873,12 +873,12 @@ class Partition(Builtin):
     def apply_no_overlap(self, l, n, evaluation):
         'Partition[l_List, n_Integer]'
         # TODO: Error checking
-        return Expression('List', *list(l.partition(n.get_int_value(), n.get_int_value())))
+        return l.restructure('List', list(l.partition(n.get_int_value(), n.get_int_value())))
 
     def apply(self, l, n, d, evaluation):
         'Partition[l_List, n_Integer, d_Integer]'
         # TODO: Error checking
-        return Expression('List', *list(l.partition(n.get_int_value(), d.get_int_value())))
+        return l.restructure('List', list(l.partition(n.get_int_value(), d.get_int_value())))
 
 
 class Extract(Builtin):

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -1939,7 +1939,7 @@ class Array(Builtin):
         'Array[f_, dimsexpr_, origins_:1, head_:List]'
 
         if dimsexpr.has_form('List', None):
-            dims = dimsexpr.leaves[:]
+            dims = dimsexpr.get_mutable_leaves()
         else:
             dims = [dimsexpr]
         for index, dim in enumerate(dims):
@@ -1952,7 +1952,7 @@ class Array(Builtin):
             if len(origins.leaves) != len(dims):
                 evaluation.message('Array', 'plen', dimsexpr, origins)
                 return
-            origins = origins.leaves[:]
+            origins = origins.get_mutable_leaves()
         else:
             origins = [origins] * len(dims)
         for index, origin in enumerate(origins):
@@ -2136,8 +2136,8 @@ class Append(Builtin):
         if expr.is_atom():
             return evaluation.message('Append', 'normal')
 
-        return Expression(expr.get_head(),
-                          *(expr.get_leaves() + [item]))
+        return Expression(
+            expr.get_head(), *list(chain(expr.get_leaves(), [item])))
 
 
 class AppendTo(Builtin):
@@ -3488,7 +3488,7 @@ class Median(_Rectangular):
             except _NotRectangularException:
                 evaluation.message('Median', 'rectn', Expression('Median', l))
         elif all(leaf.is_numeric() for leaf in l.leaves):
-            v = l.leaves[:]  # copy needed for introselect
+            v = l.get_mutable_leaves()  # copy needed for introselect
             n = len(v)
             if n % 2 == 0:  # even number of elements?
                 i = n // 2
@@ -3527,7 +3527,7 @@ class RankedMin(Builtin):
         elif py_n > len(l.leaves):
             evaluation.message('RankedMin', 'rank', py_n, len(l.leaves))
         else:
-            return introselect(l.leaves[:], py_n - 1)
+            return introselect(l.get_mutable_leaves(), py_n - 1)
 
 
 class RankedMax(Builtin):
@@ -3555,7 +3555,7 @@ class RankedMax(Builtin):
         elif py_n > len(l.leaves):
             evaluation.message('RankedMax', 'rank', py_n, len(l.leaves))
         else:
-            return introselect(l.leaves[:], len(l.leaves) - py_n)
+            return introselect(l.get_mutable_leaves(), len(l.leaves) - py_n)
 
 
 class Quantile(Builtin):
@@ -3585,7 +3585,7 @@ class Quantile(Builtin):
         '''Quantile[l_List, qs_List, {{a_, b_}, {c_, d_}}]'''
 
         n = len(l.leaves)
-        partially_sorted = l.leaves[:]
+        partially_sorted = l.get_mutable_leaves()
 
         def ranked(i):
             return introselect(partially_sorted, min(max(0, i - 1), n - 1))

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -321,7 +321,7 @@ def _parts_span_selector(pspec):
 
 
 def _parts_sequence_selector(pspec):
-    if not isinstance(pspec, list):
+    if not isinstance(pspec, (tuple, list)):
         indices = [pspec]
     else:
         indices = pspec
@@ -2365,11 +2365,11 @@ class Reap(Builtin):
             result = expr.evaluate(evaluation)
             items = []
             for pattern, tags in sown:
-                list = Expression('List')
+                leaves = []
                 for tag, elements in tags:
-                    list.leaves.append(Expression(
+                    leaves.append(Expression(
                         f, tag, Expression('List', *elements)))
-                items.append(list)
+                items.append(Expression('List', *leaves))
             return Expression('List', result, Expression('List', *items))
         finally:
             evaluation.remove_listener('sow', listener)

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -389,7 +389,7 @@ def _list_parts(items, selectors, heads, evaluation, assignment):
                     expr.original = None
                     expr.set_positions()
                 else:
-                    expr = item.restructure(picked, evaluation)
+                    expr = item.restructure(item.head, picked, evaluation)
 
                 yield expr
             else:
@@ -890,7 +890,7 @@ class Partition(Builtin):
                 if len(chunk) != n:
                     continue
 
-                yield make_slice(expr, lower, upper)
+                yield make_slice(expr, slice(lower, upper))
 
         return outer(slices())
 
@@ -1011,7 +1011,7 @@ class Most(Builtin):
         if expr.is_atom():
             evaluation.message('Most', 'normal')
             return
-        return expr.slice(0, -1, evaluation)
+        return expr.slice(expr.head, slice(0, -1), evaluation)
 
 
 class Rest(Builtin):
@@ -1038,7 +1038,7 @@ class Rest(Builtin):
         if expr.is_atom():
             evaluation.message('Rest', 'normal')
             return
-        return expr.slice(1, len(expr.leaves), evaluation)
+        return expr.slice(expr.head, slice(1, len(expr.leaves)), evaluation)
 
 
 class ReplacePart(Builtin):
@@ -1314,7 +1314,7 @@ class Select(Builtin):
             test = Expression(expr, leaf)
             return test.evaluate(evaluation).is_true()
 
-        return items.filter(cond, evaluation)
+        return items.filter(items.head, cond, evaluation)
 
 
 class Split(Builtin):
@@ -1472,7 +1472,7 @@ class Pick(Builtin):
                 if match(s):
                     yield x
                 elif not x.is_atom() and not s.is_atom():
-                    yield x.restructure(pick(x.leaves, s.leaves), evaluation)
+                    yield x.restructure(x.head, pick(x.leaves, s.leaves), evaluation)
 
         r = list(pick([items0], [sel0]))
         if not r:
@@ -1602,7 +1602,7 @@ class DeleteCases(Builtin):
         def cond(leaf):
             return not match(leaf, evaluation)
 
-        return items.filter(cond, evaluation, head='List')
+        return items.filter('List', cond, evaluation)
 
 
 class Count(Builtin):
@@ -2101,7 +2101,7 @@ class Join(Builtin):
             result.extend(list.leaves)
 
         if result:
-            return sequence[0].restructure(result, evaluation, deps=sequence)
+            return sequence[0].restructure(head, result, evaluation, deps=sequence)
         else:
             return Expression('List')
 
@@ -2132,7 +2132,12 @@ class Catenate(Builtin):
                     raise MessageException('Catenate', 'invrp', l)
 
         try:
-            return Expression('List', *list(chain(*list(parts()))))
+            result = list(chain(*list(parts())))
+            if result:
+                return lists.leaves[0].restructure(
+                    'List', result, evaluation, deps=lists.leaves)
+            else:
+                return Expression('List')
         except MessageException as e:
             e.message(evaluation)
 
@@ -2166,7 +2171,8 @@ class Append(Builtin):
         if expr.is_atom():
             return evaluation.message('Append', 'normal')
 
-        return expr.restructure(list(chain(expr.get_leaves(), [item])), evaluation, deps=(expr, item))
+        return expr.restructure(
+            expr.head, list(chain(expr.get_leaves(), [item])), evaluation, deps=(expr, item))
 
 
 class AppendTo(Builtin):
@@ -2245,8 +2251,8 @@ class Prepend(Builtin):
         if expr.is_atom():
             return evaluation.message('Prepend', 'normal')
 
-        return Expression(expr.get_head(),
-            *list(chain([item], expr.get_leaves())))
+        return expr.restructure(
+            expr.head, list(chain([item], expr.get_leaves())), evaluation, deps=(expr, item))
 
 
 def get_tuples(items):
@@ -2530,9 +2536,11 @@ class Riffle(Builtin):
         'Riffle[list_List, sep_]'
 
         if sep.has_form('List', None):
-            return Expression('List', *riffle_lists(list.get_leaves(), sep.leaves))
+            result = riffle_lists(list.get_leaves(), sep.leaves)
         else:
-            return Expression('List', *riffle_lists(list.get_leaves(), [sep]))
+            result = riffle_lists(list.get_leaves(), [sep])
+
+        return list.restructure('List', result, evaluation, deps=(list, sep))
 
 
 def _is_sameq(same_test):
@@ -3113,14 +3121,18 @@ class Reverse(Builtin):
             return expr
 
         if levels[0] == level:
-            expr = expr.restructure(reversed(expr.leaves), evaluation)
+            expr = expr.restructure(expr.head, reversed(expr.leaves), evaluation)
 
             if len(levels) > 1:
                 expr = expr.restructure(
-                    [Reverse._reverse(leaf, level + 1, levels[1:], evaluation) for leaf in expr.leaves], evaluation)
+                    expr.head,
+                    [Reverse._reverse(leaf, level + 1, levels[1:], evaluation) for leaf in expr.leaves],
+                    evaluation)
         else:
             expr = expr.restructure(
-                [Reverse._reverse(leaf, level + 1, levels, evaluation) for leaf in expr.leaves], evaluation)
+                expr.head,
+                [Reverse._reverse(leaf, level + 1, levels, evaluation) for leaf in expr.leaves],
+                evaluation)
 
         return expr
 
@@ -3418,7 +3430,7 @@ class _Rotate(Builtin):
         if len(n) > 1:
             new_leaves = [self._rotate(item, n[1:], evaluation) for item in new_leaves]
 
-        return expr.restructure(new_leaves, evaluation)
+        return expr.restructure(expr.head, new_leaves, evaluation)
 
     def apply_one(self, expr, evaluation):
         '%(name)s[expr_]'
@@ -3760,7 +3772,7 @@ class _RankedTake(Builtin):
             else:
                 result = self._get_n(py_n, heap)
 
-            return l.restructure([x[leaf_pos] for x in result], evaluation, head='List')
+            return l.restructure('List', [x[leaf_pos] for x in result], evaluation)
 
 
 class _RankedTakeSmallest(_RankedTake):

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -389,8 +389,7 @@ def _list_parts(items, selectors, heads, evaluation, assignment):
                     expr.original = None
                     expr.set_positions()
                 else:
-                    expr = Structure(
-                        item.head, item, evaluation, cache=heads).from_leaves(picked)
+                    expr = item.restructure(picked, evaluation)
 
                 yield expr
             else:
@@ -880,7 +879,7 @@ class Partition(Builtin):
         inner = Structure('List', expr, evaluation)
         outer = Structure('List', inner, evaluation)
 
-        make_slice = inner.from_slice
+        make_slice = inner.slice
 
         def slices():
             leaves = expr.leaves
@@ -893,7 +892,7 @@ class Partition(Builtin):
 
                 yield make_slice(expr, lower, upper)
 
-        return outer.from_leaves(slices())
+        return outer(slices())
 
     def apply_no_overlap(self, l, n, evaluation):
         'Partition[l_List, n_Integer]'
@@ -1315,7 +1314,7 @@ class Select(Builtin):
             test = Expression(expr, leaf)
             return test.evaluate(evaluation).is_true()
 
-        return Structure(items.head, items, evaluation).from_condition(items, cond)
+        return items.filter(cond, evaluation)
 
 
 class Split(Builtin):
@@ -1379,9 +1378,7 @@ class Split(Builtin):
 
         inner = Structure('List', mlist, evaluation)
         outer = Structure(mlist.head, inner, evaluation)
-
-        make_inner = inner.from_leaves
-        return outer.from_leaves([make_inner(l) for l in result])
+        return outer([inner(l) for l in result])
 
 
 class SplitBy(Builtin):
@@ -1431,8 +1428,9 @@ class SplitBy(Builtin):
                 result.append([leaf])
             prev = curr
 
-        return Expression(mlist.head, *[Expression('List', *l)
-                                        for l in result])
+        inner = Structure('List', mlist, evaluation)
+        outer = Structure(mlist.head, inner, evaluation)
+        return outer([inner(l) for l in result])
 
     def apply_multiple(self, mlist, funcs, evaluation):
         'SplitBy[mlist_, funcs_?ListQ]'
@@ -1474,7 +1472,7 @@ class Pick(Builtin):
                 if match(s):
                     yield x
                 elif not x.is_atom() and not s.is_atom():
-                    yield Structure(x.get_head(), x, evaluation).from_leaves(pick(x.leaves, s.leaves))
+                    yield x.restructure(pick(x.leaves, s.leaves), evaluation)
 
         r = list(pick([items0], [sel0]))
         if not r:
@@ -1604,7 +1602,7 @@ class DeleteCases(Builtin):
         def cond(leaf):
             return not match(leaf, evaluation)
 
-        return Structure('List', items, evaluation).from_condition(items, cond)
+        return items.filter(cond, evaluation, head='List')
 
 
 class Count(Builtin):
@@ -2103,7 +2101,7 @@ class Join(Builtin):
             result.extend(list.leaves)
 
         if result:
-            return Structure(head, sequence, evaluation).from_leaves(result)
+            return sequence[0].restructure(result, evaluation, deps=sequence)
         else:
             return Expression('List')
 
@@ -2168,7 +2166,7 @@ class Append(Builtin):
         if expr.is_atom():
             return evaluation.message('Append', 'normal')
 
-        return Structure(expr.get_head(), (expr, item), evaluation).from_leaves(list(chain(expr.get_leaves(), [item])))
+        return expr.restructure(list(chain(expr.get_leaves(), [item])), evaluation, deps=(expr, item))
 
 
 class AppendTo(Builtin):
@@ -3115,14 +3113,14 @@ class Reverse(Builtin):
             return expr
 
         if levels[0] == level:
-            expr = Structure(expr.head, expr, evaluation).from_leaves(reversed(expr.leaves))
+            expr = expr.restructure(reversed(expr.leaves), evaluation)
 
             if len(levels) > 1:
-                expr = Structure(expr.head, expr, evaluation).from_leaves(
-                    [Reverse._reverse(leaf, level + 1, levels[1:], evaluation) for leaf in expr.leaves])
+                expr = expr.restructure(
+                    [Reverse._reverse(leaf, level + 1, levels[1:], evaluation) for leaf in expr.leaves], evaluation)
         else:
-            expr = Structure(expr.head, expr, evaluation).from_leaves(
-                [Reverse._reverse(leaf, level + 1, levels, evaluation) for leaf in expr.leaves])
+            expr = expr.restructure(
+                [Reverse._reverse(leaf, level + 1, levels, evaluation) for leaf in expr.leaves], evaluation)
 
         return expr
 
@@ -3420,7 +3418,7 @@ class _Rotate(Builtin):
         if len(n) > 1:
             new_leaves = [self._rotate(item, n[1:], evaluation) for item in new_leaves]
 
-        return Structure(expr.get_head(), expr, evaluation).from_leaves(new_leaves)
+        return expr.restructure(new_leaves, evaluation)
 
     def apply_one(self, expr, evaluation):
         '%(name)s[expr_]'
@@ -3762,7 +3760,7 @@ class _RankedTake(Builtin):
             else:
                 result = self._get_n(py_n, heap)
 
-            return Structure('List', l, evaluation).from_leaves([x[leaf_pos] for x in result])
+            return l.restructure([x[leaf_pos] for x in result], evaluation, head='List')
 
 
 class _RankedTakeSmallest(_RankedTake):
@@ -4596,5 +4594,4 @@ class Permutations(Builtin):
         inner = Structure('List', l, evaluation)
         outer = Structure('List', inner, evaluation)
 
-        make_inner = inner.from_leaves
-        return outer.from_leaves([make_inner(p) for r in rs for p in permutations(l.leaves, r)])
+        return outer([inner(p) for r in rs for p in permutations(l.leaves, r)])

--- a/mathics/builtin/natlang.py
+++ b/mathics/builtin/natlang.py
@@ -351,13 +351,13 @@ class TextSentences(_SpacyBuiltin):
         'TextSentences[text_String, OptionsPattern[%(name)s]]'
         doc = self._nlp(text.get_string_value(), evaluation, options)
         if doc:
-            return string_list('List', *[String(sent.text) for sent in doc.sents], evaluation)
+            return string_list('List', [String(sent.text) for sent in doc.sents], evaluation)
 
     def apply_n(self, text, n, evaluation, options):
         'TextSentences[text_String, n_Integer, OptionsPattern[%(name)s]]'
         doc = self._nlp(text.get_string_value(), evaluation, options)
         if doc:
-            return string_list('List', *itertools.islice(
+            return string_list('List', itertools.islice(
                 (String(sent.text) for sent in doc.sents), n.get_int_value()), evaluation)
 
 

--- a/mathics/builtin/natlang.py
+++ b/mathics/builtin/natlang.py
@@ -385,9 +385,9 @@ class DeleteStopwords(_SpacyBuiltin):
             for w in words:
                 s = w.get_string_value()
                 if not s:
-                    yield s
+                    yield String(s)
                 elif not is_stop(s):
-                    yield s
+                    yield String(s)
         return string_list('List', filter_words(l.leaves), evaluation)
 
     def apply_string(self, s, evaluation, options):

--- a/mathics/builtin/natlang.py
+++ b/mathics/builtin/natlang.py
@@ -45,7 +45,7 @@ from mathics.builtin.base import Builtin, MessageException
 from mathics.builtin.randomnumbers import RandomEnv
 from mathics.builtin.codetables import iso639_3
 from mathics.builtin.strings import to_regex, anchor_pattern
-from mathics.core.expression import Expression, String, Integer, Real, Symbol, strip_context
+from mathics.core.expression import Expression, String, Integer, Real, Symbol, strip_context, string_list
 
 import os
 import re
@@ -317,15 +317,15 @@ class TextWords(_SpacyBuiltin):
         doc = self._nlp(text.get_string_value(), evaluation, options)
         if doc:
             punctuation = spacy.parts_of_speech.PUNCT
-            return Expression('List', *[String(word.text) for word in doc if word.pos != punctuation])
+            return string_list('List', [String(word.text) for word in doc if word.pos != punctuation], evaluation)
 
     def apply_n(self, text, n, evaluation, options):
         'TextWords[text_String, n_Integer, OptionsPattern[%(name)s]]'
         doc = self._nlp(text.get_string_value(), evaluation, options)
         if doc:
             punctuation = spacy.parts_of_speech.PUNCT
-            return Expression('List', *itertools.islice(
-                (String(word.text) for word in doc if word.pos != punctuation), n.get_int_value()))
+            return string_list('List', itertools.islice(
+                (String(word.text) for word in doc if word.pos != punctuation), n.get_int_value()), evaluation)
 
 
 class TextSentences(_SpacyBuiltin):
@@ -351,14 +351,14 @@ class TextSentences(_SpacyBuiltin):
         'TextSentences[text_String, OptionsPattern[%(name)s]]'
         doc = self._nlp(text.get_string_value(), evaluation, options)
         if doc:
-            return Expression('List', *[String(sent.text) for sent in doc.sents])
+            return string_list('List', *[String(sent.text) for sent in doc.sents], evaluation)
 
     def apply_n(self, text, n, evaluation, options):
         'TextSentences[text_String, n_Integer, OptionsPattern[%(name)s]]'
         doc = self._nlp(text.get_string_value(), evaluation, options)
         if doc:
-            return Expression('List', *itertools.islice(
-                (String(sent.text) for sent in doc.sents), n.get_int_value()))
+            return string_list('List', *itertools.islice(
+                (String(sent.text) for sent in doc.sents), n.get_int_value()), evaluation)
 
 
 class DeleteStopwords(_SpacyBuiltin):
@@ -388,7 +388,7 @@ class DeleteStopwords(_SpacyBuiltin):
                     yield s
                 elif not is_stop(s):
                     yield s
-        return Expression('List', *filter_words(l.leaves))
+        return string_list('List', filter_words(l.leaves), evaluation)
 
     def apply_string(self, s, evaluation, options):
         'DeleteStopwords[s_String, OptionsPattern[%(name)s]]'

--- a/mathics/builtin/numeric.py
+++ b/mathics/builtin/numeric.py
@@ -223,7 +223,7 @@ class N(Builtin):
             else:
                 eval_range = range(len(expr.leaves))
             head = Expression('N', expr.head, prec).evaluate(evaluation)
-            leaves = expr.leaves[:]
+            leaves = expr.get_mutable_leaves()
             for index in eval_range:
                 leaves[index] = Expression(
                     'N', leaves[index], prec).evaluate(evaluation)

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -20,7 +20,7 @@ from six import unichr
 
 from mathics.builtin.base import BinaryOperator, Builtin, Test
 from mathics.core.expression import (Expression, Symbol, String, Integer,
-                                     from_python)
+                                     from_python, string_list)
 from mathics.builtin.lists import python_seq, convert_seq
 
 
@@ -752,7 +752,7 @@ class StringSplit(Builtin):
         for re_patt in re_patts:
             result = [t for s in result for t in mathics_split(re_patt, s, flags=flags)]
 
-        return Expression('List', *[String(x) for x in result if x != ''])
+        return string_list('List', [String(x) for x in result if x != ''], evaluation)
 
 
 class StringPosition(Builtin):

--- a/mathics/builtin/structure.py
+++ b/mathics/builtin/structure.py
@@ -75,7 +75,7 @@ class Sort(Builtin):
             evaluation.message('Sort', 'normal')
         else:
             new_leaves = sorted(list.leaves)
-            return Expression(list.head, *new_leaves)
+            return list.restructure(list.head, new_leaves, evaluation)
 
     def apply_predicate(self, list, p, evaluation):
         'Sort[list_, p_]'
@@ -91,7 +91,7 @@ class Sort(Builtin):
                     return not Expression(p, self.leaf, other.leaf).evaluate(evaluation).is_true()
 
             new_leaves = sorted(list.leaves, key=Key)
-            return Expression(list.head, *new_leaves)
+            return list.restructure(list.head, new_leaves, evaluation)
 
 
 class SortBy(Builtin):
@@ -158,7 +158,7 @@ class SortBy(Builtin):
             # we sort a list of indices. after sorting, we reorder the leaves.
             new_indices = sorted(list(range(len(raw_keys))), key=Key)
             new_leaves = [raw_keys[i] for i in new_indices]  # reorder leaves
-            return Expression(l.head, *new_leaves)
+            return l.restructure(l.head, new_leaves, evaluation)
 
 
 class BinarySearch(Builtin):

--- a/mathics/builtin/structure.py
+++ b/mathics/builtin/structure.py
@@ -970,10 +970,9 @@ class Flatten(Builtin):
         expr, depth = walk_levels(expr, callback=callback, include_pos=True)
 
         # build new tree inserting nodes as needed
-        result = Expression(h)
         leaves = sorted(six.iteritems(new_indices))
 
-        def insert_leaf(expr, leaves):
+        def insert_leaf(leaves):
             # gather leaves into groups with the same leading index
             # e.g. [((0, 0), a), ((0, 1), b), ((1, 0), c), ((1, 1), d)]
             # -> [[(0, a), (1, b)], [(0, c), (1, d)]]
@@ -987,15 +986,17 @@ class Flatten(Builtin):
                     grouped_leaves.append([(index[1:], leaf)])
             # for each group of leaves we either insert them into the current level
             # or make a new level and recurse
+            new_leaves = []
             for group in grouped_leaves:
                 if len(group[0][0]) == 0:   # bottom level leaf
                     assert len(group) == 1
-                    expr.leaves.append(group[0][1])
+                    new_leaves.append(group[0][1])
                 else:
-                    expr.leaves.append(Expression(h))
-                    insert_leaf(expr.leaves[-1], group)
-        insert_leaf(result, leaves)
-        return result
+                    new_leaves.append(Expression(h, *insert_leaf(group)))
+
+            return new_leaves
+
+        return Expression(h, *insert_leaf(leaves))
 
     def apply(self, expr, n, h, evaluation):
         'Flatten[expr_, n_, h_]'
@@ -1239,7 +1240,7 @@ class Operate(Builtin):
         # Otherwise, if we get here, e.head points to the head we need
         # to apply p to. Python's reference semantics mean that this
         # assignment modifies expr as well.
-        e.head = Expression(p, e.head)
+        e.set_head(Expression(p, e.head))
 
         return expr
 

--- a/mathics/builtin/tensors.py
+++ b/mathics/builtin/tensors.py
@@ -280,17 +280,17 @@ class Inner(Builtin):
         def rec(i_cur, j_cur, i_rest, j_rest):
             evaluation.check_stopped()
             if i_rest:
-                new = Expression(head)
+                leaves = []
                 for i in range(1, i_rest[0] + 1):
-                    new.leaves.append(
+                    leaves.append(
                         rec(i_cur + [i], j_cur, i_rest[1:], j_rest))
-                return new
+                return Expression(head, *leaves)
             elif j_rest:
-                new = Expression(head)
+                leaves = []
                 for j in range(1, j_rest[0] + 1):
-                    new.leaves.append(
+                    leaves.append(
                         rec(i_cur, j_cur + [j], i_rest, j_rest[1:]))
-                return new
+                return Expression(head, *leaves)
             else:
                 def summand(i):
                     return Expression(f, get_part(list1, i_cur + [i]),

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -124,7 +124,7 @@ class Definitions(object):
         for k in self.proxy.pop(tail, []):
             definitions_cache.pop(k, None)
 
-    def changed(self, maximum, symbols):
+    def has_changed(self, maximum, symbols):
         # timestamp for the most recently changed part of a given expression.
         for name in symbols:
             symb = self.get_definition(name, only_if_exists=True)

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -124,12 +124,16 @@ class Definitions(object):
         for k in self.proxy.pop(tail, []):
             definitions_cache.pop(k, None)
 
-    def not_changed(self, expr, maximum):
+    def changed(self, token):
+        if token is None:
+            return True
+
+        maximum = token.time
         if maximum is None:
-            return False
+            return True
 
         # timestamp for the most recently changed part of a given expression.
-        for name in expr.symbols():
+        for name in token.symbols:
             symb = self.get_definition(name, only_if_exists=True)
             if symb is None:
                 # symbol doesn't exist so it was never changed
@@ -140,9 +144,9 @@ class Definitions(object):
                     # must be system symbol
                     symb.changed = 0
                 elif changed > maximum:
-                    return False
+                    return True
 
-        return True
+        return False
 
     def get_current_context(self):
         # It's crucial to specify System` in this get_ownvalue() call,

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -124,16 +124,9 @@ class Definitions(object):
         for k in self.proxy.pop(tail, []):
             definitions_cache.pop(k, None)
 
-    def changed(self, token):
-        if token is None:
-            return True
-
-        maximum = token.time
-        if maximum is None:
-            return True
-
+    def changed(self, maximum, symbols):
         # timestamp for the most recently changed part of a given expression.
-        for name in token.symbols:
+        for name in symbols:
             symb = self.get_definition(name, only_if_exists=True)
             if symb is None:
                 # symbol doesn't exist so it was never changed

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -681,6 +681,7 @@ class Expression(BaseExpression):
         expr = Expression(self._head.copy(reevaluate))
         expr._leaves = [leaf.copy(reevaluate) for leaf in self._leaves]
         if not reevaluate:
+            self._prepare_symbols()  # First[Timing[Fold[#1+#2&, Range[750]]]]
             expr._token = self._token
         expr._sequences = self._sequences
         expr.options = self.options
@@ -692,6 +693,7 @@ class Expression(BaseExpression):
         # the original, only the Expression instance is new.
         expr = Expression(self._head)
         expr._leaves = self._leaves
+        self._prepare_symbols()  # First[Timing[Fold[#1+#2&, Range[750]]]]
         expr._token = self._token
         expr._sequences = self._sequences
         expr.options = self.options

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -660,10 +660,11 @@ class Expression(BaseExpression):
         if dirty:
             self._token = EvaluationToken(time, sym)
 
-    def copy(self):
-        expr = Expression(self.head.copy())
-        expr._leaves = [leaf.copy() for leaf in self._leaves]
-        expr._token = self._token
+    def copy(self, reevaluate=False):
+        expr = Expression(self.head.copy(reevaluate))
+        expr._leaves = [leaf.copy(reevaluate) for leaf in self._leaves]
+        if not reevaluate:
+            expr._token = self._token
         expr._sequences = self._sequences
         expr.options = self.options
         expr.original = self
@@ -1549,7 +1550,7 @@ class Atom(BaseExpression):
     def numerify(self, evaluation):
         return self
 
-    def copy(self):
+    def copy(self, reevaluate=False):
         result = self.do_copy()
         result.original = self
         return result

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -2527,33 +2527,35 @@ def print_parenthesizes(precedence, outer_precedence=None,
             outer_precedence == precedence and parenthesize_when_equal)))
 
 
-def _is_neutral_head(head, cache, evaluation):
-    # a head is neutral if it does not invoke any rules, but is sure to make its Expression stay
+def _is_neutral_symbol(symbol_name, cache, evaluation):
+    # a symbol is neutral if it does not invoke any rules, but is sure to make its Expression stay
     # the way it is (e.g. List[1, 2, 3] will always stay List[1, 2, 3], so long as nobody defines
     # a rule on this).
 
-    if not isinstance(head, Symbol):
-        return False
-
-    head_name = head.get_name()
-
     if cache:
-        r = cache.get(head_name)
+        r = cache.get(symbol_name)
         if r is not None:
             return r
 
     definitions = evaluation.definitions
 
-    definition = definitions.get_definition(head_name, only_if_exists=True)
+    definition = definitions.get_definition(symbol_name, only_if_exists=True)
     if definition is None:
         r = True
     else:
         r = all(len(definition.get_values_list(x)) == 0 for x in ('up', 'sub', 'down', 'own'))
 
     if cache:
-        cache[head_name] = r
+        cache[symbol_name] = r
 
     return r
+
+
+def _is_neutral_head(head, cache, evaluation):
+    if not isinstance(head, Symbol):
+        return False
+
+    return _is_neutral_symbol(head.get_name(), cache, evaluation)
 
 
 # Structure helps implementations make the ExpressionCache not invalidate across simple commands

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -9,6 +9,7 @@ import mpmath
 import math
 import re
 from itertools import chain
+from bisect import bisect_left
 
 from mathics.core.numbers import get_type, dps, prec, min_prec, machine_precision
 from mathics.core.convert import sympy_symbol_prefix, SympyExpression
@@ -528,10 +529,42 @@ class Expression(BaseExpression):
     def leaves(self, value):
         raise ValueError('Expression.leaves is write protected. Use set_leaves().')
 
+    def partition(self, n, d):
+        assert n > 0 and d > 0
+
+        # a fast partition that relies on three optimizations:
+        # (O1) leaves are not checked via from_python
+        # (O2) sequences are efficiently derived from self.sequences()
+        # (O3) if self has been evaluated, there's no need to
+        # reevaluate any partition of self.
+
+        # performance test case: First[Timing[Partition[Range[50000], 15, 1]]]
+
+        leaves = self.leaves
+        head = Symbol('List')
+        seq = self.sequences()
+
+        for lower in range(0, len(leaves), d):
+            upper = lower + n
+
+            chunk = leaves[lower:upper]
+            if len(chunk) != n:
+                continue
+
+            a = bisect_left(seq, lower)  # all(val >= i for val in seq[a:])
+            b = bisect_left(seq, upper)  # all(val >= j for val in seq[b:])
+
+            expr = Expression(head)  # (O1)
+            expr.leaves = chunk  # (O1)
+            expr._sequences = tuple(x - lower for x in seq[a:b])  # (O2)
+            expr.last_evaluated = self.last_evaluated  # (O3)
+
+            yield expr
+
     def sequences(self):
         seq = self._sequences
         if seq is None:
-            seq = list(_sequences(self.leaves))
+            seq = tuple(_sequences(self.leaves))
             self._sequences = seq
         return seq
 

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -136,24 +136,57 @@ class KeyComparable(object):
 
 
 class EvaluationToken:
-    def __init__(self, time=None, symbols=None):
+    def __init__(self, time=None, symbols=None, sequences=None):
         self.time = time
         self.symbols = symbols
+        self.sequences = sequences
 
     def copy(self):
-        return EvaluationToken(self.time, self.symbols)
+        return EvaluationToken(self.time, self.symbols, self.sequences)
+
+    def sliced(self, lower, upper):
+        seq = self.sequences
+
+        if seq:
+            a = bisect_left(seq, lower)  # all(val >= i for val in seq[a:])
+            b = bisect_left(seq, upper)  # all(val >= j for val in seq[b:])
+            new_sequences = tuple(x - lower for x in seq[a:b])
+        elif seq is not None:
+            new_sequences = tuple()
+        else:
+            new_sequences = None
+
+        return EvaluationToken(self.time, self.symbols, new_sequences)
 
     def reordered(self):
-        return EvaluationToken(None, self.symbols)
+        sequences = self.sequences
+
+        # note that we do not touch sequences == [], which
+        # is fine even with reordered leaves.
+        if sequences:
+            sequences = None
+
+        return EvaluationToken(None, self.symbols, sequences)
 
     @staticmethod
-    def union(tokens, evaluation):
+    def union(expressions, evaluation):
         definitions = evaluation.definitions
-        for token in tokens:
-            if definitions.changed(token):
+
+        for expr in expressions:
+            if expr.changed(definitions):
                 return None
+
+        new_sequences = tuple()
+        for expr in expressions:
+            seq = expr._token.sequences
+            if seq is None or len(seq) > 0:
+                new_sequences = None
+                break
+
         return EvaluationToken(
-            definitions.now, set.union(*[token.symbols for token in tokens]))
+            definitions.now,
+            set.union(*[expr._token.symbols for expr in expressions]),
+            new_sequences)
 
 
 class BaseExpression(KeyComparable):
@@ -168,8 +201,8 @@ class BaseExpression(KeyComparable):
     def clear_token(self):
         self._token = None
 
-    def get_token(self):
-        return None
+    def changed(self, definitions):
+        return True
 
     def sequences(self):
         return None
@@ -523,12 +556,6 @@ class Monomial(object):
         return 0
 
 
-def _sequences(leaves):
-    for i, leaf in enumerate(leaves):
-        if leaf.get_head_name() == 'System`Sequence' or leaf.sequences():
-            yield i
-
-
 class Expression(BaseExpression):
     def __new__(cls, head, *leaves):
         self = super(Expression, cls).__new__(cls)
@@ -536,7 +563,6 @@ class Expression(BaseExpression):
             head = Symbol(head)
         self._head = head
         self._leaves = tuple(from_python(leaf) for leaf in leaves)
-        self._sequences = None
         return self
 
     @property
@@ -595,14 +621,13 @@ class Expression(BaseExpression):
             return False
 
     def sequences(self):
-        seq = self._sequences
-        if seq is None:
-            if self._no_symbol('System`Sequence'):
-                seq = tuple()
-            else:
-                seq = tuple(_sequences(self._leaves))
-            self._sequences = seq
-        return seq
+        token = self._token
+        if token:
+            seq = token.sequences
+            if seq is not None:
+                return seq
+
+        return self._inspect_symbols().sequences
 
     def _flatten_sequence(self, sequence, evaluation):
         indices = self.sequences()
@@ -645,63 +670,67 @@ class Expression(BaseExpression):
             expr.options = self.options
         return expr
 
-    def _prepare_symbols(self):
+    def _inspect_symbols(self):
         token = self._token
 
         if token is None:
             time = None
-        else:
-            sym = token.symbols
-            if sym is not None:
-                return token
+        elif token.symbols is None:
             time = token.time
+        elif token.sequences is None:
+            time = token.time
+        else:
+            return token
 
         sym = set((self.get_head_name(),))
+        seq = []
 
-        for leaf in self._leaves:
-            if isinstance(leaf, Symbol):
+        for i, leaf in enumerate(self._leaves):
+            if isinstance(leaf, Expression):
+                leaf_symbols = leaf._inspect_symbols().symbols
+                sym.update(leaf_symbols)
+                if 'System`Sequence' in leaf_symbols:
+                    seq.append(i)
+            elif isinstance(leaf, Symbol):
                 sym.add(leaf.get_name())
-            elif isinstance(leaf, Expression):
-                leaf_token = leaf._prepare_symbols()
-                sym.update(leaf_token.symbols)
 
-        token = EvaluationToken(time, sym)
+        token = EvaluationToken(time, sym, seq)
         self._token = token
         return token
 
-    def get_token(self):
-        # make sure that EvaluationToken is complete (i.e. has symbols).
-        # returns None if token does not exist or has no time.
-
+    def changed(self, definitions):
         token = self._token
 
         if token is None:
-            return None
+            return True
 
         time = token.time
 
         if time is None:
-            return None
+            return True
 
-        return self._prepare_symbols()
+        if token.symbols is None:
+            token = self._inspect_symbols()
+
+        return definitions.changed(time, token.symbols)
 
     def update_token(self, evaluation):
         token = self._token
 
         if token is None:
             sym = None
+            seq = None
         else:
             sym = token.symbols
+            seq = token.sequences
 
-        self._token = EvaluationToken(evaluation.definitions.now, sym)
+        self._token = EvaluationToken(evaluation.definitions.now, sym, seq)
 
     def copy(self, reevaluate=False):
         expr = Expression(self._head.copy(reevaluate))
         expr._leaves = tuple(leaf.copy(reevaluate) for leaf in self._leaves)
         if not reevaluate:
-            self._prepare_symbols()  # First[Timing[Fold[#1+#2&, Range[750]]]]
-            expr._token = self._token
-        expr._sequences = self._sequences
+            expr._token = self._inspect_symbols()  # First[Timing[Fold[#1+#2&, Range[750]]]]
         expr.options = self.options
         expr.original = self
         return expr
@@ -711,9 +740,7 @@ class Expression(BaseExpression):
         # the original, only the Expression instance is new.
         expr = Expression(self._head)
         expr._leaves = self._leaves
-        self._prepare_symbols()  # First[Timing[Fold[#1+#2&, Range[750]]]]
-        expr._token = self._token
-        expr._sequences = self._sequences
+        expr._token = self._inspect_symbols()  # First[Timing[Fold[#1+#2&, Range[750]]]]
         expr.options = self.options
         return expr
 
@@ -741,11 +768,9 @@ class Expression(BaseExpression):
         leaves[index] = value
         self._leaves = tuple(leaves)
         self._token = None
-        self._sequences = None
 
     def set_reordered_leaves(self, leaves):  # same leaves, but in a different order
         self._leaves = tuple(leaves)
-        self._sequences = None
         if self._token:
             self._token = self._token.reordered()
 
@@ -997,7 +1022,7 @@ class Expression(BaseExpression):
         try:
             while reevaluate:
                 # changed before last evaluated?
-                if not definitions.changed(expr.get_token()):
+                if not expr.changed(definitions):
                     break
 
                 names.add(expr.get_lookup_name())
@@ -2512,9 +2537,6 @@ def _is_safe_head(head, cache, evaluation):
     return r
 
 
-_optimize_sequences = True  # more complex code, gains primarily for Partition[]
-
-
 class Structure:
     # performance test case: x = Range[50000]; First[Timing[Partition[x, 15, 1]]]
 
@@ -2529,7 +2551,7 @@ class Structure:
                 token = None
         elif isinstance(orig, (list, tuple)):
             if _is_safe_head(head, cache, evaluation):
-                token = EvaluationToken.union([expr.get_token() for expr in orig], evaluation)
+                token = EvaluationToken.union(orig, evaluation)
             else:
                 token = None
         else:
@@ -2542,7 +2564,8 @@ class Structure:
 
         expr = Expression(self.head)
         expr._leaves = tuple(leaves)
-        expr._token = self._token
+        if self._token:
+            expr._token = self._token.reordered()
         return expr
 
     def filter(self, expr, cond):
@@ -2557,16 +2580,7 @@ class Structure:
         if step != 1:
             raise ValueError('Structure.slice only supports slice steps of 1')
 
-        expr = self(leaves[lower:upper])
-
-        if _optimize_sequences:
-            seq = expr._sequences
-            if seq:
-                a = bisect_left(seq, lower)  # all(val >= i for val in seq[a:])
-                b = bisect_left(seq, upper)  # all(val >= j for val in seq[b:])
-
-                expr._sequences = tuple(x - lower for x in seq[a:b])  # (O2)
-            elif seq is not None:
-                expr._sequences = ()
-
-        return expr
+        new = self(leaves[lower:upper])
+        if expr._token:
+            new._token = expr._token.sliced(lower, upper)
+        return new

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -2674,7 +2674,7 @@ def atom_list(head, leaves, atom_names, evaluation):
     # no rules associated with them, we can speed up evaluation.
 
     expr = Expression(head)
-    expr._leaves = leaves
+    expr._leaves = list(leaves)
 
     if not _is_neutral_head(head, None, evaluation) or any(not atom for atom in atom_names):
         return expr

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -80,7 +80,7 @@ class ExpressionPointer(object):
         if self.position == 0:
             self.parent.set_head(new)
         else:
-            self.parent.set_leaves(self.position - 1, new)
+            self.parent.set_leaf(self.position - 1, new)
 
     def __str__(self):
         return '%s[[%s]]' % (self.parent, self.position)
@@ -545,7 +545,7 @@ class Expression(BaseExpression):
 
     @head.setter
     def head(self, value):
-        raise ValueError('Expression.head is write protected. Use set_head().')
+        raise ValueError('Expression.head is write protected.')
 
     @property
     def leaves(self):
@@ -553,7 +553,7 @@ class Expression(BaseExpression):
 
     @leaves.setter
     def leaves(self, value):
-        raise ValueError('Expression.leaves is write protected. Use set_leaves().')
+        raise ValueError('Expression.leaves is write protected.')
 
     def slice(self, head, py_slice, evaluation):
         # faster equivalent to: Expression(head, *self.leaves[py_slice])
@@ -582,7 +582,7 @@ class Expression(BaseExpression):
     def _no_symbol(self, symbol_name):
         # if this return True, it's safe to say that self.leaves or its
         # sub leaves contain no Symbol with symbol_name. if this returns
-        # False however, such a Symbol might sitll exist.
+        # False, such a Symbol might or might not exist.
 
         token = self._token
         if token is None:
@@ -736,7 +736,7 @@ class Expression(BaseExpression):
     def get_mutable_leaves(self):  # shallow, mutable copy of the leaves array
         return list(self._leaves)
 
-    def set_leaves(self, index, value):  # leaves are removed, added or replaced
+    def set_leaf(self, index, value):  # leaves are removed, added or replaced
         leaves = list(self._leaves)
         leaves[index] = value
         self._leaves = tuple(leaves)
@@ -1042,6 +1042,8 @@ class Expression(BaseExpression):
 
         def rest_range(indices):
             if 'System`HoldAllComplete' not in attributes:
+                if self._no_symbol('System`Evaluate'):
+                    return
                 for index in indices:
                     leaf = leaves[index]
                     if leaf.has_form('Evaluate', 1):

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -164,6 +164,9 @@ class BaseExpression(KeyComparable):
         self._token = None
         return self
 
+    def clear_token(self):
+        self._token = None
+
     def sequences(self):
         return None
 
@@ -619,9 +622,6 @@ class Expression(BaseExpression):
         if hasattr(self, 'options'):
             expr.options = self.options
         return expr
-
-    def clear_token(self):
-        self._token = None
 
     def update_token(self, evaluation=None):
         token = self._token

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -603,7 +603,7 @@ class Expression(BaseExpression):
             k = i + 1
         extend(leaves[k:])
 
-        return self.restructure(self.head, flattened)
+        return self.restructure(self._head, flattened)
 
     def flatten_sequence(self):
         def sequence(leaf):
@@ -689,7 +689,7 @@ class Expression(BaseExpression):
         self._token = EvaluationToken(evaluation.definitions.now, sym)
 
     def copy(self, reevaluate=False):
-        expr = Expression(self.head.copy(reevaluate))
+        expr = Expression(self._head.copy(reevaluate))
         expr._leaves = [leaf.copy(reevaluate) for leaf in self._leaves]
         if not reevaluate:
             expr._token = self._token
@@ -701,7 +701,7 @@ class Expression(BaseExpression):
     def shallow_copy(self):
         # this is a minimal, shallow copy: head, leaves are shared with
         # the original, only the Expression instance is new.
-        expr = Expression(self.head)
+        expr = Expression(self._head)
         expr._leaves = self._leaves
         expr._token = self._token
         expr._sequences = self._sequences
@@ -710,7 +710,7 @@ class Expression(BaseExpression):
 
     def set_positions(self, position=None):
         self.position = position
-        self.head.set_positions(ExpressionPointer(self, 0))
+        self._head.set_positions(ExpressionPointer(self, 0))
         for index, leaf in enumerate(self._leaves):
             leaf.set_positions(ExpressionPointer(self, index + 1))
 
@@ -741,7 +741,7 @@ class Expression(BaseExpression):
             self._token = self._token.reordered()
 
     def get_lookup_name(self):
-        return self.head.get_lookup_name()
+        return self._head.get_lookup_name()
 
     def has_form(self, heads, *leaf_counts):
         """
@@ -752,7 +752,7 @@ class Expression(BaseExpression):
             (n1, n2, ...):    leaf count in {n1, n2, ...}
         """
 
-        head_name = self.head.get_name()
+        head_name = self._head.get_name()
         if isinstance(heads, (tuple, list, set)):
             if head_name not in [ensure_context(h) for h in heads]:
                 return False
@@ -772,7 +772,7 @@ class Expression(BaseExpression):
         return True
 
     def has_symbol(self, symbol_name):
-        return self.head.has_symbol(symbol_name) or any(
+        return self._head.has_symbol(symbol_name) or any(
             leaf.has_symbol(symbol_name) for leaf in self._leaves)
 
     def to_sympy(self, **kwargs):
@@ -815,7 +815,7 @@ class Expression(BaseExpression):
         if n_evaluation is not None:
             value = Expression('N', self).evaluate(n_evaluation)
             return value.to_python()
-        head_name = self.head.get_name()
+        head_name = self._head.get_name()
         if head_name == 'System`List':
             return [leaf.to_python(*args, **kwargs) for leaf in self._leaves]
         if head_name == 'System`DirectedInfinity' and len(self._leaves) == 1:
@@ -842,7 +842,7 @@ class Expression(BaseExpression):
             7: 0/1:        0 for Condition
             """
 
-            name = self.head.get_name()
+            name = self._head.get_name()
             pattern = 0
             if name == 'System`Blank':
                 pattern = 1
@@ -856,30 +856,30 @@ class Expression(BaseExpression):
                 else:
                     pattern += 20
             if pattern > 0:
-                return [2, pattern, 1, 1, 0, self.head.get_sort_key(True),
+                return [2, pattern, 1, 1, 0, self._head.get_sort_key(True),
                         tuple(leaf.get_sort_key(True) for leaf in self._leaves), 1]
 
             if name == 'System`PatternTest':
                 if len(self._leaves) != 2:
-                    return [3, 0, 0, 0, 0, self.head, self._leaves, 1]
+                    return [3, 0, 0, 0, 0, self._head, self._leaves, 1]
                 sub = self._leaves[0].get_sort_key(True)
                 sub[2] = 0
                 return sub
             elif name == 'System`Condition':
                 if len(self._leaves) != 2:
-                    return [3, 0, 0, 0, 0, self.head, self._leaves, 1]
+                    return [3, 0, 0, 0, 0, self._head, self._leaves, 1]
                 sub = self._leaves[0].get_sort_key(True)
                 sub[7] = 0
                 return sub
             elif name == 'System`Pattern':
                 if len(self._leaves) != 2:
-                    return [3, 0, 0, 0, 0, self.head, self._leaves, 1]
+                    return [3, 0, 0, 0, 0, self._head, self._leaves, 1]
                 sub = self._leaves[1].get_sort_key(True)
                 sub[3] = 0
                 return sub
             elif name == 'System`Optional':
                 if len(self._leaves) not in (1, 2):
-                    return [3, 0, 0, 0, 0, self.head, self._leaves, 1]
+                    return [3, 0, 0, 0, 0, self._head, self._leaves, 1]
                 sub = self._leaves[0].get_sort_key(True)
                 sub[4] = 1
                 return sub
@@ -897,20 +897,20 @@ class Expression(BaseExpression):
                 return min_key
             elif name == 'System`Verbatim':
                 if len(self._leaves) != 1:
-                    return [3, 0, 0, 0, 0, self.head, self._leaves, 1]
+                    return [3, 0, 0, 0, 0, self._head, self._leaves, 1]
                 return self._leaves[0].get_sort_key(True)
             elif name == 'System`OptionsPattern':
-                return [2, 40, 0, 1, 1, 0, self.head, self._leaves, 1]
+                return [2, 40, 0, 1, 1, 0, self._head, self._leaves, 1]
             else:
                 # Append [4] to leaves so that longer expressions have higher
                 # precedence
                 return [
-                    2, 0, 1, 1, 0, self.head.get_sort_key(True),
+                    2, 0, 1, 1, 0, self._head.get_sort_key(True),
                     tuple(chain((leaf.get_sort_key(True) for leaf in self._leaves), ([4],))),
                     1]
         else:
             exps = {}
-            head = self.head.get_name()
+            head = self._head.get_name()
             if head == 'System`Times':
                 for leaf in self._leaves:
                     name = leaf.get_name()
@@ -928,15 +928,15 @@ class Expression(BaseExpression):
                     exps[var] = exps.get(var, 0) + exp
             if exps:
                 return [1 if self.is_numeric() else 2, 2, Monomial(exps), 1,
-                        self.head, self._leaves, 1]
+                        self._head, self._leaves, 1]
             else:
-                return [1 if self.is_numeric() else 2, 3, self.head,
+                return [1 if self.is_numeric() else 2, 3, self._head,
                         self._leaves, 1]
 
     def same(self, other):
         if self.get_head_name() != other.get_head_name():
             return False
-        if not self.head.same(other.get_head()):
+        if not self._head.same(other.get_head()):
             return False
         if len(self._leaves) != len(other.get_leaves()):
             return False
@@ -964,7 +964,7 @@ class Expression(BaseExpression):
                     new_leaves.extend(new_leaf._leaves)
                 else:
                     new_leaves.append(leaf)
-            return Expression(self.head, *new_leaves)
+            return Expression(self._head, *new_leaves)
         else:
             return self
 
@@ -1023,7 +1023,7 @@ class Expression(BaseExpression):
         return expr
 
     def evaluate_next(self, evaluation):
-        head = self.head.evaluate(evaluation)
+        head = self._head.evaluate(evaluation)
         attributes = head.get_attributes(evaluation.definitions)
         leaves = self.get_mutable_leaves()
 
@@ -1083,7 +1083,7 @@ class Expression(BaseExpression):
                 leaf.unevaluated = old.unevaluated
 
         if 'System`Flat' in attributes:
-            new = new.flatten(new.head, callback=flatten_callback)
+            new = new.flatten(new._head, callback=flatten_callback)
         if 'System`Orderless' in attributes:
             new.sort()
 
@@ -1144,12 +1144,12 @@ class Expression(BaseExpression):
 
     def evaluate_leaves(self, evaluation):
         leaves = [leaf.evaluate(evaluation) for leaf in self._leaves]
-        head = self.head.evaluate_leaves(evaluation)
+        head = self._head.evaluate_leaves(evaluation)
         return Expression(head, *leaves)
 
     def __str__(self):
         return '%s[%s]' % (
-            self.head, ', '.join([six.text_type(leaf) for leaf in self._leaves]))
+            self._head, ', '.join([six.text_type(leaf) for leaf in self._leaves]))
 
     def __repr__(self):
         return '<Expression: %s>' % self
@@ -1183,7 +1183,7 @@ class Expression(BaseExpression):
         is_style, options = self.process_style_box(options)
         if is_style:
             return self._leaves[0].boxes_to_text(**options)
-        head = self.head.get_name()
+        head = self._head.get_name()
         box_construct = box_constructs.get(head)
         if box_construct is not None:
             try:
@@ -1207,7 +1207,7 @@ class Expression(BaseExpression):
         is_style, options = self.process_style_box(options)
         if is_style:
             return self._leaves[0].boxes_to_xml(**options)
-        head = self.head.get_name()
+        head = self._head.get_name()
         box_construct = box_constructs.get(head)
         if box_construct is not None:
             try:
@@ -1216,7 +1216,7 @@ class Expression(BaseExpression):
                 # raise # uncomment this to see what is going wrong in
                 # constructing boxes
                 raise BoxError(self, 'xml')
-        name = self.head.get_name()
+        name = self._head.get_name()
         if (name == 'System`RowBox' and len(self._leaves) == 1 and  # nopep8
             self._leaves[0].get_head_name() == 'System`List'):
             result = []
@@ -1293,14 +1293,14 @@ class Expression(BaseExpression):
         is_style, options = self.process_style_box(options)
         if is_style:
             return self._leaves[0].boxes_to_tex(**options)
-        head = self.head.get_name()
+        head = self._head.get_name()
         box_construct = box_constructs.get(head)
         if box_construct is not None:
             try:
                 return box_construct.boxes_to_tex(self._leaves, **options)
             except BoxConstructError:
                 raise BoxError(self, 'tex')
-        name = self.head.get_name()
+        name = self._head.get_name()
         if (name == 'System`RowBox' and len(self._leaves) == 1 and  # nopep8
             self._leaves[0].get_head_name() == 'System`List'):
             return ''.join([leaf.boxes_to_tex(**options)
@@ -1335,7 +1335,7 @@ class Expression(BaseExpression):
             raise BoxError(self, 'tex')
 
     def default_format(self, evaluation, form):
-        return '%s[%s]' % (self.head.default_format(evaluation, form),
+        return '%s[%s]' % (self._head.default_format(evaluation, form),
                            ', '.join([leaf.default_format(evaluation, form)
                                       for leaf in self._leaves]))
 
@@ -1371,14 +1371,14 @@ class Expression(BaseExpression):
             return new
 
         def descend(expr):
-            return Expression(expr.head, *[apply_leaf(leaf) for leaf in expr._leaves])
+            return Expression(expr._head, *[apply_leaf(leaf) for leaf in expr._leaves])
 
         if options is None:  # default ReplaceAll mode; replace breadth first
             result, applied = super(
                 Expression, self).apply_rules(rules, evaluation, level, options)
             if applied:
                 return result, True
-            head, applied = self.head.apply_rules(rules, evaluation, level, options)
+            head, applied = self._head.apply_rules(rules, evaluation, level, options)
             new_applied[0] = applied
             return descend(Expression(head, *self._leaves)), new_applied[0]
         else:  # Replace mode; replace depth first
@@ -1388,7 +1388,7 @@ class Expression(BaseExpression):
             new_applied[0] = new_applied[0] or applied
             if not applied and options['heads']:
                 # heads in Replace are treated at the level of the arguments, i.e. level + 1
-                head, applied = expr.head.apply_rules(rules, evaluation, level + 1, options)
+                head, applied = expr._head.apply_rules(rules, evaluation, level + 1, options)
                 new_applied[0] = new_applied[0] or applied
                 expr = Expression(head, *expr._leaves)
             return expr, new_applied[0]
@@ -1399,7 +1399,7 @@ class Expression(BaseExpression):
         from mathics.builtin.scoping import get_scoping_vars
 
         if not in_scoping:
-            if (self.head.get_name() in ('System`Module', 'System`Block', 'System`With') and
+            if (self._head.get_name() in ('System`Module', 'System`Block', 'System`With') and
                 len(self._leaves) > 0):  # nopep8
 
                 scoping_vars = set(name for name, new_def in get_scoping_vars(self._leaves[0]))
@@ -1411,7 +1411,7 @@ class Expression(BaseExpression):
 
         leaves = self._leaves
         if in_function:
-            if (self.head.get_name() == 'System`Function' and
+            if (self._head.get_name() == 'System`Function' and
                 len(self._leaves) > 1 and
                 (self._leaves[0].has_form('List', None) or
                  self._leaves[0].get_name())):
@@ -1431,13 +1431,13 @@ class Expression(BaseExpression):
             return self.shallow_copy()
 
         return Expression(
-            self.head.replace_vars(
+            self._head.replace_vars(
                 vars, options=options, in_scoping=in_scoping),
             *[leaf.replace_vars(vars, options=options, in_scoping=in_scoping)
               for leaf in leaves])
 
     def replace_slots(self, slots, evaluation):
-        if self.head.get_name() == 'System`Slot':
+        if self._head.get_name() == 'System`Slot':
             if len(self._leaves) != 1:
                 evaluation.message_args('Slot', len(self._leaves), 1)
             else:
@@ -1448,7 +1448,7 @@ class Expression(BaseExpression):
                     evaluation.message('Function', 'slotn', slot)
                 else:
                     return slots[int(slot)]
-        elif self.head.get_name() == 'System`SlotSequence':
+        elif self._head.get_name() == 'System`SlotSequence':
             if len(self._leaves) != 1:
                 evaluation.message_args('SlotSequence', len(self._leaves), 1)
             else:
@@ -1456,11 +1456,11 @@ class Expression(BaseExpression):
                 if slot is None or slot < 1:
                     evaluation.error('Function', 'slot', self._leaves[0])
             return Expression('Sequence', *slots[slot:])
-        elif (self.head.get_name() == 'System`Function' and
+        elif (self._head.get_name() == 'System`Function' and
               len(self._leaves) == 1):
             # do not replace Slots in nested Functions
             return self
-        return Expression(self.head.replace_slots(slots, evaluation),
+        return Expression(self._head.replace_slots(slots, evaluation),
                           *[leaf.replace_slots(slots, evaluation)
                             for leaf in self._leaves])
 
@@ -1490,11 +1490,11 @@ class Expression(BaseExpression):
         if dim is None:
             return False, self
         else:
-            leaves = [Expression(self.head, *item) for item in items]
+            leaves = [Expression(self._head, *item) for item in items]
             return True, Expression(head, *leaves)
 
     def is_numeric(self):
-        return (self.head.get_name() in system_symbols(
+        return (self._head.get_name() in system_symbols(
             'Sqrt', 'Times', 'Plus', 'Subtract', 'Minus', 'Power', 'Abs',
             'Divide', 'Sin') and
             all(leaf.is_numeric() for leaf in self._leaves))
@@ -1520,13 +1520,13 @@ class Expression(BaseExpression):
                     n_result = n_expr.evaluate(evaluation)
                     if isinstance(n_result, Number):
                         new_leaves[index] = n_result
-            return Expression(self.head, *new_leaves)
+            return Expression(self._head, *new_leaves)
         else:
             return self
 
     def get_atoms(self, include_heads=True):
         if include_heads:
-            atoms = self.head.get_atoms()
+            atoms = self._head.get_atoms()
         else:
             atoms = []
         for leaf in self._leaves:
@@ -1534,7 +1534,7 @@ class Expression(BaseExpression):
         return atoms
 
     def __hash__(self):
-        return hash(('Expression', self.head) + tuple(self._leaves))
+        return hash(('Expression', self._head) + tuple(self._leaves))
 
     def user_hash(self, update):
         update(("%s>%d>" % (self.get_head_name(), len(self._leaves))).encode('utf8'))
@@ -1542,7 +1542,7 @@ class Expression(BaseExpression):
             leaf.user_hash(update)
 
     def __getnewargs__(self):
-        return (self.head, self._leaves)
+        return (self._head, self._leaves)
 
 
 class Atom(BaseExpression):

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -152,7 +152,8 @@ class EvaluationToken:
         for token in tokens:
             if definitions.changed(token):
                 return None
-        return EvaluationToken(definitions.now, set.union(*[token.symbols for token in tokens]))
+        return EvaluationToken(
+            definitions.now, set.union(*[token.symbols for token in tokens]))
 
 
 class BaseExpression(KeyComparable):
@@ -166,6 +167,9 @@ class BaseExpression(KeyComparable):
 
     def clear_token(self):
         self._token = None
+
+    def get_token(self):
+        return None
 
     def sequences(self):
         return None
@@ -623,42 +627,66 @@ class Expression(BaseExpression):
             expr.options = self.options
         return expr
 
-    def update_token(self, evaluation=None):
+    def _prepare_symbols(self, as_set=False):
         token = self._token
+
+        if token is None:
+            time = None
+        else:
+            sym = token.symbols
+            if sym is not None:
+                if as_set and isinstance(sym, list):
+                    token = EvaluationToken(token.time, set(sym))
+                return token
+            time = token.time
+
+        list_of_symbols = [self.get_head_name()]
+
+        for leaf in self.leaves:
+            if isinstance(leaf, Symbol):
+                list_of_symbols.append(leaf.get_name())
+            elif isinstance(leaf, Expression):
+                leaf_token = leaf._prepare_symbols()
+                list_of_symbols.extend(list(leaf_token.symbols))
+
+        # converting the symbols list to a set is slow. by default,
+        # we only do this for the final expression given to
+        # Definitions.changed(), but not for intermediate ones.
+        # this yields better benchmarks.
+
+        sym = list_of_symbols
+
+        if as_set:
+            sym = set(sym)
+
+        token = EvaluationToken(time, sym)
+        return token
+
+    def get_token(self):
+        # make sure that EvaluationToken is complete (i.e. has symbols).
+        # returns None if token does not exist or has no time.
+
+        token = self._token
+
+        if token is None:
+            return None
+
+        time = token.time
+
+        if time is None:
+            return None
+
+        return self._prepare_symbols(as_set=True)
+
+    def update_token(self, evaluation):
+        token = self._token
+
         if token is None:
             sym = None
         else:
             sym = token.symbols
 
-        dirty = False
-        if sym is None:
-            list_of_symbols = [self.get_head_name()]
-
-            for leaf in self.leaves:
-                if isinstance(leaf, Symbol):
-                    list_of_symbols.append(leaf.get_name())
-                elif isinstance(leaf, Expression):
-                    leaf.update_token()
-                    list_of_symbols.extend(list(leaf._token.symbols))
-
-            # converting the symbols list to a set is slow. by default,
-            # we only do this for the final expression given to
-            # Definitions.changed(), but not for intermediate ones.
-            # this yields better benchmarks.
-
-            sym = list_of_symbols
-            dirty = True
-
-        if evaluation:
-            if isinstance(sym, list):
-                sym = set(list_of_symbols)
-            time = evaluation.definitions.now
-            dirty = True
-        else:
-            time = None
-
-        if dirty:
-            self._token = EvaluationToken(time, sym)
+        self._token = EvaluationToken(evaluation.definitions.now, sym)
 
     def copy(self, reevaluate=False):
         expr = Expression(self.head.copy(reevaluate))
@@ -956,7 +984,7 @@ class Expression(BaseExpression):
         try:
             while reevaluate:
                 # changed before last evaluated?
-                if not definitions.changed(expr._token):
+                if not definitions.changed(expr.get_token()):
                     break
 
                 names.add(expr.get_lookup_name())
@@ -2481,7 +2509,7 @@ class Structure:
                 token = None
         elif isinstance(orig, (list, tuple)):
             if _is_safe_head(head, cache, evaluation):
-                token = EvaluationToken.union([expr._token for expr in orig], evaluation)
+                token = EvaluationToken.union([expr.get_token() for expr in orig], evaluation)
             else:
                 token = None
         else:

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -648,6 +648,7 @@ class Expression(BaseExpression):
                 sym.update(leaf_token.symbols)
 
         token = EvaluationToken(time, sym)
+        self._token = token
         return token
 
     def get_token(self):

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -679,7 +679,7 @@ class Expression(BaseExpression):
 
     def copy(self, reevaluate=False):
         expr = Expression(self._head.copy(reevaluate))
-        expr._leaves = [leaf.copy(reevaluate) for leaf in self._leaves]
+        expr._leaves = tuple(leaf.copy(reevaluate) for leaf in self._leaves)
         if not reevaluate:
             self._prepare_symbols()  # First[Timing[Fold[#1+#2&, Range[750]]]]
             expr._token = self._token
@@ -1045,7 +1045,7 @@ class Expression(BaseExpression):
             # rest_range(range(0, 0))
 
         new = Expression(head)
-        new._leaves = leaves
+        new._leaves = tuple(leaves)
 
         if ('System`SequenceHold' not in attributes and    # noqa
             'System`HoldAllComplete' not in attributes):
@@ -1067,7 +1067,7 @@ class Expression(BaseExpression):
 
             if dirty_leaves:
                 new = Expression(head)
-                new._leaves = dirty_leaves
+                new._leaves = tuple(dirty_leaves)
                 leaves = dirty_leaves
 
         def flatten_callback(new_leaves, old):
@@ -1128,7 +1128,7 @@ class Expression(BaseExpression):
 
         if dirty_leaves:
             new = Expression(head)
-            new._leaves = dirty_leaves
+            new._leaves = tuple(dirty_leaves)
 
         new.unformatted = self.unformatted
         new.update_token(evaluation)

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -529,42 +529,8 @@ class Expression(BaseExpression):
     def leaves(self, value):
         raise ValueError('Expression.leaves is write protected. Use set_leaves().')
 
-    def restructure(self, head, leaves):
-        # NOTE: leaves must originate from self.leaves or its sub trees!
-        expr = Expression(head)
-        expr.leaves = leaves
-        expr.last_evaluated = self.last_evaluated
-        return expr
-
-    def partition(self, n, d):
-        assert n > 0 and d > 0
-
-        # a fast partition that relies on three optimizations:
-        # (O1) leaves are not checked via from_python
-        # (O2) sequences are efficiently derived from self.sequences()
-        # (O3) if self has been evaluated, there's no need to
-        # reevaluate any partition of self.
-
-        # performance test case: x = Range[50000]; First[Timing[Partition[x, 15, 1]]]
-
-        leaves = self.leaves
-        head = Symbol('List')
-        seq = self.sequences()
-
-        for lower in range(0, len(leaves), d):
-            upper = lower + n
-
-            chunk = leaves[lower:upper]
-            if len(chunk) != n:
-                continue
-
-            a = bisect_left(seq, lower)  # all(val >= i for val in seq[a:])
-            b = bisect_left(seq, upper)  # all(val >= j for val in seq[b:])
-
-            expr = self.restructure(head, chunk)  # (O1), (O3)
-            expr._sequences = tuple(x - lower for x in seq[a:b])  # (O2)
-
-            yield expr
+    def slice(self, lower, upper, evaluation):
+        return Structure(self.head, self, evaluation).from_slice(self, lower, upper)
 
     def sequences(self):
         seq = self._sequences
@@ -2420,3 +2386,68 @@ def print_parenthesizes(precedence, outer_precedence=None,
     return (outer_precedence is not None and (
         outer_precedence > precedence or (
             outer_precedence == precedence and parenthesize_when_equal)))
+
+
+class Structure:  # Select?
+    # performance test case: x = Range[50000]; First[Timing[Partition[x, 15, 1]]]
+
+    def __init__(self, head, orig, evaluation):
+        if isinstance(head, six.string_types):
+            head = Symbol(head)
+        self.head = head
+
+        if isinstance(head, Symbol):
+            definitions = evaluation.definitions
+
+            definition = definitions.get_definition(head.get_name(), only_if_exists=True)
+            if definition is None:
+                safe = True
+            else:
+                safe = all(len(definition.get_values_list(x)) == 0 for x in ('up', 'sub', 'down', 'own'))
+        else:
+            safe = False
+
+        if safe:  # no definitions for head
+            if isinstance(orig, tuple):
+                last_evaluated = definitions.now
+                for expr in orig:
+                    if expr.last_evaluated is None or definitions.last_changed(expr) > expr.last_evaluated:
+                        last_evaluated = None
+                        break
+            elif isinstance(orig, (Expression, Structure)):
+                last_evaluated = orig.last_evaluated
+            else:
+                raise ValueError
+
+            self.last_evaluated = last_evaluated
+        else:
+            self.last_evaluated = None
+
+    def from_leaves(self, leaves):
+        # IMPORTANT: caller guarantees that leaves originate from orig.leaves or its sub trees!
+
+        expr = Expression(self.head)
+        expr.leaves = leaves
+        expr.last_evaluated = self.last_evaluated
+        return expr
+
+    def from_slice(self, expr, lower, upper):
+        # IMPORTANT: caller guarantees that expr is from origins!
+
+        leaves = expr.leaves
+        n_leaves = len(leaves)
+
+        lower %= n_leaves
+        upper %= n_leaves
+
+        expr = self.from_leaves(leaves[lower:upper])
+
+        seq = expr._sequences
+        if seq:
+            a = bisect_left(seq, lower)  # all(val >= i for val in seq[a:])
+            b = bisect_left(seq, upper)  # all(val >= j for val in seq[b:])
+            expr._sequences = tuple(x - lower for x in seq[a:b])  # (O2)
+        elif seq is not None:
+            expr._sequences = ()
+
+        return expr

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -135,13 +135,33 @@ class KeyComparable(object):
         return self.get_sort_key() != other.get_sort_key()
 
 
+class EvaluationToken:
+    def __init__(self, time=None, symbols=None):
+        self.time = time
+        self.symbols = symbols
+
+    def copy(self):
+        return EvaluationToken(self.time, self.symbols)
+
+    def reordered(self):
+        return EvaluationToken(None, self.symbols)
+
+    @staticmethod
+    def union(tokens, evaluation):
+        definitions = evaluation.definitions
+        for token in tokens:
+            if definitions.changed(token):
+                return None
+        return EvaluationToken(definitions.now, set.union(*[token.symbols for token in tokens]))
+
+
 class BaseExpression(KeyComparable):
     def __new__(cls, *args, **kwargs):
         self = object.__new__(cls)
         self.options = None
         self.pattern_sequence = False
         self.unformatted = self
-        self.last_evaluated = None
+        self._token = None
         return self
 
     def sequences(self):
@@ -510,7 +530,6 @@ class Expression(BaseExpression):
         self._head = head
         self._leaves = tuple(from_python(leaf) for leaf in leaves)
         self._sequences = None
-        self._symbols = None
         return self
 
     @property
@@ -601,8 +620,17 @@ class Expression(BaseExpression):
             expr.options = self.options
         return expr
 
-    def symbols(self, intermediate=False):
-        sym = self._symbols
+    def clear_token(self):
+        self._token = None
+
+    def update_token(self, evaluation=None):
+        token = self._token
+        if token is None:
+            sym = None
+        else:
+            sym = token.symbols
+
+        dirty = False
         if sym is None:
             list_of_symbols = [self.get_head_name()]
 
@@ -610,44 +638,45 @@ class Expression(BaseExpression):
                 if isinstance(leaf, Symbol):
                     list_of_symbols.append(leaf.get_name())
                 elif isinstance(leaf, Expression):
-                    list_of_symbols.extend(list(leaf.symbols(True)))
+                    leaf.update_token()
+                    list_of_symbols.extend(list(leaf._token.symbols))
 
             # converting the symbols list to a set is slow. by default,
-            # we only do this for the final expression returned to
-            # not_changed(), but not for intermediate ones. this yields
-            # better benchmarks.
+            # we only do this for the final expression given to
+            # Definitions.changed(), but not for intermediate ones.
+            # this yields better benchmarks.
 
-            if intermediate:
-                sym = list_of_symbols
-            else:
+            sym = list_of_symbols
+            dirty = True
+
+        if evaluation:
+            if isinstance(sym, list):
                 sym = set(list_of_symbols)
+            time = evaluation.definitions.now
+            dirty = True
+        else:
+            time = None
 
-            self._symbols = sym
-        elif not intermediate and isinstance(sym, list):
-            sym = set(sym)
-            self._symbols = sym
-
-        return sym
+        if dirty:
+            self._token = EvaluationToken(time, sym)
 
     def copy(self):
-        result = Expression(
-            self.head.copy(), *[leaf.copy() for leaf in self.leaves])
-        result._sequences = self._sequences
-        result._symbols = self._symbols
-        result.options = self.options
-        result.original = self
-        # result.last_evaluated = self.last_evaluated
-        return result
+        expr = Expression(self.head.copy())
+        expr._leaves = [leaf.copy() for leaf in self._leaves]
+        expr._token = self._token
+        expr._sequences = self._sequences
+        expr.options = self.options
+        expr.original = self
+        return expr
 
     def shallow_copy(self):
         # this is a minimal, shallow copy: head, leaves are shared with
         # the original, only the Expression instance is new.
         expr = Expression(self.head)
         expr._leaves = self._leaves
+        expr._token = self._token
         expr._sequences = self._sequences
-        expr._symbols = self._symbols
         expr.options = self.options
-        expr.last_evaluated = self.last_evaluated
         return expr
 
     def set_positions(self, position=None):
@@ -661,7 +690,7 @@ class Expression(BaseExpression):
 
     def set_head(self, head):
         self._head = head
-        self._symbols = None
+        self._token = None
 
     def get_leaves(self):
         return self._leaves
@@ -673,14 +702,14 @@ class Expression(BaseExpression):
         leaves = list(self._leaves)
         leaves[index] = value
         self._leaves = tuple(leaves)
-        self._symbols = None
+        self._token = None
         self._sequences = None
-        self.last_evaluated = None
 
     def set_reordered_leaves(self, leaves):  # same leaves, but in a different order
         self._leaves = tuple(leaves)
         self._sequences = None
-        self.last_evaluated = None
+        if self._token:
+            self._token = self._token.reordered()
 
     def get_lookup_name(self):
         return self.head.get_lookup_name()
@@ -926,7 +955,7 @@ class Expression(BaseExpression):
         try:
             while reevaluate:
                 # changed before last evaluated?
-                if definitions.not_changed(expr, expr.last_evaluated):
+                if not definitions.changed(expr._token):
                     break
 
                 names.add(expr.get_lookup_name())
@@ -1028,13 +1057,13 @@ class Expression(BaseExpression):
         if 'System`Orderless' in attributes:
             new.sort()
 
-        new.last_evaluated = evaluation.definitions.now
+        new.update_token(evaluation)
 
         if 'System`Listable' in attributes:
             done, threaded = new.thread(evaluation)
             if done:
                 if threaded.same(new):
-                    new.last_evaluated = evaluation.definitions.now
+                    new.update_token(evaluation)
                     return new, False
                 else:
                     return threaded, True
@@ -1061,7 +1090,7 @@ class Expression(BaseExpression):
             result = rule.apply(new, evaluation, fully=False)
             if result is not None:
                 if result.same(new):
-                    new.last_evaluated = evaluation.definitions.now
+                    new.update_token(evaluation)
                     return new, False
                 else:
                     return result, True
@@ -1079,7 +1108,7 @@ class Expression(BaseExpression):
             new = Expression(head, *dirty_leaves)
 
         new.unformatted = self.unformatted
-        new.last_evaluated = evaluation.definitions.now
+        new.update_token(evaluation)
         return new, False
 
     def evaluate_leaves(self, evaluation):
@@ -2434,6 +2463,9 @@ def _is_safe_head(head, cache, evaluation):
     return r
 
 
+_optimize_sequences = True  # more complex code, gains primarily for Partition[]
+
+
 class Structure:
     # performance test case: x = Range[50000]; First[Timing[Partition[x, 15, 1]]]
 
@@ -2443,42 +2475,25 @@ class Structure:
         self.head = head
 
         if isinstance(orig, (Expression, Structure)):
-            last_evaluated = orig.last_evaluated
-            if last_evaluated is not None and not _is_safe_head(head, cache, evaluation):
-                last_evaluated = None
-                symbols = None
-            else:
-                symbols = orig.symbols()
+            token = orig._token
+            if token is not None and not _is_safe_head(head, cache, evaluation):
+                token = None
         elif isinstance(orig, (list, tuple)):
             if _is_safe_head(head, cache, evaluation):
-                definitions = evaluation.definitions
-                last_evaluated = definitions.now
-                symbols = set()
-                for expr in orig:
-                    if not definitions.not_changed(expr, expr.last_evaluated):
-                        last_evaluated = None
-                        symbols = None
-                        break
-                    symbols = symbols.union(expr.symbols())
+                token = EvaluationToken.union([expr._token for expr in orig], evaluation)
             else:
-                last_evaluated = None
-                symbols = None
+                token = None
         else:
             raise ValueError('expected Expression, Structure, tuple or list as orig param')
 
-        self.last_evaluated = last_evaluated
-        self._symbols = symbols
-
-    def symbols(self):
-        return self._symbols
+        self._token = token
 
     def __call__(self, leaves):  # create from leaves
         # IMPORTANT: caller guarantees that leaves originate from orig.leaves or its sub trees!
 
         expr = Expression(self.head)
         expr._leaves = tuple(leaves)
-        expr._symbols = self._symbols
-        expr.last_evaluated = self.last_evaluated
+        expr._token = self._token
         return expr
 
     def filter(self, expr, cond):
@@ -2495,13 +2510,14 @@ class Structure:
 
         expr = self(leaves[lower:upper])
 
-        seq = expr._sequences
-        if seq:
-            a = bisect_left(seq, lower)  # all(val >= i for val in seq[a:])
-            b = bisect_left(seq, upper)  # all(val >= j for val in seq[b:])
+        if _optimize_sequences:
+            seq = expr._sequences
+            if seq:
+                a = bisect_left(seq, lower)  # all(val >= i for val in seq[a:])
+                b = bisect_left(seq, upper)  # all(val >= j for val in seq[b:])
 
-            expr._sequences = tuple(x - lower for x in seq[a:b])  # (O2)
-        elif seq is not None:
-            expr._sequences = ()
+                expr._sequences = tuple(x - lower for x in seq[a:b])  # (O2)
+            elif seq is not None:
+                expr._sequences = ()
 
         return expr

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -1007,7 +1007,7 @@ class Expression(BaseExpression):
         for index, leaf in enumerate(new.leaves):
             if leaf.unevaluated:
                 new.leaves[index] = Expression('Unevaluated', leaf)
-                new.sym = None
+                new._symbols = None
 
         new.unformatted = self.unformatted
         new.last_evaluated = evaluation.definitions.now

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -529,6 +529,13 @@ class Expression(BaseExpression):
     def leaves(self, value):
         raise ValueError('Expression.leaves is write protected. Use set_leaves().')
 
+    def restructure(self, head, leaves):
+        # NOTE: leaves must originate from self.leaves or its sub trees!
+        expr = Expression(head)
+        expr.leaves = leaves
+        expr.last_evaluated = self.last_evaluated
+        return expr
+
     def partition(self, n, d):
         assert n > 0 and d > 0
 
@@ -538,7 +545,7 @@ class Expression(BaseExpression):
         # (O3) if self has been evaluated, there's no need to
         # reevaluate any partition of self.
 
-        # performance test case: First[Timing[Partition[Range[50000], 15, 1]]]
+        # performance test case: x = Range[50000]; First[Timing[Partition[x, 15, 1]]]
 
         leaves = self.leaves
         head = Symbol('List')
@@ -554,10 +561,8 @@ class Expression(BaseExpression):
             a = bisect_left(seq, lower)  # all(val >= i for val in seq[a:])
             b = bisect_left(seq, upper)  # all(val >= j for val in seq[b:])
 
-            expr = Expression(head)  # (O1)
-            expr.leaves = chunk  # (O1)
+            expr = self.restructure(head, chunk)  # (O1), (O3)
             expr._sequences = tuple(x - lower for x in seq[a:b])  # (O2)
-            expr.last_evaluated = self.last_evaluated  # (O3)
 
             yield expr
 

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -2668,3 +2668,26 @@ def structure(head, origins, evaluation, structure_cache=None):
     else:
         return LinkedStructure(head, cache)
 
+
+def atom_list(head, leaves, atom_names, evaluation):
+    # if we encounter an Expression that consists wholly of atoms and those atoms have
+    # no rules associated with them, we can speed up evaluation.
+
+    expr = Expression(head)
+    expr._leaves = leaves
+
+    if not _is_neutral_head(head, None, evaluation) or any(not atom for atom in atom_names):
+        return expr
+
+    full_atom_names = [ensure_context(atom) for atom in atom_names]
+
+    if not all(_is_neutral_symbol(atom, None, evaluation) for atom in full_atom_names):
+        return expr
+
+    sym = set(chain([head.get_name()], full_atom_names))
+    expr._cache = ExpressionCache(evaluation.definitions.now, sym, None)
+    return expr
+
+
+def string_list(head, leaves, evaluation):
+    return atom_list(head, leaves, ('String',), evaluation)

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -640,13 +640,11 @@ class Expression(BaseExpression):
         leaves = list(self._leaves)
         leaves[index] = value
         self._leaves = tuple(leaves)
-        self._leaves_changed()
-
-    def _leaves_changed(self):
         self._symbols = None
         self._sequences = None
 
-    def _leaves_reordered(self):
+    def set_reordered_leaves(self, leaves):
+        self._leaves = leaves
         self._sequences = None
 
     def get_lookup_name(self):
@@ -1253,8 +1251,7 @@ class Expression(BaseExpression):
             leaves.sort(key=lambda e: e.get_sort_key(pattern_sort=True))
         else:
             leaves.sort()
-        self._leaves = tuple(leaves)
-        self._leaves_reordered()
+        self.set_reordered_leaves(leaves)
 
     def filter_leaves(self, head_name):
         # TODO: should use sorting

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -518,7 +518,7 @@ class Expression(BaseExpression):
 
     @head.setter
     def head(self, value):
-        raise ValueError('Expression.head is write protected')
+        raise ValueError('Expression.head is write protected. Use set_head().')
 
     @property
     def leaves(self):
@@ -526,7 +526,7 @@ class Expression(BaseExpression):
 
     @leaves.setter
     def leaves(self, value):
-        raise ValueError('Expression.leaves is write protected')
+        raise ValueError('Expression.leaves is write protected. Use set_leaves().')
 
     def sequences(self):
         seq = self._sequences
@@ -641,10 +641,10 @@ class Expression(BaseExpression):
     def get_leaves(self):
         return self._leaves
 
-    def get_mutable_leaves(self):
+    def get_mutable_leaves(self):  # shallow, mutable copy of the leaves array
         return list(self._leaves)
 
-    def set_leaves(self, index, value):
+    def set_leaves(self, index, value):  # leaves are removed, added or replaced
         leaves = list(self._leaves)
         leaves[index] = value
         self._leaves = tuple(leaves)
@@ -652,7 +652,7 @@ class Expression(BaseExpression):
         self._sequences = None
         self.last_evaluated = None
 
-    def set_reordered_leaves(self, leaves):
+    def set_reordered_leaves(self, leaves):  # same leaves, but in a different order
         self._leaves = tuple(leaves)
         self._sequences = None
         self.last_evaluated = None

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -509,7 +509,7 @@ class Expression(BaseExpression):
         self.head = head
         self.leaves = [from_python(leaf) for leaf in leaves]
         self._sequences = None
-        self.sym = None
+        self._symbols = None
         return self
 
     def sequences(self):
@@ -561,7 +561,7 @@ class Expression(BaseExpression):
         return expr
 
     def symbols(self, intermediate=False):
-        sym = self.sym
+        sym = self._symbols
         if sym is None:
             list_of_symbols = [self.get_head_name()]
 
@@ -581,10 +581,10 @@ class Expression(BaseExpression):
             else:
                 sym = set(list_of_symbols)
 
-            self.sym = sym
+            self._symbols = sym
         elif not intermediate and isinstance(sym, list):
             sym = set(sym)
-            self.sym = sym
+            self._symbols = sym
 
         return sym
 
@@ -592,7 +592,7 @@ class Expression(BaseExpression):
         result = Expression(
             self.head.copy(), *[leaf.copy() for leaf in self.leaves])
         result._sequences = self._sequences
-        result.sym = self.sym
+        result._symbols = self._symbols
         result.options = self.options
         result.original = self
         # result.last_evaluated = self.last_evaluated
@@ -604,7 +604,7 @@ class Expression(BaseExpression):
         expr = Expression(self.head)
         expr.leaves = self.leaves
         expr._sequences = self._sequences
-        expr.sym = self.sym
+        expr._symbols = self._symbols
         expr.options = self.options
         expr.last_evaluated = self.last_evaluated
         return expr

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -560,7 +560,7 @@ class Expression(BaseExpression):
             expr.options = self.options
         return expr
 
-    def symbols(self):
+    def symbols(self, intermediate=False):
         sym = self.sym
         if sym is None:
             list_of_symbols = [self.get_head_name()]
@@ -569,9 +569,21 @@ class Expression(BaseExpression):
                 if isinstance(leaf, Symbol):
                     list_of_symbols.append(leaf.get_name())
                 elif isinstance(leaf, Expression):
-                    list_of_symbols.extend(list(leaf.symbols()))
+                    list_of_symbols.extend(list(leaf.symbols(True)))
 
-            sym = set(list_of_symbols)
+            # converting the symbols list to a set is slow. by default,
+            # we only do this for the final expression returned to
+            # not_changed(), but not for intermediate ones. this yields
+            # better benchmarks.
+
+            if intermediate:
+                sym = list_of_symbols
+            else:
+                sym = set(list_of_symbols)
+
+            self.sym = sym
+        elif not intermediate and isinstance(sym, list):
+            sym = set(sym)
             self.sym = sym
 
         return sym

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -603,7 +603,7 @@ class Expression(BaseExpression):
             k = i + 1
         extend(leaves[k:])
 
-        return Expression(self.head, *flattened)
+        return self.restructure(self.head, flattened)
 
     def flatten_sequence(self):
         def sequence(leaf):
@@ -1053,7 +1053,8 @@ class Expression(BaseExpression):
             eval_range(range(len(leaves)))
             # rest_range(range(0, 0))
 
-        new = Expression(head, *leaves)
+        new = Expression(head)
+        new._leaves = leaves
 
         if ('System`SequenceHold' not in attributes and    # noqa
             'System`HoldAllComplete' not in attributes):
@@ -1134,7 +1135,8 @@ class Expression(BaseExpression):
                 dirty_leaves[index] = Expression('Unevaluated', leaf)
 
         if dirty_leaves:
-            new = Expression(head, *dirty_leaves)
+            new = Expression(head)
+            new._leaves = dirty_leaves
 
         new.unformatted = self.unformatted
         new.update_token(evaluation)

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -627,7 +627,7 @@ class Expression(BaseExpression):
             expr.options = self.options
         return expr
 
-    def _prepare_symbols(self, as_set=False):
+    def _prepare_symbols(self):
         token = self._token
 
         if token is None:
@@ -635,29 +635,17 @@ class Expression(BaseExpression):
         else:
             sym = token.symbols
             if sym is not None:
-                if as_set and isinstance(sym, list):
-                    token = EvaluationToken(token.time, set(sym))
                 return token
             time = token.time
 
-        list_of_symbols = [self.get_head_name()]
+        sym = set((self.get_head_name(),))
 
         for leaf in self._leaves:
             if isinstance(leaf, Symbol):
-                list_of_symbols.append(leaf.get_name())
+                sym.add(leaf.get_name())
             elif isinstance(leaf, Expression):
                 leaf_token = leaf._prepare_symbols()
-                list_of_symbols.extend(list(leaf_token.symbols))
-
-        # converting the symbols list to a set is slow. by default,
-        # we only do this for the final expression given to
-        # Definitions.changed(), but not for intermediate ones.
-        # this yields better benchmarks.
-
-        sym = list_of_symbols
-
-        if as_set:
-            sym = set(sym)
+                sym.update(leaf_token.symbols)
 
         token = EvaluationToken(time, sym)
         return token
@@ -676,7 +664,7 @@ class Expression(BaseExpression):
         if time is None:
             return None
 
-        return self._prepare_symbols(as_set=True)
+        return self._prepare_symbols()
 
     def update_token(self, evaluation):
         token = self._token

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -529,19 +529,13 @@ class Expression(BaseExpression):
     def leaves(self, value):
         raise ValueError('Expression.leaves is write protected. Use set_leaves().')
 
-    def slice(self, lower, upper, evaluation, head=None):
-        if head is None:
-            head = self.head
-        return Structure(head, self, evaluation).slice(self, lower, upper)
+    def slice(self, head, py_slice, evaluation):
+        return Structure(head, self, evaluation).slice(self, py_slice)
 
-    def filter(self, cond, evaluation, head=None):
-        if head is None:
-            head = self.head
+    def filter(self, head, cond, evaluation):
         return Structure(head, self, evaluation).filter(self, cond)
 
-    def restructure(self, leaves, evaluation, head=None, cache=None, deps=None):
-        if head is None:
-            head = self.head
+    def restructure(self, head, leaves, evaluation, cache=None, deps=None):
         if deps is None:
             deps = self
         s = Structure(head, deps, evaluation, cache=cache)
@@ -2467,11 +2461,14 @@ class Structure:
         # IMPORTANT: caller guarantees that expr is from origins!
         return self([leaf for leaf in expr.leaves if cond(leaf)])
 
-    def slice(self, expr, lower, upper):
+    def slice(self, expr, py_slice):
         # IMPORTANT: caller guarantees that expr is from origins!
 
         leaves = expr.leaves
-        lower, upper, _ = slice(lower, upper).indices(len(leaves))
+        lower, upper, step = py_slice.indices(len(leaves))
+        if step != 1:
+            raise ValueError('Structure.slice only supports slice steps of 1')
+
         expr = self(leaves[lower:upper])
 
         seq = expr._sequences

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -135,16 +135,36 @@ class KeyComparable(object):
         return self.get_sort_key() != other.get_sort_key()
 
 
-class EvaluationToken:
-    def __init__(self, time=None, symbols=None, sequences=None):
+# ExpressionCache keeps track of the following attributes for one Expression instance:
+
+# time: (1) the last time (in terms of Definitions.now) this expression was evaluated
+#   or (2) None, if the current expression has not yet been evaluatec (i.e. is new or
+#   changed).
+# symbols: (1) a set of symbols occuring in this expression's head, its leaves'
+#   heads, any of its sub expressions' heads or as Symbol leaves somewhere (maybe deep
+#   down) in the expression tree start by this expressions' leaves, or (2) None, if no
+#   information on which symbols are contained in this expression is available
+# sequences: (1) a list of leaf indices that indicate the position of all Sequence
+#   heads that are either in the leaf's head or any of the indicated leaf's sub
+#   expressions' heads, or (2) None, if no information is available.
+
+class ExpressionCache:
+    def __init__(self, time=None, symbols=None, sequences=None, copy=None):
+        if copy is not None:
+            time = time or copy.time
+            symbols = symbols or copy.symbols
+            sequences = sequences or copy.sequences
         self.time = time
         self.symbols = symbols
         self.sequences = sequences
 
     def copy(self):
-        return EvaluationToken(self.time, self.symbols, self.sequences)
+        return ExpressionCache(self.time, self.symbols, self.sequences)
 
     def sliced(self, lower, upper):
+        # indicates that the Expression's leaves have been slices with
+        # the given indices.
+
         seq = self.sequences
 
         if seq:
@@ -156,37 +176,37 @@ class EvaluationToken:
         else:
             new_sequences = None
 
-        return EvaluationToken(self.time, self.symbols, new_sequences)
+        return ExpressionCache(self.time, self.symbols, new_sequences)
 
     def reordered(self):
+        # indicates that the Expression's leaves have been reordered
+        # or reduced (i.e. that the leaves have changed, but that
+        # no new leaf instances were added).
+
         sequences = self.sequences
 
-        # note that we do not touch sequences == [], which
-        # is fine even with reordered leaves.
+        # note that we keep sequences == [], since they are fine even
+        # after having reordered leaves.
         if sequences:
             sequences = None
 
-        return EvaluationToken(None, self.symbols, sequences)
+        return ExpressionCache(None, self.symbols, sequences)
 
     @staticmethod
     def union(expressions, evaluation):
         definitions = evaluation.definitions
 
         for expr in expressions:
-            if expr.changed(definitions):
+            if expr.has_changed(definitions):
                 return None
 
-        new_sequences = tuple()
-        for expr in expressions:
-            seq = expr._token.sequences
-            if seq is None or len(seq) > 0:
-                new_sequences = None
-                break
+        symbols = set.union(
+            *[expr._cache.symbols for expr in expressions])
 
-        return EvaluationToken(
+        return ExpressionCache(
             definitions.now,
-            set.union(*[expr._token.symbols for expr in expressions]),
-            new_sequences)
+            symbols,
+            None if 'System`Sequence' in symbols else tuple())
 
 
 class BaseExpression(KeyComparable):
@@ -195,13 +215,13 @@ class BaseExpression(KeyComparable):
         self.options = None
         self.pattern_sequence = False
         self.unformatted = self
-        self._token = None
+        self._cache = None
         return self
 
-    def clear_token(self):
-        self._token = None
+    def clear_cache(self):
+        self._cache = None
 
-    def changed(self, definitions):
+    def has_changed(self, definitions):
         return True
 
     def sequences(self):
@@ -583,13 +603,13 @@ class Expression(BaseExpression):
 
     def slice(self, head, py_slice, evaluation):
         # faster equivalent to: Expression(head, *self.leaves[py_slice])
-        return Structure(head, self, evaluation).slice(self, py_slice)
+        return structure(head, self, evaluation).slice(self, py_slice)
 
     def filter(self, head, cond, evaluation):
         # faster equivalent to: Expression(head, [leaf in self.leaves if cond(leaf)])
-        return Structure(head, self, evaluation).filter(self, cond)
+        return structure(head, self, evaluation).filter(self, cond)
 
-    def restructure(self, head, leaves, evaluation, cache=None, deps=None):
+    def restructure(self, head, leaves, evaluation, structure_cache=None, deps=None):
         # faster equivalent to: Expression(head, *leaves)
 
         # the caller guarantees that _all_ elements in leaves are either from
@@ -597,12 +617,12 @@ class Expression(BaseExpression):
         # in the tuple "deps" (or its sub trees).
 
         # if this method is called repeatedly, and the caller guarantees
-        # that no definitions change between subsequent calls, then cache
+        # that no definitions change between subsequent calls, then heads_cache
         # may be passed an initially empty dict to speed up calls.
 
         if deps is None:
             deps = self
-        s = Structure(head, deps, evaluation, cache=cache)
+        s = structure(head, deps, evaluation, structure_cache=structure_cache)
         return s(list(leaves))
 
     def _no_symbol(self, symbol_name):
@@ -610,24 +630,24 @@ class Expression(BaseExpression):
         # sub leaves contain no Symbol with symbol_name. if this returns
         # False, such a Symbol might or might not exist.
 
-        token = self._token
-        if token is None:
+        cache = self._cache
+        if cache is None:
             return False
 
-        symbols = token.symbols
+        symbols = cache.symbols
         if symbols is not None and symbol_name not in symbols:
             return True
         else:
             return False
 
     def sequences(self):
-        token = self._token
-        if token:
-            seq = token.sequences
+        cache = self._cache
+        if cache:
+            seq = cache.sequences
             if seq is not None:
                 return seq
 
-        return self._inspect_symbols().sequences
+        return self._rebuild_cache().sequences
 
     def _flatten_sequence(self, sequence, evaluation):
         indices = self.sequences()
@@ -670,67 +690,60 @@ class Expression(BaseExpression):
             expr.options = self.options
         return expr
 
-    def _inspect_symbols(self):
-        token = self._token
+    def _rebuild_cache(self):
+        cache = self._cache
 
-        if token is None:
+        if cache is None:
             time = None
-        elif token.symbols is None:
-            time = token.time
-        elif token.sequences is None:
-            time = token.time
+        elif cache.symbols is None:
+            time = cache.time
+        elif cache.sequences is None:
+            time = cache.time
         else:
-            return token
+            return cache
 
         sym = set((self.get_head_name(),))
         seq = []
 
         for i, leaf in enumerate(self._leaves):
             if isinstance(leaf, Expression):
-                leaf_symbols = leaf._inspect_symbols().symbols
+                leaf_symbols = leaf._rebuild_cache().symbols
                 sym.update(leaf_symbols)
                 if 'System`Sequence' in leaf_symbols:
                     seq.append(i)
             elif isinstance(leaf, Symbol):
                 sym.add(leaf.get_name())
 
-        token = EvaluationToken(time, sym, seq)
-        self._token = token
-        return token
+        cache = ExpressionCache(time, sym, seq)
+        self._cache = cache
+        return cache
 
-    def changed(self, definitions):
-        token = self._token
+    def has_changed(self, definitions):
+        cache = self._cache
 
-        if token is None:
+        if cache is None:
             return True
 
-        time = token.time
+        time = cache.time
 
         if time is None:
             return True
 
-        if token.symbols is None:
-            token = self._inspect_symbols()
+        if cache.symbols is None:
+            cache = self._rebuild_cache()
 
-        return definitions.changed(time, token.symbols)
+        return definitions.has_changed(time, cache.symbols)
 
-    def update_token(self, evaluation):
-        token = self._token
-
-        if token is None:
-            sym = None
-            seq = None
-        else:
-            sym = token.symbols
-            seq = token.sequences
-
-        self._token = EvaluationToken(evaluation.definitions.now, sym, seq)
+    def _timestamp_cache(self, evaluation):
+        self._cache = ExpressionCache(evaluation.definitions.now, copy=self._cache)
 
     def copy(self, reevaluate=False):
         expr = Expression(self._head.copy(reevaluate))
         expr._leaves = tuple(leaf.copy(reevaluate) for leaf in self._leaves)
         if not reevaluate:
-            expr._token = self._inspect_symbols()  # First[Timing[Fold[#1+#2&, Range[750]]]]
+            # rebuilding the cache in self speeds up large operations, e.g.
+            # First[Timing[Fold[#1+#2&, Range[750]]]]
+            expr._cache = self._rebuild_cache()
         expr.options = self.options
         expr.original = self
         return expr
@@ -740,7 +753,9 @@ class Expression(BaseExpression):
         # the original, only the Expression instance is new.
         expr = Expression(self._head)
         expr._leaves = self._leaves
-        expr._token = self._inspect_symbols()  # First[Timing[Fold[#1+#2&, Range[750]]]]
+        # rebuilding the cache in self speeds up large operations, e.g.
+        # First[Timing[Fold[#1+#2&, Range[750]]]]
+        expr._cache = self._rebuild_cache()
         expr.options = self.options
         return expr
 
@@ -755,7 +770,7 @@ class Expression(BaseExpression):
 
     def set_head(self, head):
         self._head = head
-        self._token = None
+        self._cache = None
 
     def get_leaves(self):
         return self._leaves
@@ -767,12 +782,12 @@ class Expression(BaseExpression):
         leaves = list(self._leaves)
         leaves[index] = value
         self._leaves = tuple(leaves)
-        self._token = None
+        self._cache = None
 
     def set_reordered_leaves(self, leaves):  # same leaves, but in a different order
         self._leaves = tuple(leaves)
-        if self._token:
-            self._token = self._token.reordered()
+        if self._cache:
+            self._cache = self._cache.reordered()
 
     def get_lookup_name(self):
         return self._head.get_lookup_name()
@@ -1022,7 +1037,7 @@ class Expression(BaseExpression):
         try:
             while reevaluate:
                 # changed before last evaluated?
-                if not expr.changed(definitions):
+                if not expr.has_changed(definitions):
                     break
 
                 names.add(expr.get_lookup_name())
@@ -1128,13 +1143,13 @@ class Expression(BaseExpression):
         if 'System`Orderless' in attributes:
             new.sort()
 
-        new.update_token(evaluation)
+        new._timestamp_cache(evaluation)
 
         if 'System`Listable' in attributes:
             done, threaded = new.thread(evaluation)
             if done:
                 if threaded.same(new):
-                    new.update_token(evaluation)
+                    new._timestamp_cache(evaluation)
                     return new, False
                 else:
                     return threaded, True
@@ -1161,7 +1176,7 @@ class Expression(BaseExpression):
             result = rule.apply(new, evaluation, fully=False)
             if result is not None:
                 if result.same(new):
-                    new.update_token(evaluation)
+                    new._timestamp_cache(evaluation)
                     return new, False
                 else:
                     return result, True
@@ -1180,7 +1195,7 @@ class Expression(BaseExpression):
             new._leaves = tuple(dirty_leaves)
 
         new.unformatted = self.unformatted
-        new.update_token(evaluation)
+        new._timestamp_cache(evaluation)
         return new, False
 
     def evaluate_leaves(self, evaluation):
@@ -2512,7 +2527,11 @@ def print_parenthesizes(precedence, outer_precedence=None,
             outer_precedence == precedence and parenthesize_when_equal)))
 
 
-def _is_safe_head(head, cache, evaluation):
+def _is_neutral_head(head, cache, evaluation):
+    # a head is neutral if it does not invoke any rules, but is sure to make its Expression stay
+    # the way it is (e.g. List[1, 2, 3] will always stay List[1, 2, 3], so long as nobody defines
+    # a rule on this).
+
     if not isinstance(head, Symbol):
         return False
 
@@ -2537,50 +2556,113 @@ def _is_safe_head(head, cache, evaluation):
     return r
 
 
-class Structure:
-    # performance test case: x = Range[50000]; First[Timing[Partition[x, 15, 1]]]
+# Structure helps implementations make the ExpressionCache not invalidate across simple commands
+# such as Take[], Most[], etc. without this, constant reevaluation of lists happens, which results
+# in quadratic runtimes for command like Fold[#1+#2&, Range[x]].
 
-    def __init__(self, head, orig, evaluation, cache=None):
-        if isinstance(head, six.string_types):
-            head = Symbol(head)
-        self.head = head
+# A good performance test case for Structure: x = Range[50000]; First[Timing[Partition[x, 15, 1]]]
 
-        if isinstance(orig, (Expression, Structure)):
-            token = orig._token
-            if token is not None and not _is_safe_head(head, cache, evaluation):
-                token = None
-        elif isinstance(orig, (list, tuple)):
-            if _is_safe_head(head, cache, evaluation):
-                token = EvaluationToken.union(orig, evaluation)
-            else:
-                token = None
-        else:
-            raise ValueError('expected Expression, Structure, tuple or list as orig param')
 
-        self._token = token
+class Structure(object):
+    def __call__(self, leaves):
+        # create an Expression with the given list "leaves" as leaves.
+        # NOTE: the caller guarantees that "leaves" only contains items that are from "origins".
+        raise NotImplementedError
 
-    def __call__(self, leaves):  # create from leaves
-        # IMPORTANT: caller guarantees that leaves originate from orig.leaves or its sub trees!
+    def filter(self, expr, cond):
+        # create an Expression with a subset of "expr".leaves (picked out by the filter "cond").
+        # NOTE: the caller guarantees that "expr" is from "origins".
+        raise NotImplementedError
 
-        expr = Expression(self.head)
+    def slice(self, expr, py_slice):
+        # create an Expression, using the given slice of "expr".leaves as leaves.
+        # NOTE: the caller guarantees that "expr" is from "origins".
+        raise NotImplementedError
+
+
+# UnlinkedStructure produces Expressions that are not linked to "origins" in terms of cache.
+# This produces the same thing as doing Expression(head, *leaves).
+
+class UnlinkedStructure(Structure):
+    def __init__(self, head):
+        self._head = head
+        self._cache = None
+
+    def __call__(self, leaves):
+        expr = Expression(self._head)
         expr._leaves = tuple(leaves)
-        if self._token:
-            expr._token = self._token.reordered()
         return expr
 
     def filter(self, expr, cond):
-        # IMPORTANT: caller guarantees that expr is from origins!
         return self([leaf for leaf in expr._leaves if cond(leaf)])
 
     def slice(self, expr, py_slice):
-        # IMPORTANT: caller guarantees that expr is from origins!
+        leaves = expr._leaves
+        lower, upper, step = py_slice.indices(len(leaves))
+        if step != 1:
+            raise ValueError('Structure.slice only supports slice steps of 1')
+        return self(leaves[lower:upper])
 
+
+# LinkedStructure produces Expressions that are linked to "origins" in terms of cache. This
+# carries over information from the cache of the originating Expressions into the Expressions
+# that are newly created.
+
+class LinkedStructure(Structure):
+    def __init__(self, head, cache):
+        self._head = head
+        self._cache = cache
+
+    def __call__(self, leaves):
+        expr = Expression(self._head)
+        expr._leaves = tuple(leaves)
+        expr._cache = self._cache.reordered()
+        return expr
+
+    def filter(self, expr, cond):
+        return self([leaf for leaf in expr._leaves if cond(leaf)])
+
+    def slice(self, expr, py_slice):
         leaves = expr._leaves
         lower, upper, step = py_slice.indices(len(leaves))
         if step != 1:
             raise ValueError('Structure.slice only supports slice steps of 1')
 
-        new = self(leaves[lower:upper])
-        if expr._token:
-            new._token = expr._token.sliced(lower, upper)
+        new = Expression(self._head)
+        new._leaves = tuple(leaves[lower:upper])
+        if expr._cache:
+            new._cache = expr._cache.sliced(lower, upper)
+
         return new
+
+
+def structure(head, origins, evaluation, structure_cache=None):
+    # creates a Structure for building Expressions with head "head" and leaves
+    # originating (exlusively) from "origins" (leaves are passed into the functions
+    # of Structure further down).
+
+    # "origins" may either be an Expression (i.e. all leaves must originate from that
+    # expression), a Structure (all leaves passed in this "self" Structure must be
+    # manufactured using that Structure), or a list of Expressions (i.e. all leaves
+    # must originate from one of the listed Expressions).
+
+    if isinstance(head, six.string_types):
+        head = Symbol(head)
+
+    if isinstance(origins, (Expression, Structure)):
+        cache = origins._cache
+        if cache is not None and not _is_neutral_head(head, structure_cache, evaluation):
+            cache = None
+    elif isinstance(origins, (list, tuple)):
+        if _is_neutral_head(head, structure_cache, evaluation):
+            cache = ExpressionCache.union(origins, evaluation)
+        else:
+            cache = None
+    else:
+        raise ValueError('expected Expression, Structure, tuple or list as orig param')
+
+    if cache is None:
+        return UnlinkedStructure(head)
+    else:
+        return LinkedStructure(head, cache)
+

--- a/mathics/core/pattern.py
+++ b/mathics/core/pattern.py
@@ -9,6 +9,7 @@ from mathics.core.expression import (Expression, system_symbols,
                                      ensure_context)
 from mathics.core.util import subsets, subranges, permutations
 from six.moves import range
+from itertools import chain
 
 # from mathics.core.pattern_nocython import (
 #    StopGenerator #, Pattern #, ExpressionPattern)
@@ -451,11 +452,11 @@ class ExpressionPattern(Pattern):
                 if next_rest is None:
                     yield_func(
                         next_vars,
-                        (rest_expression[0] + items_rest[0], []))
+                        (list(chain(rest_expression[0], items_rest[0])), []))
                 else:
                     yield_func(
                         next_vars,
-                        (rest_expression[0] + items_rest[0], next_rest[1]))
+                        (list(chain(rest_expression[0], items_rest[0])), next_rest[1]))
 
             def match_yield(new_vars, _):
                 if rest_leaves:

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -89,16 +89,15 @@ class Rule(BaseRule):
         # options' values. this is achieved through Expression.evaluate(), which then triggers OptionValue.apply,
         # which in turn consults evaluation.options to return an option value.
 
-        # in order to get there, our expression 'new' (or parts of it) must have last_evaluated None, since this
-        # would make Expression.evaluate() quit early. doing a clean deep copy here, will reset
-        # Expression.last_evaluated for all nodes in the tree.
+        # in order to get there, we copy 'new' using copy(reevaluate=True), as this will ensure that the whole thing
+        # will get reevaluated.
 
         # if the expression contains OptionValue[] patterns, but options is empty here, we don't need to act, as the
         # expression won't change in that case. the Expression.options would be None anyway, so OptionValue.apply
         # would just return the unchanged expression (which is what we have already).
 
         if options:
-            new = new.copy()
+            new = new.copy(reevaluate=True)
 
         return new
 

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -6,9 +6,9 @@ from __future__ import absolute_import
 
 from mathics.core.expression import Expression, strip_context, KeyComparable
 from mathics.core.pattern import Pattern, StopGenerator
-
 from mathics.core.util import function_arguments
 
+from itertools import chain
 
 class StopGenerator_BaseRule(StopGenerator):
     pass
@@ -42,8 +42,8 @@ class BaseRule(KeyComparable):
             if new_expression is None:
                 new_expression = expression
             if rest[0] or rest[1]:
-                result = Expression(expression.get_head(), *(
-                    rest[0] + [new_expression] + rest[1]))
+                result = Expression(expression.get_head(), *list(
+                    chain(rest[0], [new_expression], rest[1])))
             else:
                 result = new_expression
 

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -48,7 +48,7 @@ class BaseRule(KeyComparable):
                 result = new_expression
 
             # Flatten out sequences (important for Rule itself!)
-            result = result.flatten_pattern_sequence()
+            result = result.flatten_pattern_sequence(evaluation)
             if return_list:
                 result_list.append(result)
                 # count += 1

--- a/mathics/core/util.py
+++ b/mathics/core/util.py
@@ -10,6 +10,7 @@ from six import unichr
 
 import re
 import sys
+from itertools import chain
 
 FORMAT_RE = re.compile(r'\`(\d*)\`')
 
@@ -75,10 +76,10 @@ def subsets(items, min, max, included=None, less_first=False):
         if count < 0 or len(rest) < count:
             return
         if count == 0:
-            yield chosen, not_chosen + rest
+            yield chosen, list(chain(not_chosen, rest))
         elif len(rest) == count:
             if included is None or all(item in included for item in rest):
-                yield chosen + rest, not_chosen
+                yield list(chain(chosen, rest)), not_chosen
         elif rest:
             item = rest[0]
             if included is None or item in included:


### PR DESCRIPTION
This is continuation of #575 and #615. It's my cleaned up proposal for fixing quadratic runtimes in Mathics.

The following plots show the results of the accompanying two commands, run once using `master` (yellowish) and once using this PR (blue). Don't ask me where the spurious regular dots come from (garbage collection?).

`First[Timing[Fold[#1+#2&, Range[#]]]]& /@ Range[750]`

![plot-1](https://cloud.githubusercontent.com/assets/11859538/19362024/387d7fd0-9185-11e6-9c51-439b803e8aa1.png)

```
MyTotal[x0_] := Module[{x = x0, y = 0}, While[Length[x] > 0, y = y + First[x]; x = Rest[x]]; y];
First[Timing[MyTotal[Range[#]]]]& /@ Range[500]
```

![plot2](https://cloud.githubusercontent.com/assets/11859538/19362039/456eed8c-9185-11e6-83b0-569cb1150c17.png)

The changes are twofold:
- First, a new class called a `Structure` was introduced to enable list operations like `Most` or `Take` not to trigger an evaluation of every leaf again (this used to be #615).
- Second, the cache check is now based on a set of symbols rather than a full tree traversal (this used to be #575).

The quadratic runtimes are only fixed when both measures are applied, which is why I merged everything into this PR now.

All the information regarding cached `Expression` information (including what is `Expression._sequences` in `master`) is now bundled in `ExpressionCache`, which makes the code much cleaner I think.

I experimented with quite a variety of data structures, including `dict`s instead of `set`s for the symbol caching, but a `set` and a `sequences` list seems to be the best thing to do.
