### PR TITLE
Fix documentation errors regarding UTF8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ before_install:
     fi
   - if [[ "$DOC" == "true" ]]; then
       sudo apt-get install -qq asymptote texlive-latex-extra texlive-latex3 texlive-fonts-recommended;
-      sudo apt-get install -qq  texlive-font-utils latexmk  lmodern;
+      sudo apt-get install -qq  texlive-font-utils latexmk texlive-xetex lmodern;
       sudo add-apt-repository -y ppa:inkscape.dev/stable-daily && sudo apt-get update && sudo apt-get install -qq inkscape;
     fi
   - if [[ "$CYTHON" == "true" ]]; then

--- a/mathics/doc/doc.py
+++ b/mathics/doc/doc.py
@@ -191,7 +191,6 @@ def escape_latex(text):
     text = _replace_all(text, [
         ('$', r'\$'), ('\u03c0', r'$\pi$'), ('≥', r'$\ge$'), ('≤', r'$\le$'),
         ('≠', r'$\ne$'),
-        ('\u29E6',r'\equiv'), ('\u22BB',r'\xor'), ('\uF523',r'\Rightarrow'),
         ('ç',r'\c{c}'),('é',r'\'e'),('ê',r'\^e'),('ñ',r'\~n'),
          ('∫',r'\int'),('',r'd'),   ])
 
@@ -952,7 +951,8 @@ class DocSection(DocElement):
             '\\addcontentsline{toc}{section}{%(title)s}') % {
                 'title': title,
                 'index': index,
-                'content': self.doc.latex(output)}
+                'content': self.doc.latex(output)
+            }
 
     def get_url(self):
         return '/%s/%s/%s/' % (
@@ -1080,9 +1080,15 @@ class DocTests(object):
     def latex(self, output):
         if len(self.tests) == 0:
             return "\n"
+
+        testLatexStrings = [test.latex(output) for test in self.tests
+                       if not test.private]
+        testLatexStrings = [t for t in testLatexStrings if len(t)>1]
+        if len(testLatexStrings) == 0:
+            return "\n"
+        
         return '\\begin{tests}%%\n%s%%\n\\end{tests}' % (
-            '%\n'.join(test.latex(output) for test in self.tests
-                       if not test.private))
+            '%\n'.join(testLatexStrings))
 
     def html(self, counters=None):
         if len(self.tests) == 0:

--- a/mathics/doc/tex/Makefile
+++ b/mathics/doc/tex/Makefile
@@ -1,10 +1,11 @@
-TEX = pdflatex
+#TEX = pdflatex
+TEX = xelatex
 LATEXMK = latexmk
 #-quiet
 
 mathics.pdf: mathics.tex documentation.tex
 	$(LATEXMK) -pdf -pdflatex=$(TEX) mathics
-	
+
 latex: mathics.pdf
 
 clean:

--- a/mathics/doc/tex/Makefile
+++ b/mathics/doc/tex/Makefile
@@ -1,4 +1,4 @@
-#TEX = pdflatex
+
 TEX = xelatex
 LATEXMK = latexmk
 #-quiet

--- a/mathics/doc/tex/latexmkrc
+++ b/mathics/doc/tex/latexmkrc
@@ -1,4 +1,4 @@
-sub asy {return system("asy '$_[0]' -render=0 -nosafe -noprc");}
+sub asy {return system("asy '$_[0]' -render=0 -nosafe -noprc --gsOptions='-P'");}
 add_cus_dep("asy","eps",0,"asy");
 add_cus_dep("asy","pdf",0,"asy");
 add_cus_dep("asy","tex",0,"asy");

--- a/mathics/doc/tex/latexmkrc
+++ b/mathics/doc/tex/latexmkrc
@@ -1,4 +1,4 @@
-sub asy {return system("asy '$_[0]' -render=0 -noprc");}
+sub asy {return system("asy '$_[0]' -render=0 -nosafe -noprc");}
 add_cus_dep("asy","eps",0,"asy");
 add_cus_dep("asy","pdf",0,"asy");
 add_cus_dep("asy","tex",0,"asy");

--- a/mathics/doc/tex/mathics.tex
+++ b/mathics/doc/tex/mathics.tex
@@ -61,6 +61,12 @@
     {ä}{{\"a}}1
     {ö}{{\"o}}1
     {~}{{\textasciitilde}}1
+    {⧦}{{===}}1
+    {}{{=>}}1
+    {⊻}{{xor}}1
+    {…}{{...}}1
+    {∫}{{S}}1
+    {}{{d}}1
 }
 
 \setlength{\columnsep}{1cm}
@@ -219,10 +225,12 @@
 \tableofcontents
 
 \lstset{
-breaklines=true,
-breakatwhitespace=false,
-showspaces=false,
-basicstyle=\ttfamily
+  inputencoding=utf8,
+  extendedchars=true,
+  breaklines=true,
+  breakatwhitespace=false,
+  showspaces=false,
+  basicstyle=\ttfamily
 }
 
 \lstdefinestyle{python}{language=Python,tabsize=2,basicstyle=\scriptsize\ttfamily,showstringspaces=false,stringstyle=\color{pythonstring},commentstyle=\ttfamily\color{pythonstring},frame=lines}


### PR DESCRIPTION
Well, 
I was able to fix the utf8 errors using xelatex instead of pdflatex, and the issue of the empty tests. There are still errors coming from the asy interface for graphics generation. I am not an expert on that package, so I will need some help from here. Otherwise, we could simply remove the tests that generate problematic graphics.