### PR TITLE
Give warnings when using options not supported by a Builtin

### DIFF
--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -77,7 +77,11 @@ class Builtin(object):
         name = self.get_name()
 
         options = {}
+        option_syntax = 'Warn'
         for option, value in six.iteritems(self.options):
+            if option == '$OptionSyntax':
+                option_syntax = value
+                continue
             option = ensure_context(option)
             options[option] = parse_builtin_rule(value)
             if option.startswith('System`'):
@@ -88,9 +92,36 @@ class Builtin(object):
                     definitions.builtin[option] = Definition(
                         name=name, attributes=set())
 
+        # Check if the given options are actually supported by the Builtin.
+        # If not, we might issue an optx error and abort. Using '$OptionSyntax'
+        # in your Builtin's 'options', you can specify the exact behaviour
+        # using one of the following values:
+
+        # - 'Strict': warn and fail with unsupported options
+        # - 'Warn': warn about unsupported options, but continue
+        # - 'Ignore': allow unsupported options, do not warn
+
+        if option_syntax in ('Strict', 'Warn'):
+            def check_options(options_to_check, evaluation):
+                for key, value in options_to_check.items():
+                    short_key = strip_context(key)
+                    if not has_option(options, short_key, evaluation):
+                        evaluation.message(
+                            self.name,
+                            'optx',
+                            Expression('Rule', short_key, value),
+                            strip_context(self.name))
+                        if option_syntax == 'Strict':
+                            return False
+                return True
+        elif option_syntax == 'Ignore':
+            check_options = None
+        else:
+            raise ValueError('illegal option mode %s; check $OptionSyntax.' % option_syntax)
+
         rules = []
         for pattern, function in self.get_functions():
-            rules.append(BuiltinRule(name, pattern, function, options, system=True))
+            rules.append(BuiltinRule(name, pattern, function, check_options, system=True))
         for pattern, replace in self.rules.items():
             if not isinstance(pattern, BaseExpression):
                 pattern = pattern % {'name': name}
@@ -135,7 +166,7 @@ class Builtin(object):
                 if form not in formatvalues:
                     formatvalues[form] = []
                 formatvalues[form].append(BuiltinRule(
-                    name, pattern, function, {}, system=True))
+                    name, pattern, function, None, system=True))
         for pattern, replace in self.formats.items():
             forms, pattern = extract_forms(name, pattern)
             for form in forms:
@@ -155,7 +186,7 @@ class Builtin(object):
                     for msg, value in self.messages.items()]
 
         messages.append(Rule(Expression('MessageName', Symbol(name), String('optx')),
-            String('Option `1` in `2` is not supported by Mathics.'), system=True))
+            String('`1` is not a supported option for `2`[].'), system=True))
 
         if name == 'System`MakeBoxes':
             attributes = []

--- a/mathics/builtin/importexport.py
+++ b/mathics/builtin/importexport.py
@@ -515,6 +515,10 @@ class Import(Builtin):
         'Import[filename_]': 'Import[filename, {}]',
     }
 
+    options = {
+        '*': 'Automatic',  # pass through all options
+    }
+
     def apply(self, filename, evaluation, options={}):
         'Import[filename_, OptionsPattern[]]'
         return self.apply_elements(filename, Expression('List'), evaluation, options)
@@ -784,6 +788,10 @@ class Export(Builtin):
     rules = {
         'Export[filename_, expr_, elems_?NotListQ]': (
             'Export[filename, expr, {elems}]'),
+    }
+
+    options = {
+        '*': 'Automatic',  # pass through all options
     }
 
     def apply(self, filename, expr, evaluation, options={}):

--- a/mathics/builtin/options.py
+++ b/mathics/builtin/options.py
@@ -13,6 +13,7 @@ import six
 from mathics.builtin.base import Builtin, Test
 from mathics.core.expression import Symbol, Expression, get_default_value, ensure_context
 from mathics.builtin.image import Image
+from mathics.core.expression import strip_context
 
 
 class Options(Builtin):
@@ -293,5 +294,5 @@ class FilterRules(Builtin):
 def options_to_rules(options, filter=None):
     items = sorted(six.iteritems(options))
     if filter:
