### PR TITLE
Fixed the behaviour of `Quit`

### DIFF
--- a/mathics/builtin/evaluation.py
+++ b/mathics/builtin/evaluation.py
@@ -451,7 +451,7 @@ class Out(Builtin):
 class Exit(Builtin):
     '''
     <dl>
-    <dt>'Exit'
+    <dt>'Exit[]'
       <dd>terminates the Mathics session.
     <dt>'Exit[n]'
       <dd>terminates with exit code $n$.
@@ -460,28 +460,26 @@ class Exit(Builtin):
     Exit is an alias for Quit.
     '''
 
-    def apply(self, evaluation):
-        'Exit'
-        exit()
-
-    def apply_n(self, n, evaluation):
-        'Exit[n_Integer]'
-        exit(n.get_int_value())
+    rules = {
+        'Exit': "Quit",
+    }
 
 
 class Quit(Builtin):
     '''
     <dl>
-    <dt>'Quit'
+    <dt>'Quit[]'
       <dd>terminates the Mathics session.
     <dt>'Quit[n]'
       <dd>terminates with exit code $n$.
     </dl>
-
-    Quit is an alias for Exit.
     '''
 
     rules = {
-        'Quit[n_Integer]': 'Exit[n]',
-        'Quit': 'Exit',
+        'Quit[]': "Quit[0]",
     }
+
+    def apply(self, n, evaluation):
+        'Quit[n_Integer]'
+        exit(n.get_int_value())
+


### PR DESCRIPTION
There was a bug that caused the exit code in `Quit[n]` to be ignored. It's now fixed, but the `Quit` shortcut for `Quit[]` doesn't work anymore.