### PR TITLE
InputForm should escape backslash

### DIFF
--- a/mathics/builtin/files.py
+++ b/mathics/builtin/files.py
@@ -2093,7 +2093,7 @@ class Get(PrefixOperator):
     #> Hold[<< ~/some_example/dir/] // FullForm
      = Hold[Get["~/some_example/dir/"]]
     #> Hold[<<`/.\-_:$*~?] // FullForm
-     = Hold[Get["`/.\\-_:$*~?"]]
+     = Hold[Get["`/.\\\\-_:$*~?"]]
     """
 
     operator = '<<'

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -1821,7 +1821,7 @@ class StandardForm(Builtin):
 
 
 class InputForm(Builtin):
-    """
+    r"""
     <dl>
     <dt>'InputForm[$expr$]'
         <dd>displays $expr$ in an unambiguous form suitable for input.
@@ -1837,6 +1837,8 @@ class InputForm(Builtin):
      = Derivative[1, 0][f][x]
     #> InputForm[2 x ^ 2 + 4z!]
      = 2*x^2 + 4*z!
+    #> InputForm["\$"]
+     = "\\$"
     """
 
 

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -2057,7 +2057,7 @@ class _IterationFunction(Builtin):
     def apply_range(self, expr, i, imax, evaluation):
         '%(name)s[expr_, {i_Symbol, imax_}]'
 
-        if imax.get_head_name() == 'Range':
+        if imax.has_form('Range', None):
             seq = Expression('Sequence', *(imax.evaluate(evaluation).leaves))
             return self.apply_list(expr, i, seq, evaluation)
         else:

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -2289,7 +2289,12 @@ class String(Atom):
                 return render('%s', text)
 
     def atom_to_boxes(self, f, evaluation):
-        return String('"' + str(self.value) + '"')
+        inner = str(self.value)
+
+        if f.get_name() in system_symbols('InputForm', 'FullForm'):
+            inner = inner.replace('\\', '\\\\')
+
+        return String('"' + inner + '"')
 
     def do_copy(self) -> 'String':
         return String(self.value)


### PR DESCRIPTION
Fixed #538. This was fixed by @sn6uv in https://github.com/mathics/Mathics/pull/539. I just rebased his commit.