-        items = [(name, value) for name, value in items if name in filter.keys()]
+        items = [(name, value) for name, value in items if strip_context(name) in filter.keys()]
     return [Expression('Rule', Symbol(name), value) for name, value in items]

--- a/mathics/builtin/options.py
+++ b/mathics/builtin/options.py
@@ -290,6 +290,8 @@ class FilterRules(Builtin):
         return Expression('List', *list(matched()))
 
 
-def options_to_rules(options):
+def options_to_rules(options, remove=None):
     items = sorted(six.iteritems(options))
+    if remove:
+        items = [(name, value) for name, value in items if name not in remove]
     return [Expression('Rule', Symbol(name), value) for name, value in items]

--- a/mathics/builtin/options.py
+++ b/mathics/builtin/options.py
@@ -290,8 +290,8 @@ class FilterRules(Builtin):
         return Expression('List', *list(matched()))
 
 
-def options_to_rules(options, remove=None):
+def options_to_rules(options, filter=None):
     items = sorted(six.iteritems(options))
-    if remove:
-        items = [(name, value) for name, value in items if name not in remove]
+    if filter:
+        items = [(name, value) for name, value in items if name in filter.keys()]
     return [Expression('Rule', Symbol(name), value) for name, value in items]

--- a/mathics/builtin/plot.py
+++ b/mathics/builtin/plot.py
@@ -30,6 +30,13 @@ try:
 except ImportError as e:
     has_compile = False
 
+_plot_options = set([
+    'System`PlotPoints',
+    'System`Exclusions',
+    'System`MaxRecursion',
+    'System`Mesh',
+])
+
 def gradient_palette(color_function, n, evaluation):  # always returns RGB values
     if isinstance(color_function, String):
         color_data = Expression('ColorData', color_function).evaluate(evaluation)
@@ -603,7 +610,7 @@ class _Plot(Builtin):
                     'Point', Expression('List', *meshpoints)))
 
         return Expression('Graphics', Expression('List', *graphics),
-                          *options_to_rules(options))
+                          *options_to_rules(options, _plot_options))
 
 
 class _ListPlot(Builtin):
@@ -765,7 +772,7 @@ class _ListPlot(Builtin):
         options['System`PlotRange'] = from_python([x_range, y_range])
 
         return Expression('Graphics', Expression('List', *graphics),
-                          *options_to_rules(options))
+                          *options_to_rules(options, _plot_options))
 
 
 class _Plot3D(Builtin):
@@ -1490,7 +1497,7 @@ class Plot3D(_Plot3D):
 
     def final_graphics(self, graphics, options):
         return Expression('Graphics3D', Expression('List', *graphics),
-                          *options_to_rules(options))
+                          *options_to_rules(options, _plot_options))
 
 
 class DensityPlot(_Plot3D):
@@ -1625,4 +1632,4 @@ class DensityPlot(_Plot3D):
 
     def final_graphics(self, graphics, options):
         return Expression('Graphics', Expression('List', *graphics),
-                          *options_to_rules(options))
+                          *options_to_rules(options, _plot_options))

--- a/mathics/builtin/plot.py
+++ b/mathics/builtin/plot.py
@@ -283,6 +283,7 @@ class _Plot(Builtin):
         'PlotRange': 'Automatic',
         'PlotPoints': 'None',
         'Exclusions': 'Automatic',
+        '$OptionSyntax': 'Strict',
     })
 
     messages = {

--- a/mathics/builtin/plot.py
+++ b/mathics/builtin/plot.py
@@ -22,7 +22,8 @@ from mathics.builtin.base import Builtin
 from mathics.builtin.scoping import dynamic_scoping
 from mathics.builtin.options import options_to_rules
 from mathics.builtin.numeric import chop
-
+from mathics.builtin.graphics import Graphics
+from mathics.builtin.graphics3d import Graphics3D
 
 try:
     from mathics.builtin.compile import _compile, CompileArg, CompileError, real_type
@@ -30,12 +31,6 @@ try:
 except ImportError as e:
     has_compile = False
 
-_plot_options = set([
-    'System`PlotPoints',
-    'System`Exclusions',
-    'System`MaxRecursion',
-    'System`Mesh',
-])
 
 def gradient_palette(color_function, n, evaluation):  # always returns RGB values
     if isinstance(color_function, String):
@@ -610,7 +605,7 @@ class _Plot(Builtin):
                     'Point', Expression('List', *meshpoints)))
 
         return Expression('Graphics', Expression('List', *graphics),
-                          *options_to_rules(options, _plot_options))
+                          *options_to_rules(options, Graphics.options))
 
 
 class _ListPlot(Builtin):
