### PR TITLE
graphics.py: Remove duplicate imports

### DIFF
--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -16,7 +16,6 @@ from six.moves import map
 from six.moves import range
 from six.moves import zip
 from itertools import chain
-from math import sin, cos, pi
 
 from mathics.builtin.base import (
     Builtin, InstancableBuiltin, BoxConstruct, BoxConstructError)


### PR DESCRIPTION
On line 12, `sin, cos, pi` are already imported from `math`, but are then imported again on line 19.