### PR TITLE
Don't use p/q of Rational + import cleanup

### DIFF
--- a/mathics/builtin/algebra.py
+++ b/mathics/builtin/algebra.py
@@ -455,27 +455,26 @@ class FactorTermsList(Builtin):
         result = []
         numer, denom = sympy_expr.as_numer_denom()
         try:
-            from sympy import factor, factor_list, Poly
             if denom == 1:
                 # Get numerical part
-                num_coeff, num_polys = factor_list(Poly(numer))
+                num_coeff, num_polys = sympy.factor_list(sympy.Poly(numer))
                 result.append(num_coeff)
                 
                 # Get factors are independent of sub list of variables
                 if (sympy_vars and isinstance(expr, Expression) 
                     and any(x.free_symbols.issubset(sympy_expr.free_symbols) for x in sympy_vars)):
                     for i in reversed(range(len(sympy_vars))):
-                        numer = factor(numer) / factor(num_coeff)
-                        num_coeff, num_polys = factor_list(Poly(numer), *[x for x in sympy_vars[:(i+1)]])
+                        numer = sympy.factor(numer) / sympy.factor(num_coeff)
+                        num_coeff, num_polys = sympy.factor_list(sympy.Poly(numer), *[x for x in sympy_vars[:(i+1)]])
                         result.append(sympy.expand(num_coeff))
                 
                 # Last factor
-                numer = factor(numer) / factor(num_coeff)
+                numer = sympy.factor(numer) / sympy.factor(num_coeff)
                 result.append(sympy.expand(numer))
             else:
-                num_coeff, num_polys = factor_list(Poly(numer))
-                den_coeff, den_polys = factor_list(Poly(denom))
-                result = [num_coeff / den_coeff, sympy.expand(factor(numer)/num_coeff / (factor(denom)/den_coeff))]
+                num_coeff, num_polys = sympy.factor_list(sympy.Poly(numer))
+                den_coeff, den_polys = sympy.factor_list(sympy.Poly(denom))
+                result = [num_coeff / den_coeff, sympy.expand(sympy.factor(numer)/num_coeff / (sympy.factor(denom)/den_coeff))]
         except sympy.PolynomialError: # MMA does not raise error for non poly
             result.append(sympy.expand(numer))
             # evaluation.message(self.get_name(), 'poly', expr)

--- a/mathics/builtin/image.py
+++ b/mathics/builtin/image.py
@@ -497,7 +497,7 @@ class ImageResize(_ImageBuiltin):
         'imgrssz': 'The size `1` is not a valid image size specification.',
         'imgrsm': 'Invalid resampling method `1`.',
         'gaussaspect': 'Gaussian resampling needs to maintain aspect ratio.',
-        'skimage': 'Please install skimage to use Resampling -> Gaussian.',
+        'skimage': 'Please install scikit-image to use Resampling -> Gaussian.',
     }
 
     def _get_image_size_spec(self, old_size, new_size):

--- a/mathics/core/convert.py
+++ b/mathics/core/convert.py
@@ -149,17 +149,18 @@ def from_sympy(expr):
         elif isinstance(expr, sympy.numbers.ImaginaryUnit):
             return Complex(Integer(0), Integer(1))
         elif isinstance(expr, sympy.Integer):
-            return Integer(expr.p)
+            return Integer(int(expr))
         elif isinstance(expr, sympy.Rational):
-            if expr.q == 0:
-                if expr.p > 0:
+            numerator, denominator = map(int, expr.as_numer_denom())
+            if denominator == 0:
+                if numerator > 0:
                     return Symbol('Infinity')
-                elif expr.p < 0:
+                elif numerator < 0:
                     return Expression('Times', Integer(-1), Symbol('Infinity'))
                 else:
-                    assert expr.p == 0
+                    assert numerator == 0
                     return Symbol('Indeterminate')
-            return Rational(expr.p, expr.q)
+            return Rational(numerator, denominator)
         elif isinstance(expr, sympy.Float):
             if expr._prec == machine_precision:
                 return MachineReal(float(expr))

--- a/mathics/core/convert.py
+++ b/mathics/core/convert.py
@@ -101,8 +101,6 @@ def from_sympy(expr):
         Symbol, Integer, Rational, Real, Complex, String, Expression, MachineReal)
     from mathics.core.numbers import machine_precision
 
-    from sympy.core import numbers, function, symbol
-
     if isinstance(expr, (tuple, list)):
         return Expression('List', *[from_sympy(item) for item in expr])
     if isinstance(expr, int):
@@ -127,7 +125,7 @@ def from_sympy(expr):
         name = None
         if expr.is_Symbol:
             name = str(expr)
-            if isinstance(expr, symbol.Dummy):
+            if isinstance(expr, sympy.Dummy):
                 name = name + ('__Dummy_%d' % expr.dummy_index)
                 return Symbol(name, sympy_dummy=expr)
             if is_Cn_expr(name):
@@ -144,15 +142,15 @@ def from_sympy(expr):
             if builtin is not None:
                 name = builtin.get_name()
             return Symbol(name)
-        elif isinstance(expr, (numbers.Infinity, numbers.ComplexInfinity)):
+        elif isinstance(expr, (sympy.numbers.Infinity, sympy.numbers.ComplexInfinity)):
             return Symbol(expr.__class__.__name__)
-        elif isinstance(expr, numbers.NegativeInfinity):
+        elif isinstance(expr, sympy.numbers.NegativeInfinity):
             return Expression('Times', Integer(-1), Symbol('Infinity'))
-        elif isinstance(expr, numbers.ImaginaryUnit):
+        elif isinstance(expr, sympy.numbers.ImaginaryUnit):
             return Complex(Integer(0), Integer(1))
-        elif isinstance(expr, numbers.Integer):
+        elif isinstance(expr, sympy.Integer):
             return Integer(expr.p)
-        elif isinstance(expr, numbers.Rational):
+        elif isinstance(expr, sympy.Rational):
             if expr.q == 0:
                 if expr.p > 0:
                     return Symbol('Infinity')
@@ -162,13 +160,13 @@ def from_sympy(expr):
                     assert expr.p == 0
                     return Symbol('Indeterminate')
             return Rational(expr.p, expr.q)
-        elif isinstance(expr, numbers.Float):
+        elif isinstance(expr, sympy.Float):
             if expr._prec == machine_precision:
                 return MachineReal(float(expr))
             return Real(expr)
-        elif isinstance(expr, numbers.NaN):
+        elif isinstance(expr, sympy.numbers.NaN):
             return Symbol('Indeterminate')
-        elif isinstance(expr, function.FunctionClass):
+        elif isinstance(expr, sympy.function.FunctionClass):
             return Symbol(str(expr))
         elif expr is sympy.true:
             return Symbol('True')

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -1674,7 +1674,7 @@ class Integer(Number):
 
 
 class Rational(Number):
-    def __new__(cls, numerator, denominator=None):
+    def __new__(cls, numerator, denominator=1):
         self = super(Rational, cls).__new__(cls)
         self.value = sympy.Rational(numerator, denominator)
         return self


### PR DESCRIPTION
Hello,

I did [some work](https://github.com/skirpichev/Mathics/tree/diofant-experiment) to make Mathcis codebase working on a different CAS kernel, the [Diofant](https://github.com/diofant/diofant).  To my surprise, it works quite well (test pass locally) and required changes are small.

Not sure if Mathics developers will be positive on making Python CAS backend swichable, but here some simple fixes from the mentioned branch. I hope, this could be useful on its own.