### PR TITLE
CharacterEncoding and more

### DIFF
--- a/mathics/autoload/formats/CSV/Export.m
+++ b/mathics/autoload/formats/CSV/Export.m
@@ -7,9 +7,9 @@ Options[CSVExport] = {
     "FieldSeparators" -> ","
 };
 
-CSVExport[filename_String, data_, opts:OptionsPattern[]]:=
-    Module[{strm, char, wraplist, sep = "FieldSeparators" /. {opts}},
-        strm = OpenWrite @@ Join[{filename}, FilterRules[{opts}, "CharacterEncoding"]];
+CSVExport[filename_String, data_, OptionsPattern[]]:=
+    Module[{strm, char, wraplist, sep = OptionValue["FieldSeparators"]},
+        strm = OpenWrite[filename, CharacterEncoding -> OptionValue["CharacterEncoding"]];
         If[strm === $Failed, Return[$Failed]];
         wraplist[x_] := If[Head[x] === List, x, {x}];
         char = Map[ToString, wraplist /@ wraplist[data], {2}];

--- a/mathics/autoload/formats/CSV/Export.m
+++ b/mathics/autoload/formats/CSV/Export.m
@@ -2,25 +2,33 @@
 
 Begin["System`Convert`TableDump`"]
 
+Options[CSVExport] = {
+    "CharacterEncoding" :> $CharacterEncoding,
+    "FieldSeparators" -> ","
+};
 
-CSVExport[filename_String, data_, opts___]:=
-  Module[{strm, char, wraplist},
-    strm = OpenWrite[filename];
-    If[strm === $Failed, Return[$Failed]];
-    wraplist[x_] := If[Head[x] === List, x, {x}];
-    char = Map[ToString, wraplist /@ wraplist[data], {2}];
-    char = StringJoin[Riffle[Riffle[#, ","] & /@ char, "\n"]];
-    WriteString[strm, char];
-    Close[strm];
-  ]
+CSVExport[filename_String, data_, opts:OptionsPattern[]]:=
+    Module[{strm, char, wraplist, sep = "FieldSeparators" /. {opts}},
+        strm = OpenWrite[filename];
+        If[strm === $Failed, Return[$Failed]];
+        wraplist[x_] := If[Head[x] === List, x, {x}];
+        char = Map[ToString, wraplist /@ wraplist[data], {2}];
+        char = StringJoin[Riffle[Riffle[#, sep] & /@ char, "\n"]];
+        WriteString[strm, char];
+        Close[strm];
+    ]
 
 ImportExport`RegisterExport[
-  "CSV",
-  System`Convert`TableDump`CSVExport,
-  FunctionChannels -> {"FileNames"},
-  Options -> {"ByteOrderMark"},
-  DefaultElement -> "Plaintext",
-  BinaryFormat -> True
+    "CSV",
+    System`Convert`TableDump`CSVExport,
+    FunctionChannels -> {"FileNames"},
+    Options -> {"ByteOrderMark"},
+    DefaultElement -> "Plaintext",
+    BinaryFormat -> True,
+    Options -> {
+        "CharacterEncoding",
+        "FieldSeparators"
+    }
 ]
 
 

--- a/mathics/autoload/formats/CSV/Export.m
+++ b/mathics/autoload/formats/CSV/Export.m
@@ -9,7 +9,7 @@ Options[CSVExport] = {
 
 CSVExport[filename_String, data_, opts:OptionsPattern[]]:=
     Module[{strm, char, wraplist, sep = "FieldSeparators" /. {opts}},
-        strm = OpenWrite[filename];
+        strm = OpenWrite @@ Join[{filename}, FilterRules[{opts}, "CharacterEncoding"]];
         If[strm === $Failed, Return[$Failed]];
         wraplist[x_] := If[Head[x] === List, x, {x}];
         char = Map[ToString, wraplist /@ wraplist[data], {2}];

--- a/mathics/autoload/formats/CSV/Import.m
+++ b/mathics/autoload/formats/CSV/Import.m
@@ -3,10 +3,15 @@
 Begin["System`Convert`TableDump`"]
 
 
+Options[ImportCSV] = {
+    "CharacterEncoding" :> $CharacterEncoding,
+    "FieldSeparators" -> ","
+};
+
 ImportCSV[filename_String, opts:OptionsPattern[]]:=
-    Module[{stream, data, grid, sep = FilterRules[{opts}, System`FieldSeparators][[1]]},
-        stream = OpenRead @@ Join[{filename}, FilterRules[{opts}, System`CharacterEncoding]];
-        data = StringSplit[#, ","]& /@ ReadList[stream, String];
+    Module[{stream, data, grid, sep = "FieldSeparators" /. {opts}},
+        stream = OpenRead @@ Join[{filename}, {} (* FilterRules[{opts}, "CharacterEncoding"] *)  ];
+        data = StringSplit[#, sep]& /@ ReadList[stream, String];
         grid = Grid[data];
         Close[stream];
         {
@@ -25,7 +30,11 @@ ImportExport`RegisterImport[
     (* Sources -> ImportExport`DefaultSources["Table"], *)
     FunctionChannels -> {"FileNames"},
     AvailableElements -> {"Data", "Grid"},
-    DefaultElement -> "Data"
+    DefaultElement -> "Data",
+    Options -> {
+        "CharacterEncoding",
+        "FieldSeparators"
+    }
 ]
 
 

--- a/mathics/autoload/formats/CSV/Import.m
+++ b/mathics/autoload/formats/CSV/Import.m
@@ -8,9 +8,9 @@ Options[ImportCSV] = {
     "FieldSeparators" -> ","
 };
 
-ImportCSV[filename_String, opts:OptionsPattern[]]:=
-    Module[{stream, data, grid, sep = "FieldSeparators" /. {opts}},
-        stream = OpenRead @@ Join[{filename}, FilterRules[{opts}, "CharacterEncoding"]];
+ImportCSV[filename_String, OptionsPattern[]]:=
+    Module[{stream, data, grid, sep = OptionValue["FieldSeparators"]},
+        stream = OpenRead[filename, CharacterEncoding -> OptionValue["CharacterEncoding"]];
         data = StringSplit[#, sep]& /@ ReadList[stream, String];
         grid = Grid[data];
         Close[stream];

--- a/mathics/autoload/formats/CSV/Import.m
+++ b/mathics/autoload/formats/CSV/Import.m
@@ -3,9 +3,9 @@
 Begin["System`Convert`TableDump`"]
 
 
-ImportCSV[filename_String]:=
-    Module[{stream, data, grid},
-        stream = OpenRead[filename];
+ImportCSV[filename_String, opts:OptionsPattern[]]:=
+    Module[{stream, data, grid, sep = FilterRules[{opts}, System`FieldSeparators][[1]]},
+        stream = OpenRead @@ Join[{filename}, FilterRules[{opts}, System`CharacterEncoding]];
         data = StringSplit[#, ","]& /@ ReadList[stream, String];
         grid = Grid[data];
         Close[stream];

--- a/mathics/autoload/formats/CSV/Import.m
+++ b/mathics/autoload/formats/CSV/Import.m
@@ -10,7 +10,7 @@ Options[ImportCSV] = {
 
 ImportCSV[filename_String, opts:OptionsPattern[]]:=
     Module[{stream, data, grid, sep = "FieldSeparators" /. {opts}},
-        stream = OpenRead @@ Join[{filename}, {} (* FilterRules[{opts}, "CharacterEncoding"] *)  ];
+        stream = OpenRead @@ Join[{filename}, FilterRules[{opts}, "CharacterEncoding"]];
         data = StringSplit[#, sep]& /@ ReadList[stream, String];
         grid = Grid[data];
         Close[stream];

--- a/mathics/autoload/formats/Text/Export.m
+++ b/mathics/autoload/formats/Text/Export.m
@@ -6,9 +6,9 @@ Options[TextExport] = {
     "CharacterEncoding" :> $CharacterEncoding
 };
 
-TextExport[filename_, expr_, opts:OptionsPattern[]] :=
+TextExport[filename_, expr_, OptionsPattern[]] :=
   Module[{strm, data},
-    strm = OpenWrite @@ Join[{filename}, FilterRules[{opts}, "CharacterEncoding"]];
+    strm = OpenWrite[filename, CharacterEncoding -> OptionValue["CharacterEncoding"]];
     If[strm === $Failed, Return[$Failed]];
     data = ToString[expr];
     WriteString[strm, data];

--- a/mathics/autoload/formats/Text/Export.m
+++ b/mathics/autoload/formats/Text/Export.m
@@ -2,10 +2,13 @@
 
 Begin["System`Convert`TextDump`"]
 
+Options[TextExport] = {
+    "CharacterEncoding" :> $CharacterEncoding
+};
 
-TextExport[filename_, expr_, opts___] := 
-  Module[{strm, data}, 
-    strm = OpenWrite[filename];
+TextExport[filename_, expr_, opts:OptionsPattern[]] :=
+  Module[{strm, data},
+    strm = OpenWrite @@ Join[{filename}, FilterRules[{opts}, "CharacterEncoding"]];
     If[strm === $Failed, Return[$Failed]];
     data = ToString[expr];
     WriteString[strm, data];
@@ -16,7 +19,7 @@ ImportExport`RegisterExport[
     "Text",
 	System`Convert`TextDump`TextExport,
 	FunctionChannels -> {"FileNames"},
-	Options -> {"ByteOrderMark"},
+	Options -> {"CharacterEncoding", "ByteOrderMark"},
 	DefaultElement -> "Plaintext",
 	BinaryFormat -> True
 ]

--- a/mathics/autoload/formats/Text/Import.m
+++ b/mathics/autoload/formats/Text/Import.m
@@ -47,7 +47,8 @@ ImportExport`RegisterImport[
 	AvailableElements -> {"Data", "Lines", "Plaintext", "String", "Words"},
 	BinaryFormat -> True,
 	DefaultElement -> "Plaintext",
-    FunctionChannels -> {"Streams"}
+    FunctionChannels -> {"Streams"},
+	Options -> {"CharacterEncoding"}
 ]
 
 

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -8,6 +8,7 @@ import re
 import sympy
 from functools import total_ordering
 import importlib
+from itertools import chain
 
 from mathics.core.definitions import Definition
 from mathics.core.rules import Rule, BuiltinRule, Pattern
@@ -192,12 +193,16 @@ class Builtin(object):
 
     @staticmethod
     def get_option(options, name, evaluation, pop=False):
-        # we do not care, whether an option X is given as
-        # System`X, Global`X, or "X". we always handle it
-        # as the same option. this matches Wolfram Language
+        # we do not care whether an option X is given as System`X,
+        # Global`X, or with any prefix from $ContextPath for that
+        # matter. Also, the quoted string form "X" is ok. all these
+        # variants name the same option. this matches Wolfram Language
         # behaviour.
 
-        for variant in ('System`%s', 'Global`%s', '"%s"'):
+        contexts = (s + '%s' for s in
+                    evaluation.definitions.get_context_path())
+
+        for variant in chain(contexts, ('"%s"',)):
             resolved_name = variant % name
 
             if pop:

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -192,14 +192,21 @@ class Builtin(object):
 
     @staticmethod
     def get_option(options, name, evaluation, pop=False):
-        for context in ('System`%s', 'Global`%s', '"%s"'):
-            resolved_name = context % name
-            if resolved_name in options:
-                value = options.pop(resolved_name, None) if pop else options.get(resolved_name)
-                if value is not None:
-                    return value.evaluate(evaluation)
-                else:
-                    return None
+        # we do not care, whether an option X is given as
+        # System`X, Global`X, or "X". we always handle it
+        # as the same option. this matches Wolfram Language
+        # behaviour.
+
+        for variant in ('System`%s', 'Global`%s', '"%s"'):
+            resolved_name = variant % name
+
+            if pop:
+                value = options.pop(resolved_name, None)
+            else:
+                value = options.get(resolved_name)
+
+            if value is not None:
+                return value.evaluate(evaluation)
 
         return None
 

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -190,13 +190,18 @@ class Builtin(object):
                 else:
                     yield (pattern, function)
 
-    def get_option(self, options, name, evaluation, pop=False):
-        name = ensure_context(name)
-        value = options.pop(name, None) if pop else options.get(name)
-        if value is not None:
-            return value.evaluate(evaluation)
-        else:
-            return None
+    @staticmethod
+    def get_option(options, name, evaluation, pop=False):
+        for context in ('System`%s', 'Global`%s', '"%s"'):
+            resolved_name = context % name
+            if resolved_name in options:
+                value = options.pop(resolved_name, None) if pop else options.get(resolved_name)
+                if value is not None:
+                    return value.evaluate(evaluation)
+                else:
+                    return None
+
+        return None
 
     def _get_unavailable_function(self):
         requires = getattr(self, 'requires', [])

--- a/mathics/builtin/files.py
+++ b/mathics/builtin/files.py
@@ -1961,7 +1961,7 @@ class _OpenAction(Builtin):
             path_string = tmp
 
         try:
-            encoding = options.get('System`CharacterEncoding')
+            encoding = options.get('System`CharacterEncoding').evaluate(evaluation)
             if not isinstance(encoding, String):
                 return
 

--- a/mathics/builtin/files.py
+++ b/mathics/builtin/files.py
@@ -1961,7 +1961,7 @@ class _OpenAction(Builtin):
             path_string = tmp
 
         try:
-            encoding = options.get('System`CharacterEncoding').evaluate(evaluation)
+            encoding = self.get_option(options, 'CharacterEncoding', evaluation)
             if not isinstance(encoding, String):
                 return
 

--- a/mathics/builtin/importexport.py
+++ b/mathics/builtin/importexport.py
@@ -485,7 +485,7 @@ class Import(Builtin):
      = ...
     #> Import["ExampleData/Middlemarch.txt"];
      : An invalid unicode sequence was encountered and ignored.
-    #> StringTake[Import["ExampleData/Middlemarch.txt", CharacterEncoding -> "Latin-1"], {21, 69}]
+    #> StringTake[Import["ExampleData/Middlemarch.txt", CharacterEncoding -> "ISO8859-1"], {21, 69}]
      = "Le sentiment de la fausseté des plaisirs présents"
 
     ## JSON

--- a/mathics/builtin/importexport.py
+++ b/mathics/builtin/importexport.py
@@ -486,7 +486,7 @@ class Import(Builtin):
     #> Import["ExampleData/Middlemarch.txt"];
      : An invalid unicode sequence was encountered and ignored.
     #> StringTake[Import["ExampleData/Middlemarch.txt", CharacterEncoding -> "ISO8859-1"], {21, 69}]
-     = "Le sentiment de la fausseté des plaisirs présents"
+     = Le sentiment de la fausseté des plaisirs présents
 
     ## JSON
     >> Import["ExampleData/colors.json"]
@@ -519,7 +519,7 @@ class Import(Builtin):
         return self.apply_elements(filename, Expression('List', element), evaluation, options)
 
     def apply_elements(self, filename, elements, evaluation, options={}):
-        'Import[filename_, elements_List?AllTrue[#, NotOptionQ]&, OptionsPattern[]]'
+        'Import[filename_, elements_List?(AllTrue[#, NotOptionQ]&), OptionsPattern[]]'
 
         # Check filename
         path = filename.to_python()
@@ -802,7 +802,7 @@ class Export(Builtin):
         return self.apply_elements(filename, expr, Expression('List', element), evaluation, options)
 
     def apply_elements(self, filename, expr, elems, evaluation, options={}):
-        "Export[filename_, expr_, elems_List?AllTrue[#, NotOptionQ]&, OptionsPattern[]]"
+        "Export[filename_, expr_, elems_List?(AllTrue[#, NotOptionQ]&), OptionsPattern[]]"
 
         # Check filename
         if not self._check_filename(filename, evaluation):

--- a/mathics/builtin/importexport.py
+++ b/mathics/builtin/importexport.py
@@ -475,6 +475,8 @@ class Import(Builtin):
     = {{0.88, 0.60, 0.94}, {0.76, 0.19, 0.51}, {0.97, 0.04, 0.26}, {0.33, 0.74, 0.79}, {0.42, 0.64, 0.56}}
     #> Import["ExampleData/numberdata.csv"]
     = {{0.88, 0.60, 0.94}, {0.76, 0.19, 0.51}, {0.97, 0.04, 0.26}, {0.33, 0.74, 0.79}, {0.42, 0.64, 0.56}}
+    #> Import["ExampleData/numberdata.csv", "FieldSeparators" -> "."]
+    = {{0, 88,0, 60,0, 94}, {0, 76,0, 19,0, 51}, {0, 97,0, 04,0, 26}, {0, 33,0, 74,0, 79}, {0, 42,0, 64,0, 56}}
 
     ## Text
     >> Import["ExampleData/ExampleData.txt", "Elements"]
@@ -483,6 +485,8 @@ class Import(Builtin):
      = ...
     #> Import["ExampleData/Middlemarch.txt"];
      : An invalid unicode sequence was encountered and ignored.
+    #> StringTake[Import["ExampleData/Middlemarch.txt", CharacterEncoding -> "Latin-1"], {21, 69}]
+     = "Le sentiment de la fausseté des plaisirs présents"
 
     ## JSON
     >> Import["ExampleData/colors.json"]
@@ -715,6 +719,20 @@ class Export(Builtin):
     #> FilePrint[%]
      | 1 + x + y
     #> DeleteFile[%%]
+
+    #> Export["abc.txt", "ä", CharacterEncoding -> "Latin-1"];
+    #> strm = OpenRead["abc.txt", BinaryFormat -> True];
+    #> BinaryRead[strm]
+     = 228
+    #> Close[strm];
+    #> DeleteFile["abc.txt"];
+
+    #> Export["abc.txt", "ä", CharacterEncoding -> "UTF-8"];
+    #> strm = OpenRead["abc.txt", BinaryFormat -> True];
+    #> BinaryRead[strm]
+     = 195
+    #> Close[strm];
+    #> DeleteFile["abc.txt"];
 
     ## CSV
     #> Export["abc.csv", {{1, 2, 3}, {4, 5, 6}}]

--- a/mathics/builtin/importexport.py
+++ b/mathics/builtin/importexport.py
@@ -514,8 +514,12 @@ class Import(Builtin):
         'Import[filename_, OptionsPattern[]]'
         return self.apply_elements(filename, Expression('List'), evaluation, options)
 
+    def apply_element(self, filename, element, evaluation, options={}):
+        'Import[filename_, element_String, OptionsPattern[]]'
+        return self.apply_elements(filename, Expression('List', element), evaluation, options)
+
     def apply_elements(self, filename, elements, evaluation, options={}):
-        'Import[filename_, elements_List, OptionsPattern[]]'
+        'Import[filename_, elements_List?AllTrue[#, NotOptionQ]&, OptionsPattern[]]'
 
         # Check filename
         path = filename.to_python()
@@ -777,7 +781,7 @@ class Export(Builtin):
             'Export[filename, expr, {elems}]'),
     }
 
-    def apply_noelems(self, filename, expr, evaluation, options={}):
+    def apply(self, filename, expr, evaluation, options={}):
         "Export[filename_, expr_, OptionsPattern[]]"
 
         # Check filename
@@ -791,9 +795,13 @@ class Export(Builtin):
             evaluation.message('Export', 'infer', filename)
             return Symbol('$Failed')
         else:
-            return self.apply(filename, expr, String(form), evaluation, options)
+            return self.apply_elements(filename, expr, String(form), evaluation, options)
 
-    def apply(self, filename, expr, elems, evaluation, options={}):
+    def apply_element(self, filename, expr, element, evaluation, options={}):
+        'Export[filename_, expr_, element_String, OptionsPattern[]]'
+        return self.apply_elements(filename, expr, Expression('List', element), evaluation, options)
+
+    def apply_elements(self, filename, expr, elems, evaluation, options={}):
         "Export[filename_, expr_, elems_List?AllTrue[#, NotOptionQ]&, OptionsPattern[]]"
 
         # Check filename

--- a/mathics/builtin/importexport.py
+++ b/mathics/builtin/importexport.py
@@ -724,7 +724,7 @@ class Export(Builtin):
      | 1 + x + y
     #> DeleteFile[%%]
 
-    #> Export["abc.txt", "ä", CharacterEncoding -> "Latin-1"];
+    #> Export["abc.txt", "ä", CharacterEncoding -> "ISOLatin1"];
     #> strm = OpenRead["abc.txt", BinaryFormat -> True];
     #> BinaryRead[strm]
      = 228

--- a/mathics/builtin/importexport.py
+++ b/mathics/builtin/importexport.py
@@ -429,7 +429,7 @@ class FetchURL(Builtin):
             def determine_filetype():
                 return mimetype_dict.get(content_type)
 
-            result = Import._import(temp_path, determine_filetype, elements, evaluation)
+            result = Import._import(temp_path, determine_filetype, elements, evaluation, {})
         except HTTPError as e:
             evaluation.message(
                 'FetchURL', 'httperr', url,

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -1620,6 +1620,7 @@ class General(Builtin):
         'write': "Tag `1` in `2` is Protected.",
         'wrsym': "Symbol `1` is Protected.",
         'ucdec': "An invalid unicode sequence was encountered and ignored.",
+        'charcode': 'The character encoding `1` is not supported. Use $CharacterEncodings to list supported encodings.',
 
         # Self-defined messages
         # 'rep': "`1` is not a valid replacement rule.",

--- a/mathics/builtin/logic.py
+++ b/mathics/builtin/logic.py
@@ -180,6 +180,23 @@ class _ManyTrue(Builtin):
 
 
 class NoneTrue(_ManyTrue):
+    """
+    <dl>
+    <dt>'NoneTrue[{$expr1$, $expr2$, ...}, $test$]'
+        <dd>returns True if no application of $test$ to $expr1$, $expr2$, ... evaluates to True.
+    <dt>'NoneTrue[$list$, $test$, $level$]'
+        <dd>returns True if no application of $test$ to items of $list$ at $level$ evaluates to True.
+    <dt>'NoneTrue[$test$]'
+        <dd>gives an operator that may be applied to expressions.
+    </dl>
+
+    >> NoneTrue[{1, 3, 5}, EvenQ]
+     = True
+
+    >> NoneTrue[{1, 4, 5}, EvenQ]
+     = False
+    """
+
     def _short_circuit(self, what):
         if what:
             raise _ShortCircuit(Symbol('False'))
@@ -189,6 +206,23 @@ class NoneTrue(_ManyTrue):
 
 
 class AnyTrue(_ManyTrue):
+    """
+    <dl>
+    <dt>'AnyTrue[{$expr1$, $expr2$, ...}, $test$]'
+        <dd>returns True if any application of $test$ to $expr1$, $expr2$, ... evaluates to True.
+    <dt>'AnyTrue[$list$, $test$, $level$]'
+        <dd>returns True if any application of $test$ to items of $list$ at $level$ evaluates to True.
+    <dt>'AnyTrue[$test$]'
+        <dd>gives an operator that may be applied to expressions.
+    </dl>
+
+    >> AnyTrue[{1, 3, 5}, EvenQ]
+     = False
+
+    >> AnyTrue[{1, 4, 5}, EvenQ]
+     = True
+    """
+
     def _short_circuit(self, what):
         if what:
             raise _ShortCircuit(Symbol('True'))
@@ -198,6 +232,22 @@ class AnyTrue(_ManyTrue):
 
 
 class AllTrue(_ManyTrue):
+    """
+    <dl>
+    <dt>'AllTrue[{$expr1$, $expr2$, ...}, $test$]'
+        <dd>returns True if all applications of $test$ to $expr1$, $expr2$, ... evaluate to True.
+    <dt>'AllTrue[$list$, $test$, $level$]'
+        <dd>returns True if all applications of $test$ to items of $list$ at $level$ evaluate to True.
+    <dt>'AllTrue[$test$]'
+        <dd>gives an operator that may be applied to expressions.
+    </dl>
+
+    >> AllTrue[{2, 4, 6}, EvenQ]
+     = True
+
+    >> AllTrue[{2, 4, 7}, EvenQ]
+     = False
+    """
     def _short_circuit(self, what):
         if not what:
             raise _ShortCircuit(Symbol('False'))

--- a/mathics/builtin/logic.py
+++ b/mathics/builtin/logic.py
@@ -4,7 +4,8 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
-from mathics.builtin.base import BinaryOperator, Predefined, PrefixOperator
+from mathics.builtin.base import BinaryOperator, Predefined, PrefixOperator, Builtin
+from mathics.builtin.lists import InvalidLevelspecError, python_levelspec, walk_levels
 from mathics.core.expression import Expression, Symbol
 
 
@@ -137,3 +138,70 @@ class False_(Predefined):
     </dl>
     """
     name = 'False'
+
+
+class _ShortCircuit(Exception):
+    def __init__(self, result):
+        self.result = result
+
+
+class _ManyTrue(Builtin):
+    rules = {
+        '%(name)s[list_List, test_]': '%(name)s[list, test, 1]',
+        '%(name)s[test_][list_List]': '%(name)s[list, test]',
+    }
+
+    def _short_circuit(self, what):
+        raise NotImplementedError
+
+    def _no_short_circuit(self):
+        raise NotImplementedError
+
+    def apply(self, expr, test, level, evaluation):
+        '%(name)s[expr_, test_, level_]'
+
+        try:
+            start, stop = python_levelspec(level)
+        except InvalidLevelspecError:
+            evaluation.message('Level', 'level', level)
+            return
+
+        def callback(node):
+            self._short_circuit(Expression(
+                test, node).evaluate(evaluation).is_true())
+            return node
+
+        try:
+            walk_levels(expr, start, stop, callback=callback)
+        except _ShortCircuit as e:
+            return e.result
+
+        return self._no_short_circuit()
+
+
+class NoneTrue(_ManyTrue):
+    def _short_circuit(self, what):
+        if what:
+            raise _ShortCircuit(Symbol('False'))
+
+    def _no_short_circuit(self):
+        return Symbol('True')
+
+
+class AnyTrue(_ManyTrue):
+    def _short_circuit(self, what):
+        if what:
+            raise _ShortCircuit(Symbol('True'))
+
+    def _no_short_circuit(self):
+        return Symbol('False')
+
+
+class AllTrue(_ManyTrue):
+    def _short_circuit(self, what):
+        if not what:
+            raise _ShortCircuit(Symbol('False'))
+
+    def _no_short_circuit(self):
+        return Symbol('True')
+

--- a/mathics/builtin/logic.py
+++ b/mathics/builtin/logic.py
@@ -195,6 +195,9 @@ class NoneTrue(_ManyTrue):
 
     >> NoneTrue[{1, 4, 5}, EvenQ]
      = False
+
+    #> NoneTrue[{}, EvenQ]
+     = True
     """
 
     def _short_circuit(self, what):
@@ -221,6 +224,9 @@ class AnyTrue(_ManyTrue):
 
     >> AnyTrue[{1, 4, 5}, EvenQ]
      = True
+
+    #> AnyTrue[{}, EvenQ]
+     = False
     """
 
     def _short_circuit(self, what):
@@ -247,6 +253,9 @@ class AllTrue(_ManyTrue):
 
     >> AllTrue[{2, 4, 7}, EvenQ]
      = False
+
+    #> AllTrue[{}, EvenQ]
+     = True
     """
     def _short_circuit(self, what):
         if not what:

--- a/mathics/builtin/options.py
+++ b/mathics/builtin/options.py
@@ -248,6 +248,39 @@ class NotOptionQ(Test):
                        for e in expr)
 
 
+class FilterRules(Builtin):
+    """
+    <dl>
+    <dt>'FilterRules[$rules$, $pattern$]'
+        <dd>gives those $rules$ that have a left side that matches $pattern$.
+    <dt>'FilterRules[$rules$, {$pattern1$, $pattern2$, ...}]'
+        <dd>gives those $rules$ that have a left side that match at least one of $pattern1$, $pattern2$, ...
+    </dl>
+
+    >> FilterRules[{x -> 100, y -> 1000}, x]
+     = {x -> 100}
+
+    >> FilterRules[{x -> 100, y -> 1000, z -> 10000}, {a, b, x, z}]
+     = {x -> 100, z -> 10000}
+    """
+
+    rules = {
+        'FilterRules[rules_List, patterns_List]': 'FilterRules[rules, Alternatives @@ patterns]',
+    }
+
+    def apply(self, rules, pattern, evaluation):
+        'FilterRules[rules_List, pattern_]'
+        from mathics.builtin.patterns import Matcher
+        match = Matcher(pattern).match
+
+        def matched():
+            for rule in rules.leaves:
+                if rule.has_form('Rule', 2) and match(rule.leaves[0], evaluation):
+                    yield rule
+
+        return Expression('List', *list(matched()))
+
+
 def options_to_rules(options):
     items = sorted(six.iteritems(options))
     return [Expression('Rule', Symbol(name), value) for name, value in items]

--- a/mathics/builtin/options.py
+++ b/mathics/builtin/options.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import
 import six
 
 from mathics.builtin.base import Builtin, Test
-from mathics.core.expression import Symbol, Expression, get_default_value
+from mathics.core.expression import Symbol, Expression, get_default_value, ensure_context
 from mathics.builtin.image import Image
 
 
@@ -33,6 +33,11 @@ class Options(Builtin):
      = x ^ 2
     >> f[x, n -> 3]
      = x ^ 3
+
+    #> f[x_, OptionsPattern[f]] := x ^ OptionValue["m"];
+    #> Options[f] = {"m" -> 7};
+    #> f[x]
+     = x ^ 7
 
     Delayed option rules are evaluated just when the corresponding 'OptionValue' is called:
     >> f[a :> Print["value"]] /. f[OptionsPattern[{}]] :> (OptionValue[a]; Print["between"]; OptionValue[a]);
@@ -127,6 +132,10 @@ class OptionValue(Builtin):
         if evaluation.options is None:
             return
         name = symbol.get_name()
+        if not name:
+            name = symbol.get_string_value()
+            if name:
+                name = ensure_context(name)
         if not name:
             evaluation.message('OptionValue', 'sym', symbol, 1)
             return

--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -1311,7 +1311,9 @@ class OptionsPattern(PatternObject):
 
     def match(self, yield_func, expression, vars, evaluation, **kwargs):
         if self.defaults is None:
-            self.defaults = kwargs['head']
+            self.defaults = kwargs.get('head')
+            if self.defaults is None:
+                self.defaults = Expression('List')
         values = self.defaults.get_option_values(
             evaluation, allow_symbols=True, stop_on_error=False)
         sequence = expression.get_sequence()

--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -1313,6 +1313,10 @@ class OptionsPattern(PatternObject):
         if self.defaults is None:
             self.defaults = kwargs.get('head')
             if self.defaults is None:
+                # we end up here with OptionsPattern that do not have any
+                # default options defined, e.g. with this code:
+                # f[x:OptionsPattern[]] := x; f["Test" -> 1]
+                # set self.defaults to an empty List, so we don't crash.
                 self.defaults = Expression('List')
         values = self.defaults.get_option_values(
             evaluation, allow_symbols=True, stop_on_error=False)

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -1762,7 +1762,6 @@ class FromCharacterCode(Builtin):
             'Non-negative machine-sized integer expected at '
             'position `2` in `1`.'),
         'utf8': 'The given codes could not be decoded as utf-8.',
-        'code': 'The given codes could not be decoded as `1`.',
     }
 
     rules = {
@@ -1791,10 +1790,7 @@ class FromCharacterCode(Builtin):
                     s += unichr(pyni)
                 return s
             else:
-                codes = [x.get_int_value() for x in l]
-                if not all(0 <= code <= 255 for code in codes):
-                    evaluation.message('FromCharacterCode', 'code', encoding)
-                    raise _InvalidCodepointError
+                codes = [x.get_int_value() & 0xff for x in l]
                 return bytes(codes).decode(py_encoding)
 
         try:

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -18,7 +18,7 @@ import six
 from six.moves import range
 from six import unichr
 
-from mathics.builtin.base import BinaryOperator, Builtin, Test
+from mathics.builtin.base import BinaryOperator, Builtin, Test, Predefined
 from mathics.core.expression import (Expression, Symbol, String, Integer,
                                      from_python)
 from mathics.builtin.lists import python_seq, convert_seq
@@ -242,6 +242,23 @@ def mathics_split(patt, string, flags):
 
     # slice up the string
     return [string[start:stop] for start, stop in indices]
+
+
+class CharacterEncoding(Predefined):
+    """
+    <dl>
+    <dt>'CharacterEncoding'
+        <dd>specifies the default character encoding to use if no other encoding is
+        specified.
+    </dl>
+    """
+
+    name = '$CharacterEncoding'
+    value = '"UTF-8"'
+
+    rules = {
+        '$CharacterEncoding': value,
+    }
 
 
 class StringExpression(BinaryOperator):

--- a/mathics/builtin/xmlformat.py
+++ b/mathics/builtin/xmlformat.py
@@ -11,6 +11,7 @@ from __future__ import unicode_literals
 from mathics.builtin.base import Builtin
 from mathics.builtin.files import mathics_open
 from mathics.core.expression import Expression, String, Symbol, from_python
+from mathics.builtin.base import MessageException
 
 from io import StringIO
 import re
@@ -166,6 +167,12 @@ def parse_xml(parse, text, evaluation):
         return parse(text.get_string_value())
     except ParseError as e:
         evaluation.message('XML`Parser`Get', 'prserr', str(e))
+        return Symbol('$Failed')
+    except IOError:
+        evaluation.message('General', 'noopen', text.get_string_value())
+        return Symbol('$Failed')
+    except MessageException as e:
+        e.message(evaluation)
         return Symbol('$Failed')
 
 

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -342,6 +342,8 @@ class BaseExpression(KeyComparable):
                     else:
                         continue
                 name = option.leaves[0].get_name()
+                if not name and isinstance(option.leaves[0], String):
+                    name = '"%s"' % option.leaves[0].get_string_value()
                 if not name:
                     if stop_on_error:
                         return None

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -343,7 +343,7 @@ class BaseExpression(KeyComparable):
                         continue
                 name = option.leaves[0].get_name()
                 if not name and isinstance(option.leaves[0], String):
-                    name = '"%s"' % option.leaves[0].get_string_value()
+                    name = ensure_context(option.leaves[0].get_string_value())
                 if not name:
                     if stop_on_error:
                         return None


### PR DESCRIPTION
This adds the `CharacterEncoding` option to text and csv `Import` and `Export`, as well as to `FromCharacterCode` and `ToCharacterCode`.

Along the way, I encountered quite a number of things I needed to add/change, specifically:

- importers and exporters may now specify `Options` and they are passed down to the respective calls
- options are now parsed very leniently; it doesn't matter whether you write `X -> 1` or `"X" -> 1`; it also doesn't matter if X has been declared a `System` symbol or not (i.e. it doesn't matter if `X` resolves to ```System`X``` or ```Global`X```.
- `FilterRules`
- `AllTrue`, `AnyTrue`, `NoneTrue`
