### PR TITLE
Sum product fix

### DIFF
--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -1837,7 +1837,7 @@ class Sum(_IterationFunction, SympyFunction):
         if expr.has_form('Sum', 2) and expr.leaves[1].has_form('List', 3):
             index = expr.leaves[1]
             arg_kwargs = kwargs.copy()
-            arg_kwargs['converted_functions_all'] = True
+            arg_kwargs['convert_all_global_functions'] = True
             arg = expr.leaves[0].to_sympy(**arg_kwargs)
             bounds = (index.leaves[0].to_sympy(**kwargs), 
                       index.leaves[1].to_sympy(**kwargs), 
@@ -1906,7 +1906,7 @@ class Product(_IterationFunction, SympyFunction):
             index = expr.leaves[1]
             try:
                 e_kwargs = kwargs.copy()
-                e_kwargs['converted_functions_all'] = True
+                e_kwargs['convert_all_global_functions'] = True
                 e = expr.leaves[0].to_sympy(**e_kwargs)
                 i = index.leaves[0].to_sympy(**kwargs)
                 start = index.leaves[1].to_sympy(**kwargs)

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -1836,8 +1836,10 @@ class Sum(_IterationFunction, SympyFunction):
     def to_sympy(self, expr, **kwargs):
         if expr.has_form('Sum', 2) and expr.leaves[1].has_form('List', 3):
             index = expr.leaves[1]
-            arg = expr.leaves[0].to_sympy()
-            bounds = (index.leaves[0].to_sympy(), index.leaves[1].to_sympy(), index.leaves[2].to_sympy())
+            arg = expr.leaves[0].to_sympy(**kwargs)
+            bounds = (index.leaves[0].to_sympy(**kwargs), 
+                      index.leaves[1].to_sympy(**kwargs), 
+                      index.leaves[2].to_sympy(**kwargs))
             if arg is not None and None not in bounds:
                 return sympy.summation(arg, bounds)
 

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -1836,10 +1836,13 @@ class Sum(_IterationFunction, SympyFunction):
     def to_sympy(self, expr, **kwargs):
         if expr.has_form('Sum', 2) and expr.leaves[1].has_form('List', 3):
             index = expr.leaves[1]
-            arg = expr.leaves[0].to_sympy(**kwargs)
+            arg_kwargs = kwargs.copy()
+            arg_kwargs['converted_functions_all'] = True
+            arg = expr.leaves[0].to_sympy(**arg_kwargs)
             bounds = (index.leaves[0].to_sympy(**kwargs), 
                       index.leaves[1].to_sympy(**kwargs), 
                       index.leaves[2].to_sympy(**kwargs))
+
             if arg is not None and None not in bounds:
                 return sympy.summation(arg, bounds)
 
@@ -1902,7 +1905,9 @@ class Product(_IterationFunction, SympyFunction):
         if expr.has_form('Product', 2) and expr.leaves[1].has_form('List', 3):
             index = expr.leaves[1]
             try:
-                e = expr.leaves[0].to_sympy(**kwargs)
+                e_kwargs = kwargs.copy()
+                e_kwargs['converted_functions_all'] = True
+                e = expr.leaves[0].to_sympy(**e_kwargs)
                 i = index.leaves[0].to_sympy(**kwargs)
                 start = index.leaves[1].to_sympy(**kwargs)
                 stop = index.leaves[2].to_sympy(**kwargs)

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -637,15 +637,16 @@ class Expression(BaseExpression):
         if None in sym_args:
             return None
 
-        func = sympy.Function(str(sympy_symbol_prefix + self.get_head_name()))
-        return func(*sym_args)
+        f = sympy.Function(str(sympy_symbol_prefix + self.get_head_name()))
+        return f(*sym_args)
 
     def to_sympy(self, **kwargs):
         from mathics.builtin import mathics_to_sympy
 
-        if 'converted_functions_all' in kwargs:
-            if len(self.leaves) > 0 and kwargs['converted_functions_all']:
-                return self._as_sympy_function(**kwargs)
+        if 'convert_all_global_functions' in kwargs:
+            if len(self.leaves) > 0 and kwargs['convert_all_global_functions']:
+                if self.get_head_name().startswith('Global`'): 
+                    return self._as_sympy_function(**kwargs)
 
         if 'converted_functions' in kwargs:
             functions = kwargs['converted_functions']


### PR DESCRIPTION
Fixed a bug concerning the behaviour of the `Sum` and `Product` builtins.

# Before the patch

```
In[1]:= Sum[f[i], {i, 1, 7}]
Out[1]= 7 f[i]
```

# After the patch

```
In[1]:= Sum[f[i], {i, 1, 7}]
Out[1]= f[1] + f[2] + f[3] + f[4] + f[5] + f[6] + f[7]
```