### PR TITLE
Remove escape deprecation warnings

### DIFF
--- a/mathics/builtin/diffeqns.py
+++ b/mathics/builtin/diffeqns.py
@@ -8,7 +8,7 @@ Differential equation solver functions
 import sympy
 from mathics.builtin.base import Builtin
 from mathics.core.expression import Expression
-from mathics.core.convert import sympy_symbol_prefix, from_sympy
+from mathics.core.convert import from_sympy
 
 
 class DSolve(Builtin):
@@ -75,7 +75,7 @@ class DSolve(Builtin):
 
     # XXX sympy #11669 test
     """
-    #> DSolve[\[Gamma]'[x] == 0, \[Gamma], x]
+    #> DSolve[\\[Gamma]'[x] == 0, \\[Gamma], x]
      : Hit sympy bug #11669.
      = ...
     """

--- a/mathics/builtin/exptrig.py
+++ b/mathics/builtin/exptrig.py
@@ -123,7 +123,7 @@ class Degree(SympyConstant):
      = Cos[Degree[x]]
 
     ## Issue 274
-    #> \[Degree] == ° == Degree
+    #> \\[Degree] == ° == Degree
      = True
 
     #> N[Degree]

--- a/mathics/builtin/files.py
+++ b/mathics/builtin/files.py
@@ -172,7 +172,7 @@ class InitialDirectory(Predefined):
     """
     <dl>
     <dt>'$InitialDirectory'
-      <dd>returns the directory from which \Mathics was started.
+      <dd>returns the directory from which \\Mathics was started.
     </dl>
 
     >> $InitialDirectory
@@ -190,7 +190,7 @@ class InstallationDirectory(Predefined):
     """
     <dl>
     <dt>'$InstallationDirectory'
-      <dd>returns the directory in which \Mathics was installed.
+      <dd>returns the directory in which \\Mathics was installed.
     </dl>
 
     >> $InstallationDirectory
@@ -1560,7 +1560,7 @@ class BinaryRead(Builtin):
     #> ToCharacterCode[WbR[{50, 154, 182, 236}, {"Character16", "Character16"}]]
      = {{39474}, {60598}}
     ## #> WbR[ {91, 146, 206, 54}, {"Character16", "Character16"}]
-    ##  = {\:925b, \:36ce}
+    ##  = {\\:925b, \\:36ce}
 
     ## Complex64
     #> WbR[{80, 201, 77, 239, 201, 177, 76, 79}, "Complex64"] // InputForm
@@ -2467,7 +2467,7 @@ class FileNameJoin(Builtin):
 
     ## TODO
     ## #> FileNameJoin[{"dir1", "dir2", "dir3"}, OperatingSystem -> "Windows"]
-    ##  = dir1\dir2\dir3
+    ##  = dir1\\dir2\\dir3
     """
 
     attributes = ('Protected')

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -6,7 +6,6 @@ Input and Output
 """
 
 import re
-import sympy
 import mpmath
 
 import typing
@@ -19,10 +18,10 @@ from mathics.builtin.comparison import expr_min
 from mathics.builtin.lists import list_boxes
 from mathics.builtin.options import options_to_rules
 from mathics.core.expression import (
-    Expression, String, Symbol, Integer, Rational, Real, Complex, BoxError,
+    Expression, String, Symbol, Integer, Real, BoxError,
     from_python, MachineReal, PrecisionReal)
 from mathics.core.numbers import (
-    dps, prec, convert_base, machine_precision, reconstruct_digits)
+    dps, convert_base, machine_precision, reconstruct_digits)
 
 MULTI_NEWLINE_RE = re.compile(r"\n{2,}")
 
@@ -305,33 +304,33 @@ class MakeBoxes(Builtin):
     <dt>'MakeBoxes[$expr$]'
         <dd>is a low-level formatting primitive that converts $expr$
         to box form, without evaluating it.
-    <dt>'\( ... \)'
+    <dt>'\\( ... \\)'
         <dd>directly inputs box objects.
     </dl>
 
     String representation of boxes
-    >> \(x \^ 2\)
+    >> \\(x \\^ 2\\)
      = SuperscriptBox[x, 2]
 
-    >> \(x \_ 2\)
+    >> \\(x \\_ 2\\)
      = SubscriptBox[x, 2]
 
-    >> \( a \+ b \% c\)
+    >> \\( a \\+ b \\% c\\)
      = UnderoverscriptBox[a, b, c]
 
-    >> \( a \& b \% c\)
+    >> \\( a \\& b \\% c\\)
      = UnderoverscriptBox[a, c, b]
 
