### PR TITLE
Speed up pattern matching for large lists

### DIFF
--- a/mathics/core/pattern.py
+++ b/mathics/core/pattern.py
@@ -374,8 +374,6 @@ class ExpressionPattern(Pattern):
 
         candidates = rest_expression[1]
 
-        leaf_candidates = set(leaf_candidates)  # for fast lookup
-
         # "Artificially" only use more leaves than specified for some kind
         # of pattern.
         # TODO: This could be further optimized!
@@ -399,6 +397,12 @@ class ExpressionPattern(Pattern):
         less_first = len(rest_leaves) > 0
 
         if 'System`Orderless' in attributes:
+            # we only want leaf_candidates to be a set if we're orderless.
+            # otherwise, constructing a set() is very slow for large lists.
+            # performance test case:
+            # x = Range[100000]; Timing[Combinatorica`BinarySearch[x, 100]]
+            leaf_candidates = set(leaf_candidates)  # for fast lookup
+
             sets = None
             if leaf.get_head_name() == 'System`Pattern':
                 varname = leaf.leaves[0].get_name()


### PR DESCRIPTION
This actually has no effect in its current form (i.e. in `master`).

When applied to the `qtime` branch (https://github.com/mathics/Mathics/pull/619) though, it speeds up things quite considerably and effectively gives Mathics a whole new, snappy feeling when working with large lists.

Before (i.e. untampered https://github.com/mathics/Mathics/pull/619):

```
In[1]:= x = Range[100000]; Timing[Combinatorica`BinarySearch[x, 100]]
Out[1]= {0.142646, 100}
```

After:

```
In[1]:= x = Range[100000]; Timing[Combinatorica`BinarySearch[x, 100]]
Out[1]= {0.000985, 100}
```

 In the non-ordered case, `leaf_candidates` is actually only used in the call to `subranges`, only that it's currently not used there; a future implementation should be fine with a list as well.
