### PR TITLE
Adding 3 new functions: Integers, PrependTo and ContainsOnly

### DIFF
--- a/mathics/builtin/calculus.py
+++ b/mathics/builtin/calculus.py
@@ -522,7 +522,7 @@ class Solve(Builtin):
     <dt>'Solve[$equation$, $vars$]'
         <dd>attempts to solve $equation$ for the variables $vars$.
     <dt>'Solve[$equation$, $vars$, $domain$]'
-        <dd>restricts variables to $domain$, which can be 'Complexes' or 'Reals'.
+        <dd>restricts variables to $domain$, which can be 'Complexes' or 'Reals' or 'Integers'.
     </dl>
 
     >> Solve[x ^ 2 - 3 x == 4, x]
@@ -588,7 +588,9 @@ class Solve(Builtin):
      = {{x -> -1}, {x -> 1}}
     >> Solve[x^2 == -1, x, Complexes]
      = {{x -> -I}, {x -> I}}
-
+    >> Solve[4 - 4 * x^2 - x^4 + x^6 == 0, x, Integers]
+     = {{x -> -1}, {x -> 1}}
+     
     #> Solve[x^2 +1 == 0, x] // FullForm
      = List[List[Rule[x, Complex[0, -1]]], List[Rule[x, Complex[0, 1]]]]
 
@@ -631,6 +633,8 @@ class Solve(Builtin):
         'Solve[eqs_, vars_, Complexes]': 'Solve[eqs, vars]',
         'Solve[eqs_, vars_, Reals]': (
             'Cases[Solve[eqs, vars], {Rule[x_,y_?RealNumberQ]}]'),
+        'Solve[eqs_, vars_, Integers]': (
+            'Cases[Solve[eqs, vars], {Rule[x_,y_?IntegerQ]}]'),
     }
 
     def apply(self, eqs, vars, evaluation):
@@ -767,7 +771,20 @@ class Solve(Builtin):
             if str(exc).startswith("expected Symbol, Function or Derivative"):
                 evaluation.message('Solve', 'ivar', vars_original)
 
