### PR TITLE
Faster leading blank patterns

### DIFF
--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -756,6 +756,9 @@ class Pattern_(PatternObject):
             self.error('patvar', expr)
         self.pattern = Pattern.create(expr.leaves[1])
 
+    def __repr__(self):
+        return '<Pattern: %s>' % repr(self.pattern)
+
     def get_match_count(self, vars={}):
         return self.pattern.get_match_count(vars)
 


### PR DESCRIPTION
I came across this while using `GatherBy`; without this PR, `x = Range[5000]; First[Timing[GatherBy[x, OddQ]]]` evaluates to `29.0664`, with this PR this changes to `0.517357`.

The basic problem is described in the comment in `yield_choice`: sub patterns that are very expensive to check are tested, even though the Blank match should be obvious.

Seems to give a very slight but measurable improvement in runtime.

[master.txt](https://github.com/mathics/Mathics/files/534476/master.txt)

[fastblank.txt](https://github.com/mathics/Mathics/files/534477/fastblank.txt)
