### PR TITLE
Iohooks

### DIFF
--- a/mathics/builtin/__init__.py
+++ b/mathics/builtin/__init__.py
@@ -103,6 +103,30 @@ def get_module_doc(module):
     return title, text
 
 
+inout_hooks = {'$PreRead':"$PreRead is a global variable whose value, if set, is applied to the \
+text or box form of every input expression before it is fed to the parser. ",
+               '$Pre': "$Pre is a global variable whose value, if set, is applied to every \
+input expression.",
+               '$Post': "$Post is a global variable whose value, if set, is applied to every \
+output expression. ",
+               '$PrePrint': "$PrePrint is a global variable whose value, if set, is applied to \
+every expression before it is printed. ",
+               '$SyntaxHandler': "$SyntaxHandler is a global variable which, if set, is applied to any \
+input string that is found to contain a syntax error. ",
+           }
+
+def load_InOut_hooks(definitions):
+    from mathics.core.definitions import Definition
+    from mathics.core.expression import  Symbol, String
+    from mathics.core.rules import Rule
+    from mathics.core.pattern import Pattern_create
+    from mathics.builtin.inout import MessageName
+    for hook in inout_hooks:
+        fullname = "System`" + hook
+        definitions.builtin[fullname] = Definition(name = fullname )
+        usage = Rule(MessageName(Symbol(fullname), String("usage")), String(inout_hooks[hook]))
+        definitions.builtin[fullname].set_values_list('messages',[usage])
+
 def contribute(definitions):
     # let MakeBoxes contribute first
     builtins['System`MakeBoxes'].contribute(definitions)
@@ -110,6 +134,8 @@ def contribute(definitions):
         if name != 'System`MakeBoxes':
             item.contribute(definitions)
 
+    load_InOut_hooks(definitions)
+    
     from mathics.core.expression import ensure_context
     from mathics.core.parser import all_operator_names
     from mathics.core.definitions import Definition
@@ -121,3 +147,9 @@ def contribute(definitions):
         if not definitions.have_definition(ensure_context(operator)):
             op = ensure_context(operator)
             definitions.builtin[op] = Definition(name=op)
+
+    
+#    definitions.builtin['System`$PrePrint'].set_values_list('messages',
+#                                                            Rule('usage',"$PrePrint is a global variable whose value, if set, is applied to \
+#every expression before it is printed. ",True))
+    

--- a/mathics/builtin/__init__.py
+++ b/mathics/builtin/__init__.py
@@ -104,7 +104,7 @@ def get_module_doc(module):
 
 
 inout_hooks = {'$PreRead':"$PreRead is a global variable whose value, if set, is applied to the \
-text or box form of every input expression before it is fed to the parser. ",
+text or box form of every input expression before it is fed to the parser. (Not implemented yet) ",
                '$Pre': "$Pre is a global variable whose value, if set, is applied to every \
 input expression.",
                '$Post': "$Post is a global variable whose value, if set, is applied to every \
@@ -112,7 +112,7 @@ output expression. ",
                '$PrePrint': "$PrePrint is a global variable whose value, if set, is applied to \
 every expression before it is printed. ",
                '$SyntaxHandler': "$SyntaxHandler is a global variable which, if set, is applied to any \
-input string that is found to contain a syntax error. ",
+               input string that is found to contain a syntax error. (Not implemented yet) ",
            }
 
 def load_InOut_hooks(definitions):

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -687,6 +687,6 @@ class Definition(object):
         return False
 
     def __repr__(self):
-        s = '<Definition: name: {}, downvalues: {}, formats: {}, attributes: {}  dict: {} >'.format(
-            self.name, self.downvalues, self.formatvalues, self.attributes, self.__dict__)
+        s = '<Definition: name: {}, downvalues: {}, formats: {}, attributes: {} >'.format(
+            self.name, self.downvalues, self.formatvalues, self.attributes)
         return s.encode('unicode_escape')

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -687,6 +687,6 @@ class Definition(object):
         return False
 
     def __repr__(self):
-        s = '<Definition: name: {}, downvalues: {}, formats: {}, attributes: {}>'.format(
-            self.name, self.downvalues, self.formatvalues, self.attributes)
+        s = '<Definition: name: {}, downvalues: {}, formats: {}, attributes: {}  dict: {} >'.format(
+            self.name, self.downvalues, self.formatvalues, self.attributes, self.__dict__)
         return s.encode('unicode_escape')

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -687,6 +687,6 @@ class Definition(object):
         return False
 
     def __repr__(self):
-        s = '<Definition: name: {}, downvalues: {}, formats: {}, attributes: {} >'.format(
+        s = '<Definition: name: {}, downvalues: {}, formats: {}, attributes: {}>'.format(
             self.name, self.downvalues, self.formatvalues, self.attributes)
         return s.encode('unicode_escape')

--- a/mathics/core/evaluation.py
+++ b/mathics/core/evaluation.py
@@ -193,6 +193,10 @@ class Output(object):
         raise NotImplementedError
 
 
+
+
+    
+    
 class Evaluation(object):
     def __init__(self, definitions=None,
                  output=None, format='text', catch_interrupt=True):
@@ -253,12 +257,23 @@ class Evaluation(object):
 
         result = None
         exc_result = None
+        
+        def check_io_hook(hook):
+            return  len(self.definitions.get_definition(hook).ownvalues)>0
 
+            
         def evaluate():
             if history_length > 0:
                 self.definitions.add_rule('In', Rule(
                     Expression('In', line_no), query))
-            result = query.evaluate(self)
+            if check_io_hook('System`$Pre'):
+                result = Expression('System`$Pre', query).evaluate(self)
+            else:
+                result = query.evaluate(self)
+
+            if check_io_hook('System`$Post'):
+                result = Expression('System`$Post', result).evaluate(self)
+
             if history_length > 0:
                 if self.predetermined_out is not None:
                     out_result = self.predetermined_out
@@ -270,6 +285,9 @@ class Evaluation(object):
                 self.definitions.add_rule('Out', Rule(
                     Expression('Out', line_no), stored_result))
             if result != Symbol('Null'):
+                if check_io_hook('System`$PrePrint'): 
+                    print(self.definitions.get_definition('System`$PrePrint').__repr__())
+                    result = Expression('System`$PrePrint', result).evaluate(self)
                 return self.format_output(result, self.format)
             else:
                 return None


### PR DESCRIPTION
In MMA, the main loop includes some hooks which allow us to modify the way in which expressions are readed from the input, and postprocessed after evaluation:

""
$PreRead	a function applied to each input string before being fed to Mathematica
$Pre	a function applied to each input expression before evaluation
$Post	a function applied to each expression after evaluation
$PrePrint	a function applied after Out[n] is assigned, but before the result is printed
$SyntaxHandler	a function applied to any input line that yields a syntax error
""
This PR is (maybe a raw)  proposal to implement this functionality. By now, just $Pre, $Post and $PrePrint hooks are implemented. 