+class Integers(Builtin):
+    """
+    <dl>
+    <dt>'Integers'
+        <dd>is the set of integer numbers.
+    </dl>
 
+    Limit a solution to integer numbers:
+    >> Solve[-4 - 4 x + x^4 + x^5 == 0, x, Integers]
+     = {{x -> -1}}
+    >> Solve[x^4 == 4, x, Integers]
+     = {}
+    """
+    
 class Reals(Builtin):
     """
     <dl>

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -2416,6 +2416,65 @@ class Prepend(Builtin):
                           *([item] + expr.get_leaves()))
 
 
+class PrependTo(Builtin):
+    """
+    <dl>
+    <dt>'PrependTo[$s$, $item$]'
+        <dd>prepends $item$ to value of $s$ and sets $s$ to the result.
+    </dl>
+
+    Assign s to a list
+    >> s = {1, 2, 4, 9}
+     = {1, 2, 4, 9}
+    
+    Add a new value at the beginning of the list: 
+    >> PrependTo[s, 0]
+     = {0, 1, 2, 4, 9}
+    
+    The value assigned to s has changed: 
+    >> s
+     = {0, 1, 2, 4, 9}
+
+    'PrependTo' works with a head other than 'List':
+    >> y = f[a, b, c];
+    >> PrependTo[y, x]
+     = f[x, a, b, c]
+    >> y
+     = f[x, a, b, c]
+
+    #> PrependTo[{a, b}, 1]
+     :  {a, b} is not a variable with a value, so its value cannot be changed.
+     = PrependTo[{a, b}, 1]
+
+    #> PrependTo[a, b]
+     : a is not a variable with a value, so its value cannot be changed.
+     = PrependTo[a, b]
+
+    #> x = 1 + 2;
+    #> PrependTo[x, {3, 4}]
+     : Nonatomic expression expected at position 1 in PrependTo[x, {3, 4}].
+     =  PrependTo[x, {3, 4}]
+    """
+
+    attributes = ('HoldFirst',)
+
+    messages = {
+        'rvalue': '`1` is not a variable with a value, so its value cannot be changed.',
+        'normal': 'Nonatomic expression expected at position 1 in `1`.'
+    }
+
+    def apply(self, s, item, evaluation):
+        'PrependTo[s_, item_]'
+        if isinstance(s, Symbol):
+            resolved_s = s.evaluate(evaluation)
+
+            if not resolved_s.is_atom():
+                result = Expression('Set', s, Expression('Prepend', resolved_s, item))
+                return result.evaluate(evaluation)
+            if s != resolved_s:
+                return evaluation.message('PrependTo', 'normal', Expression('PrependTo', s, item))
+        return evaluation.message('PrependTo', 'rvalue', s)
+    
 def get_tuples(items):
     if not items:
         yield []

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -4818,3 +4818,107 @@ class Permutations(Builtin):
         return Expression('List', *[Expression('List', *p)
                                     for r in rs
                                     for p in permutations(l.leaves, r)])
+
+class ContainsOnly(Builtin):
+    """
+    <dl>
+    <dt>'ContainsOnly[$list1$, $list2$]'
+        <dd>yields True if $list1$ contains only elements that appear in $list2$.
+    </dl>
+
+    >> ContainsOnly[{b, a, a}, {a, b, c}]
+     = True
+
+    The first list contains elements not present in the second list:
+    >> ContainsOnly[{b, a, d}, {a, b, c}]
+     = False
+
+    >> ContainsOnly[{}, {a, b, c}]
+     = True
+
+    #> ContainsOnly[1, {1, 2, 3}]
+     : List or association expected instead of 1.
+     = ContainsOnly[1, {1, 2, 3}]
+
+    #> ContainsOnly[{1, 2, 3}, 4]
+     : List or association expected instead of 4.
+     = ContainsOnly[{1, 2, 3}, 4]
+
+    Use Equal as the comparison function to have numerical tolerance:
+    >> ContainsOnly[{a, 1.0}, {1, a, b}, {SameTest -> Equal}]
+     = True
+     
+    #> ContainsOnly[{c, a}, {a, b, c}, IgnoreCase -> True]
+     : Unknown option IgnoreCase for ContainsOnly.
+     = True
+    
+    #> ContainsOnly[{a, 1.0}, {1, a, b}, {IgnoreCase -> True, SameTest -> Equal}]
+     : Unknown option IgnoreCase for ContainsOnly.
+     = True
+
+    #> ContainsOnly[Pi, "E", {IgnoreCase -> True, SameTest -> Equal}]
+     : List or association expected instead of E.
+     : Unknown option IgnoreCase in ContainsOnly[Pi, E, {IgnoreCase -> True, SameTest -> Equal}].
+     = ContainsOnly[Pi, E, {IgnoreCase -> True, SameTest -> Equal}]
+
+    #> ContainsOnly["Pi", E, {IgnoreCase -> True, SameTest -> Equal}]
+     : List or association expected instead of Pi.
+     : Unknown option IgnoreCase in ContainsOnly[Pi, E, {IgnoreCase -> True, SameTest -> Equal}].
+     = ContainsOnly[Pi, E, {IgnoreCase -> True, SameTest -> Equal}]
+
+    #> ContainsOnly[Pi, E, {IgnoreCase -> True, SameTest -> Equal}]
+     : Unknown option IgnoreCase in ContainsOnly[Pi, E, {IgnoreCase -> True, SameTest -> Equal}].
+     = ContainsOnly[Pi, E, {IgnoreCase -> True, SameTest -> Equal}]
+    """
+
+    attributes = ('ReadProtected',)
+    
+    messages = {
+        'lsa': "List or association expected instead of `1`.",
+        'nodef': "Unknown option `1` for ContainsOnly.",
+        'optx': "Unknown option `1` in `2`.",
+    }
+
+    options = {
+        'SameTest': 'SameQ',
+    }
+
+    def check_options(self, expr, evaluation, options):
+        for key in options:
+            if key != 'System`SameTest':
+                if expr is None:
+                    evaluation.message('ContainsOnly', 'nodef', Symbol(key))
+                else:
+                    return evaluation.message('ContainsOnly', 'optx', Symbol(key), expr)
+        return None
+
+    def apply(self, list1, list2, evaluation, options={}):
+        'ContainsOnly[list1_?ListQ, list2_?ListQ, OptionsPattern[ContainsOnly]]'
+
+        same_test = self.get_option(options, 'SameTest', evaluation)
+
+        def same(a, b):
+            result = Expression(same_test, a, b).evaluate(evaluation)
+            return result.is_true()
+
+        self.check_options(None, evaluation, options)
+        for a in list1.leaves:
+            if not any(same(a, b) for b in list2.leaves):
+                return Symbol('False')
+        return Symbol('True')
+
+    def apply_msg(self, e1, e2, evaluation, options={}):
+        'ContainsOnly[e1_, e2_, OptionsPattern[ContainsOnly]]'
+
+        opts = options_to_rules(options) if len(options) <= 1 else [Expression('List', *options_to_rules(options))]
+        expr = Expression('ContainsOnly', e1, e2, *opts)
+
+        if not isinstance(e1, Symbol) and not e1.has_form('List', None):
+            evaluation.message('ContainsOnly', 'lsa', e1)
+            return self.check_options(expr, evaluation, options)
+
+        if not isinstance(e2, Symbol) and not e2.has_form('List', None):
+            evaluation.message('ContainsOnly', 'lsa', e2)
+            return self.check_options(expr, evaluation, options)
+
+        return self.check_options(expr, evaluation, options)


### PR DESCRIPTION
This pull request includes the implementation of the following functions:
- Integers[]
- PrependTo[]
- ContainsOnly[]

Note: The IPython API version 6.0+ does not support Python 2.6, 2.7, 3.0, 3.1, or 3.2. So I have changed the .travis.yml to install IPython 5.0 for covering all the test cases.