-    #> \( \@ 5 \)
+    #> \\( \\@ 5 \\)
      = SqrtBox[5]
 
-    >> \(x \& y \)
+    >> \\(x \\& y \\)
      = OverscriptBox[x, y]
 
-    >> \(x \+ y \)
+    >> \\(x \\+ y \\)
      = UnderscriptBox[x, y]
 
-    #> \( x \^ 2 \_ 4 \)
+    #> \\( x \\^ 2 \\_ 4 \\)
      = SuperscriptBox[x, SubscriptBox[2, 4]]
 
     ## Tests for issue 151 (infix operators in heads)
@@ -346,13 +345,13 @@ class MakeBoxes(Builtin):
 
     # TODO: Convert operators to appropriate representations e.g. 'Plus' to '+'
     """
-    >> \(a + b\)
+    >> \\(a + b\\)
      = RowBox[{a, +, b}]
 
-    >> \(TraditionalForm \` a + b\)
+    >> \\(TraditionalForm \\` a + b\\)
      = FormBox[RowBox[{a, +, b}], TraditionalForm]
 
-    >> \(x \/ \(y + z\)\)
+    >> \\(x \\/ \\(y + z\\)\\)
      =  FractionBox[x, RowBox[{y, +, z}]]
     """
 
@@ -395,24 +394,24 @@ class MakeBoxes(Builtin):
 
     # TODO: Correct precedence
     """
-    >> \(x \/ y + z\)
+    >> \\(x \\/ y + z\\)
      = RowBox[{FractionBox[x, y], +, z}]
-    >> \(x \/ (y + z)\)
+    >> \\(x \\/ (y + z)\\)
      = FractionBox[x, RowBox[{(, RowBox[{y, +, z}], )}]]
 
-    #> \( \@ a + b \)
+    #> \\( \\@ a + b \\)
      = RowBox[{SqrtBox[a], +, b}]
     """
 
     # FIXME: Don't insert spaces with brackets
     """
-    #> \(c (1 + x)\)
+    #> \\(c (1 + x)\\)
      = RowBox[{c, RowBox[{(, RowBox[{1, +, x}], )}]}]
     """
 
     # TODO: Required MakeExpression
     """
-    #> \!\(x \^ 2\)
+    #> \\!\\(x \\^ 2\\)
      = x ^ 2
     #> FullForm[%]
      = Power[x, 2]
@@ -426,7 +425,7 @@ class MakeBoxes(Builtin):
 
     # TODO: Parsing of special characters (like commas)
     """
