### PR TITLE
Added mentation about docker images in the documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,11 @@ Installing
 ----------
 `Here <https://github.com/mathics/Mathics/wiki/Installing>`_ is a short guide on how to install Mathics on your computer.
 
+Docker
+------
+
+Alternatively to the installation step above, ``mathics`` can be installed and run via `docker <https://www.docker.com/>`_. Please refer to `sealemar/mathics-dockerized <https://github.com/sealemar/mathics-dockerized>`_ repo for instructions.
+
 Contributing
 ------------
 


### PR DESCRIPTION
This PR steals the relevant commits from https://github.com/mathics/Mathics/pull/753. It's a fix for #751.