### PR TITLE
Adding ImportString and ExportString functionalities

### DIFF
--- a/mathics/autoload/formats/CSV/Export.m
+++ b/mathics/autoload/formats/CSV/Export.m
@@ -7,21 +7,19 @@ Options[CSVExport] = {
     "FieldSeparators" -> ","
 };
 
-CSVExport[filename_String, data_, OptionsPattern[]]:=
-    Module[{strm, char, wraplist, sep = OptionValue["FieldSeparators"]},
-        strm = OpenWrite[filename, CharacterEncoding -> OptionValue["CharacterEncoding"]];
+CSVExport[strm_OutputStream, data_, OptionsPattern[]]:=
+    Module[{char, wraplist, sep = OptionValue["FieldSeparators"]},        
         If[strm === $Failed, Return[$Failed]];
         wraplist[x_] := If[Head[x] === List, x, {x}];
         char = Map[ToString, wraplist /@ wraplist[data], {2}];
         char = StringJoin[Riffle[Riffle[#, sep] & /@ char, "\n"]];
         WriteString[strm, char];
-        Close[strm];
     ]
 
 ImportExport`RegisterExport[
     "CSV",
     System`Convert`TableDump`CSVExport,
-    FunctionChannels -> {"FileNames"},
+    FunctionChannels -> {"Streams"},
     Options -> {"ByteOrderMark"},
     DefaultElement -> "Plaintext",
     BinaryFormat -> True,

--- a/mathics/autoload/formats/CSV/Import.m
+++ b/mathics/autoload/formats/CSV/Import.m
@@ -8,12 +8,10 @@ Options[ImportCSV] = {
     "FieldSeparators" -> ","
 };
 
-ImportCSV[filename_String, OptionsPattern[]]:=
-    Module[{stream, data, grid, sep = OptionValue["FieldSeparators"]},
-        stream = OpenRead[filename, CharacterEncoding -> OptionValue["CharacterEncoding"]];
+ImportCSV[stream_InputStream, OptionsPattern[]]:=
+    Module[{data, grid, sep = OptionValue["FieldSeparators"]},        
         data = StringSplit[#, sep]& /@ ReadList[stream, String];
         grid = Grid[data];
-        Close[stream];
         {
             "Data" -> data,
             "Grid" -> grid
@@ -28,7 +26,7 @@ ImportExport`RegisterImport[
 	    "Grid" :> GetGrid
     },
     (* Sources -> ImportExport`DefaultSources["Table"], *)
-    FunctionChannels -> {"FileNames"},
+    FunctionChannels -> {"Streams"},
     AvailableElements -> {"Data", "Grid"},
     DefaultElement -> "Data",
     Options -> {

--- a/mathics/autoload/formats/Image/Export.m
+++ b/mathics/autoload/formats/Image/Export.m
@@ -5,6 +5,7 @@ Begin["System`Convert`Image`"]
 RegisterImageExport[type_] := ImportExport`RegisterExport[
     type,
 	System`ImageExport,
+        FunctionChannels -> {"FileNames"},
 	Options -> {},
 	BinaryFormat -> True
 ];

--- a/mathics/autoload/formats/SVG/Export.m
+++ b/mathics/autoload/formats/SVG/Export.m
@@ -7,8 +7,8 @@ SVGExport[filename_, expr_, opts___] :=
   Module[{strm, data}, 
     strm = OpenWrite[filename];
     If[strm === $Failed, Return[$Failed]];
-    data = StringTake[ToString[MathMLForm[expr]],{25,-29}];
-    WriteString[strm, data];
+    data = StringTake[ToString[MathMLForm[expr]],{7,-8}];
+    WriteString[strm, "<svg>" <> data <> "</svg>"];
     Close[strm];
   ]
 

--- a/mathics/builtin/files.py
+++ b/mathics/builtin/files.py
@@ -3502,7 +3502,7 @@ class StringToStream(Builtin):
     def apply(self, string, evaluation):
         'StringToStream[string_]'
         pystring = string.to_python()[1:-1]
-        stream = io.StringIO(str(pystring))
+        stream = io.StringIO(str(pystring))        
 
         name = Symbol('String')
         n = next(NSTREAMS)

--- a/mathics/builtin/pymimesniffer/magic.py
+++ b/mathics/builtin/pymimesniffer/magic.py
@@ -4,6 +4,7 @@
 import sys
 import os.path
 import logging
+import io
 
 
 class MagicRule(object):
@@ -26,34 +27,35 @@ class MagicDetector(object):
         self.mimetypes = mimetypes
 
     def match(self, filename, data=None):
+        matches = {}
+        
         if not data:
             file = open(filename, 'rb')
-        elif isinstance(data, str) or isinstance(data, str):
+            buf = b''
+        elif isinstance(data, str):
             from io import StringIO
-
             file = StringIO(data)
+            matches['text/plain'] =  self.mimetypes['text/plain']
+            buf = ''
         elif hasattr(data, 'read'):
+            buf = b''
             file = data
         else:
-            from io import StringIO
-
-            file = StringIO(str(data))
-
+            from io import BytesIO
+            file = BytesIO(data)
+            buf = b''
+            
         ext = os.path.splitext(filename)[1]
 
         if ext:
             ext = ext[1:]
-
-        matches = {}
-
-        buf = b''
 
         for mimetype, rules in self.mimetypes.items():
             for rule in rules:
                 if rule.parentType and rule.parentType not in list(matches.keys()):
                     continue
 
-                if rule.extensions and ext not in rule.extensions:
+                if rule.extensions and ext != ""  and ext not in rule.extensions:
                     continue
 
                 for offset, value in rule.magicNumbers:


### PR DESCRIPTION
I included also some small fixes in Import and Export to avoid duplicate code. The implementation accept both formats Importer/Exporter with FunctionChannels {"FileNames"} and {"Streams"}. However, in the first case, the creation of a temporal file is required.
There is also a change in  the CSV importer/exporter to work with {"Streams"} as FunctionChannels, in a way to write simpler test cases.