### PR TITLE
Faster startup

### DIFF
--- a/mathics/builtin/manipulate.py
+++ b/mathics/builtin/manipulate.py
@@ -13,8 +13,11 @@ from mathics.core.expression import Expression, Symbol, Integer, from_python
 
 import demandimport
 
-with demandimport.enabled():
-    import ipywidgets
+try:
+    with demandimport.enabled():
+        import ipywidgets
+except ImportError:
+    pass  # ok due to "require"
 
 
 def _has_kernel():

--- a/mathics/builtin/natlang.py
+++ b/mathics/builtin/natlang.py
@@ -55,9 +55,12 @@ import heapq
 import math
 import demandimport
 
-with demandimport.enabled():
-    import nltk
-    import spacy
+try:
+    with demandimport.enabled():
+        import nltk
+        import spacy
+except ImportError:
+    pass  # ok due to "require"
 
 
 class _Lazy(object):

--- a/mathics/settings.py
+++ b/mathics/settings.py
@@ -88,6 +88,9 @@ SITE_ID = 1
 # users to access local files
 ENABLE_FILES_MODULE = True
 
+# Enabling this prints out some stats on what takes time to startup Mathics.
+BENCHMARK_STARTUP = False
+
 # If you set this to False, Django will make some optimizations so as not
 # to load the internationalization machinery.
 USE_I18N = True

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ else:
 
 # General Requirements
 INSTALL_REQUIRES += ['sympy==1.0', 'django >= 1.8, < 1.9a0',
-                     'mpmath>=0.19', 'python-dateutil', 'colorama', 'six>=1.10']
+                     'mpmath>=0.19', 'python-dateutil', 'colorama', 'demandimport', 'six>=1.10']
 
 
 def subdirs(root, file='*.*', depth=10):


### PR DESCRIPTION
A bunch of changes aimed at making Mathics start up faster:
- a `settings` variable named `BENCHMARK_STARTUP` that turns on benchmarking of module import during startup and prints out loading times for each module
- delayed module imports for `natlang` and `manipulate` (the two slowest modules with 0.6s and 0.3s) based on a new tiny mandatory package called `demandimport` that allows lazy `import`s