@@ -772,7 +767,7 @@ class _ListPlot(Builtin):
         options['System`PlotRange'] = from_python([x_range, y_range])
 
         return Expression('Graphics', Expression('List', *graphics),
-                          *options_to_rules(options, _plot_options))
+                          *options_to_rules(options, Graphics.options))
 
 
 class _Plot3D(Builtin):
@@ -1497,7 +1492,7 @@ class Plot3D(_Plot3D):
 
     def final_graphics(self, graphics, options):
         return Expression('Graphics3D', Expression('List', *graphics),
-                          *options_to_rules(options, _plot_options))
+                          *options_to_rules(options, Graphics3D.options))
 
 
 class DensityPlot(_Plot3D):
@@ -1632,4 +1627,4 @@ class DensityPlot(_Plot3D):
 
     def final_graphics(self, graphics, options):
         return Expression('Graphics', Expression('List', *graphics),
-                          *options_to_rules(options, _plot_options))
+                          *options_to_rules(options, Graphics.options))

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -105,24 +105,17 @@ class Rule(BaseRule):
 
 
 class BuiltinRule(BaseRule):
-    def __init__(self, name, pattern, function, supported_options, system=False):
+    def __init__(self, name, pattern, function, check_options, system=False):
         super(BuiltinRule, self).__init__(pattern, system=system)
         self.name = name
         self.function = function
-        self.supported_options = supported_options
+        self.check_options = check_options
         self.pass_expression = 'expression' in function_arguments(function)
 
     def do_replace(self, expression, vars, options, evaluation):
-        # check if the given options are actually supported by the
-        # Builtin. if not, issue an optx error and abort.
-        if options and '*' not in self.supported_options:
-            from mathics.builtin.base import has_option
-            for key in options.keys():
-                if not has_option(self.supported_options, strip_context(key), evaluation):
-                    evaluation.message(
-                        self.name, 'optx',
-                        Expression('Rule', strip_context(key), options[key]), self.name)
-                    return None
+        if options and self.check_options:
+            if not self.check_options(options, evaluation):
+                return None
         # The Python function implementing this builtin expects
         # argument names corresponding to the symbol names without
         # context marks.

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -115,7 +115,7 @@ class BuiltinRule(BaseRule):
     def do_replace(self, expression, vars, options, evaluation):
         # check if the given options are actually supported by the
         # Builtin. if not, issue an optx error and abort.
-        if options:
+        if options and '*' not in self.supported_options:
             from mathics.builtin.base import has_option
             for key in options.keys():
                 if not has_option(self.supported_options, strip_context(key), evaluation):


### PR DESCRIPTION
Currently, if options are given for commands that are not supported, they are simply ignored. This can be very confusing for novice users, especially if they mistype an option (e.g. `FieldSeperetors` instead of `FieldSeparators`).

This PR adds a new meta option called `$OptionSyntax` that may be either `Strict`, `Warn` or `Ignore`, and defines what should happen, if the user specifies an option that does not show up in  the `Builtin`'s `options` dictionary.

The default (also used if no `$OptionSyntax` is specified) is to give a warning but continue with evaluation. `Strict` gives a warning and stops the evaluation (this happens for `Plot`). `Ignore` is the old behavior. 

In addition to this, this PR adds custom checks for `Import` and `Export` that gives warnings for options that are not supported by the import/export plugin.

In this current form, `Import`, `Export` and other commands will warn about unused options, which might differ from MMA. Still, I think these kinds of warnings are so useful that we should accept their general existence in Mathics. In addition, some commands, like `Plot`, really want to abort evaluation, if non-supported options are given, and this PR offers a solution for not having to code this checks for each single Builtin that wants to behave in that way.