-    >> \( a, b \)
+    >> \\( a, b \\)
      = RowBox[{a, ,, b}]
     """
 
@@ -1771,7 +1770,7 @@ class Print(Builtin):
     >> Print["The answer is ", 7 * 6, "."]
      | The answer is 42.
 
-    #> Print["\[Mu]"]
+    #> Print["\\[Mu]"]
      | μ
     #> Print["μ"]
      | μ
@@ -1930,7 +1929,7 @@ class TeXForm(Builtin):
             # Replace multiple newlines by a single one e.g. between asy-blocks
             tex = MULTI_NEWLINE_RE.sub('\n', tex)
 
-            tex = tex.replace(' \uF74c', ' \, d')  # tmp hack for Integrate
+            tex = tex.replace(' \uF74c', ' \\, d')  # tmp hack for Integrate
         except BoxError:
             evaluation.message(
                 'General', 'notboxes',

--- a/mathics/test.py
+++ b/mathics/test.py
@@ -44,20 +44,18 @@ def compare(result, wanted):
             return False
     return True
 
-stars = "*" * 10
-def test_case(test, tests, index=0, subindex=0, quiet=False, section=None):
+
+def test_case(test, tests, index=0, quiet=False):
     test, wanted_out, wanted = test.test, test.outs, test.result
+    part, chapter, section = tests.part, tests.chapter, tests.section
 
     def fail(why):
-        part, chapter, section = tests.part, tests.chapter, tests.section
         print("%sTest failed: %s in %s / %s\n%s\n%s\n" % (
             sep, section, part, chapter, test, why))
         return False
 
     if not quiet:
-        if section:
-            print("%s %s / %s %s" % (stars, tests.chapter, section, stars))
-        print('%4d (%2d): TEST %s' % (index, subindex, test))
+        print('%4d. TEST %s' % (index, test))
 
     feeder = SingleLineFeeder(test, '<test>')
     evaluation = Evaluation(definitions, catch_interrupt=False, output=TestOutput())
@@ -97,12 +95,12 @@ def test_case(test, tests, index=0, subindex=0, quiet=False, section=None):
             '\n'.join(str(o) for o in wanted_out)))
     return True
 
+
 def test_tests(tests, index, quiet=False, stop_on_failure=False, start_at=0):
     definitions.reset_user_definitions()
     count = failed = skipped = 0
     failed_symbols = set()
-    section = tests.section
-    for subindex, test in enumerate(tests.tests):
+    for test in tests.tests:
         if test.ignore:
             continue
         count += 1
@@ -110,12 +108,11 @@ def test_tests(tests, index, quiet=False, stop_on_failure=False, start_at=0):
         if index < start_at:
             skipped += 1
             continue
-        if not test_case(test, tests, index, subindex + 1, quiet, section):
+        if not test_case(test, tests, index, quiet):
             failed += 1
             failed_symbols.add((tests.part, tests.chapter, tests.section))
             if stop_on_failure:
                 break
-        section = None
     return count, failed, skipped, failed_symbols, index
 
 
@@ -260,13 +257,14 @@ def main():
 
     if args.tex:
         write_latex()
-    elif args.section:
-        test_section(args.section, stop_on_failure=args.stop_on_failure)
     else:
-        start_at = args.skip + 1
-        test_all(quiet=args.quiet, generate_output=args.output,
-                 stop_on_failure=args.stop_on_failure,
-                 start_at=start_at)
+        if args.section:
+            test_section(args.section, stop_on_failure=args.stop_on_failure)
+        else:
+            start_at = args.skip + 1
+            test_all(quiet=args.quiet, generate_output=args.output,
+                     stop_on_failure=args.stop_on_failure,
+                     start_at=start_at)
 
 if __name__ == '__main__':
     main()

--- a/mathics/test.py
+++ b/mathics/test.py
@@ -44,18 +44,20 @@ def compare(result, wanted):
             return False
     return True
 
-
-def test_case(test, tests, index=0, quiet=False):
+stars = "*" * 10
+def test_case(test, tests, index=0, subindex=0, quiet=False, section=None):
     test, wanted_out, wanted = test.test, test.outs, test.result
-    part, chapter, section = tests.part, tests.chapter, tests.section
 
     def fail(why):
+        part, chapter, section = tests.part, tests.chapter, tests.section
         print("%sTest failed: %s in %s / %s\n%s\n%s\n" % (
             sep, section, part, chapter, test, why))
         return False
 
     if not quiet:
-        print('%4d. TEST %s' % (index, test))
+        if section:
+            print("%s %s / %s %s" % (stars, tests.chapter, section, stars))
+        print('%4d (%2d): TEST %s' % (index, subindex, test))
 
     feeder = SingleLineFeeder(test, '<test>')
     evaluation = Evaluation(definitions, catch_interrupt=False, output=TestOutput())
@@ -95,12 +97,12 @@ def test_case(test, tests, index=0, quiet=False):
             '\n'.join(str(o) for o in wanted_out)))
     return True
 
-
 def test_tests(tests, index, quiet=False, stop_on_failure=False, start_at=0):
     definitions.reset_user_definitions()
     count = failed = skipped = 0
     failed_symbols = set()
-    for test in tests.tests:
+    section = tests.section
+    for subindex, test in enumerate(tests.tests):
         if test.ignore:
             continue
         count += 1
@@ -108,11 +110,12 @@ def test_tests(tests, index, quiet=False, stop_on_failure=False, start_at=0):
         if index < start_at:
             skipped += 1
             continue
-        if not test_case(test, tests, index, quiet):
+        if not test_case(test, tests, index, subindex + 1, quiet, section):
             failed += 1
             failed_symbols.add((tests.part, tests.chapter, tests.section))
             if stop_on_failure:
                 break
+        section = None
     return count, failed, skipped, failed_symbols, index
 
 
@@ -257,14 +260,13 @@ def main():
 
     if args.tex:
         write_latex()
+    elif args.section:
+        test_section(args.section, stop_on_failure=args.stop_on_failure)
     else:
-        if args.section:
-            test_section(args.section, stop_on_failure=args.stop_on_failure)
-        else:
-            start_at = args.skip + 1
-            test_all(quiet=args.quiet, generate_output=args.output,
-                     stop_on_failure=args.stop_on_failure,
-                     start_at=start_at)
+        start_at = args.skip + 1
+        test_all(quiet=args.quiet, generate_output=args.output,
+                 stop_on_failure=args.stop_on_failure,
+                 start_at=start_at)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Remove deprecation warning associated with \.

In older Python's backslash () followed by a symbol that is not an by one of the acceptable escape characters was okay and would be the two symbols. For example "\[" would represent the string "\[".

In newer Pythons the escape is expected to be escaped. e.g. "\\[ represents \['.