### PR TITLE
In-memory sessions

### DIFF
--- a/mathics/core/evaluation.py
+++ b/mathics/core/evaluation.py
@@ -294,22 +294,10 @@ class Evaluation(object):
         return result
 
     def get_stored_result(self, result):
-        from mathics.core.expression import Symbol
-
         # Remove outer format
         if result.has_form(FORMATS, 1):
             result = result.leaves[0]
 
-        # Prevent too large results from being stored, as this can exceed the
-        # DB's max_allowed_packet size
-        max_stored_size = self.output.max_stored_size(settings)
-        if max_stored_size is not None:
-            try:
-                data = pickle.dumps(result)
-                if len(data) > max_stored_size:
-                    return Symbol('Null')
-            except (ValueError, pickle.PicklingError):
-                return Symbol('Null')
         return result
 
     def stop(self):

--- a/mathics/web/models.py
+++ b/mathics/web/models.py
@@ -6,6 +6,34 @@ from __future__ import absolute_import
 
 from django.db import models
 from django.contrib.auth.models import User
+from django.db.models.signals import pre_delete
+from django.contrib.sessions.models import Session
+
+from mathics.core.definitions import Definitions
+from mathics.core.evaluation import Evaluation, Output
+
+
+class WebOutput(Output):
+    pass
+
+definitions = Definitions(add_builtin=True)
+_evaluations = {}
+
+
+def get_session_evaluation(session):
+    evaluation = _evaluations.get(session.session_key)
+    if evaluation is None:
+        evaluation = Evaluation(
+            definitions, format='xml', output=WebOutput())
+        _evaluations[session.session_key] = evaluation
+    return evaluation
+
+
+def end_session_evaluation(sender, **kwargs):
+    session_key = kwargs.get('instance').session_key
+    del _evaluations[session_key]
+
+pre_delete.connect(end_session_evaluation, sender=Session)
 
 
 class Query(models.Model):

--- a/mathics/web/models.py
+++ b/mathics/web/models.py
@@ -16,13 +16,13 @@ from mathics.core.evaluation import Evaluation, Output
 class WebOutput(Output):
     pass
 
-definitions = Definitions(add_builtin=True)
 _evaluations = {}
 
 
 def get_session_evaluation(session):
     evaluation = _evaluations.get(session.session_key)
     if evaluation is None:
+        definitions = Definitions(add_builtin=True)
         evaluation = Evaluation(
             definitions, format='xml', output=WebOutput())
         _evaluations[session.session_key] = evaluation


### PR DESCRIPTION
I'm wondering if we really want to store definitions data in the database for the classic mathics server. If there's a lot of data, the interface gets really sluggish since it needs to unpickle and repickle all definitions for each query.

Here's a proposal to keep everything in memory, which is always fast (but loses its data, as soon as you quit the mathicsserver process).
