### PR TITLE
Eigenvalues/Eigenvectors fix

### DIFF
--- a/mathics/builtin/linalg.py
+++ b/mathics/builtin/linalg.py
@@ -701,9 +701,15 @@ class Eigenvalues(Builtin):
             eigenvalues = sorted(six.iteritems(eigenvalues),
                                  key=lambda v_c: (abs(v_c[0]), -v_c[0]), 
                                  reverse=True)
+        # Complex numbers
         except TypeError:
-            eigenvalues = sorted(eigenvalues.items(), 
-                                 key=lambda v_c: -abs(v_c[0])
+            try:
+                eigenvalues = sorted(eigenvalues.items(), 
+                                     key=lambda v_c: -abs(v_c[0]))
+            # Something else: don't sort the results at all
+            except TypeError:
+                pass
+
         return from_sympy([v for (v, c) in eigenvalues for _ in range(c)])
 
 
@@ -972,16 +978,21 @@ class Eigenvectors(Builtin):
             return evaluation.message(
                 'Eigenvectors', 'eigenvecnotimplemented', m)
 
-        # The eigenvectors are given in the same order as the eigenvalues.
+        # The eigenvectors are given in the same order as the eigenvalues (if
+        # we are able to sort them).
         try:
             eigenvects = sorted(eigenvects, 
                                 key=lambda v_c: (abs(v_c[0]), -v_c[0]), 
                                 reverse=True)
-
         # Complex numbers
         except TypeError:
-            eigenvects = sorted(eigenvects, 
-                                key=lambda val_c_vect: -abs(v_c[0]))
+            try:
+                eigenvects = sorted(eigenvects, 
+                                    key=lambda v_c: -abs(v_c[0]))
+            # Something else: don't sort the results at all
+            except TypeError:
+                pass
+
         result = []
         for val, count, basis in eigenvects:
             # Select the i'th basis vector, convert matrix to vector,

--- a/mathics/builtin/linalg.py
+++ b/mathics/builtin/linalg.py
@@ -5,6 +5,13 @@
 Linear algebra
 """
 
+from __future__ import unicode_literals
+from __future__ import absolute_import
+
+import six
+from six.moves import range
+from six.moves import zip
+
 import sympy
 from mpmath import mp
 
@@ -49,37 +56,6 @@ def to_mpmath_matrix(data, **kwargs):
         return mp.matrix(data)
     except (TypeError, AssertionError, ValueError):
         return None
-
-
-class Tr(Builtin):
-    """
-    <dl>
-    <dt>'Tr[$m$]'
-        <dd>computes the trace of the matrix $m$.
-    </dl>
-    
-    >> Tr[{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}]
-     = 15
-    
-    Symbolic trace:
-    >> Tr[{{a, b, c}, {d, e, f}, {g, h, i}}]
-     = a + e + i
-    """
-    
-    messages = {
-        'matsq': "The matrix `1` is not square."
-    }
-    
-    #TODO: generalize to vectors and higher-rank tensors, and allow function arguments for application
-    
-    def apply(self, m, evaluation):
-        'Tr[m_]'
-        
-        matrix = to_sympy_matrix(m)
-        if matrix is None or matrix.cols != matrix.rows or matrix.cols == 0:
-            return evaluation.message('Tr', 'matsq', m)
-        tr = matrix.trace()
-        return from_sympy(tr)
 
 
 class Det(Builtin):
@@ -271,6 +247,10 @@ class QRDecomposition(Builtin):
 
     >> QRDecomposition[{{1, 2}, {3, 4}, {5, 6}}]
      = {{{Sqrt[35] / 35, 3 Sqrt[35] / 35, Sqrt[35] / 7}, {13 Sqrt[210] / 210, 2 Sqrt[210] / 105, -Sqrt[210] / 42}}, {{Sqrt[35], 44 Sqrt[35] / 35}, {0, 2 Sqrt[210] / 35}}}
+
+    #> QRDecomposition[{{1, 2, 3, 4}, {1, 4, 9, 16}, {1, 8, 27, 64}}]
+     : Sympy is unable to perform the QR decomposition.
+     = QRDecomposition[{{1, 2, 3, 4}, {1, 4, 9, 16}, {1, 8, 27, 64}}]
 
     #> QRDecomposition[{1, {2}}]
      : Argument {1, {2}} at position 1 is not a non-empty rectangular matrix.
@@ -718,12 +698,12 @@ class Eigenvalues(Builtin):
             return evaluation.message('Eigenvalues', 'matsq', m)
         eigenvalues = matrix.eigenvals()
         try:
-            eigenvalues = sorted(eigenvalues.items(),
-                                 key=lambda v_c: (abs(v_c[0]), -v_c[0]), reverse=True)
-        except TypeError as e:
-            if not str(e).startswith('cannot determine truth value of'):
-                raise e
-            eigenvalues = list(eigenvalues.items())
+            eigenvalues = sorted(six.iteritems(eigenvalues),
+                                 key=lambda v_c: (abs(v_c[0]), -v_c[0]), 
+                                 reverse=True)
+        except TypeError:
+            eigenvalues = sorted(eigenvalues.items(), 
+                                 key=lambda v_c: -abs(v_c[0])
         return from_sympy([v for (v, c) in eigenvalues for _ in range(c)])
 
 
@@ -757,7 +737,7 @@ class MatrixPower(Builtin):
      = {{169, -70}, {-70, 29}}
 
     #> MatrixPower[{{0, x}, {0, 0}}, n]
-     = MatrixPower[{{0, x}, {0, 0}}, n]
+     = {{0 ^ n, n x 0 ^ (-1 + n)}, {0, 0 ^ n}}
 
     #> MatrixPower[{{1, 0}, {0}}, 2]
      : Argument {{1, 0}, {0}} at position 1 is not a non-empty rectangular matrix.
@@ -765,9 +745,8 @@ class MatrixPower(Builtin):
     """
 
     messages = {
-        'matrixpowernotimplemented': 'Matrix power not implemented for matrix `1`.',
-        'matrix': 'Argument `1` at position `2` is not a non-empty rectangular matrix.',
-        'matrixpowernotinvertible': 'Matrix det == 0; not invertible'
+        'matrixpowernotimplemented': ('Matrix power not implemented for matrix `1`.'),
+        'matrix': "Argument `1` at position `2` is not a non-empty rectangular matrix.",
     }
 
     def apply(self, m, power, evaluation):
@@ -784,8 +763,6 @@ class MatrixPower(Builtin):
             res = sympy_m ** sympy_power
         except NotImplementedError:
             return evaluation.message('MatrixPower', 'matrixpowernotimplemented', m)
-        except ValueError as e:
-            return evaluation.message('MatrixPower', 'matrixpowernotinvertible', m)
         return from_sympy(res)
 
 
@@ -996,7 +973,15 @@ class Eigenvectors(Builtin):
                 'Eigenvectors', 'eigenvecnotimplemented', m)
 
         # The eigenvectors are given in the same order as the eigenvalues.
-        eigenvects = sorted(eigenvects, key=lambda val_c_vect: (abs(val_c_vect[0]), -val_c_vect[0]), reverse=True)
+        try:
+            eigenvects = sorted(eigenvects, 
+                                key=lambda v_c: (abs(v_c[0]), -v_c[0]), 
+                                reverse=True)
+
+        # Complex numbers
+        except TypeError:
+            eigenvects = sorted(eigenvects, 
+                                key=lambda val_c_vect: -abs(v_c[0]))
         result = []
         for val, count, basis in eigenvects:
             # Select the i'th basis vector, convert matrix to vector,


### PR DESCRIPTION
This is a follow up to https://github.com/mathics/Mathics/issues/795. Although Mathics had no problem computing the eigenvalues and eigenvectors of complex matrices, it tried sorting them before returning the results. This PR makes it so that the results are only sorted whenever it's possible to do so.