### PR TITLE
Various Makefile bug fixes and improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PYTHON ?= python3
 PIP ?= pip3
 RM  ?= rm
 
-PHONY: all build check clean develop dist doc pytest test rmChangeLog
+.PHONY: all build check clean develop dist doc pytest test rmChangeLog
 
 #: Default target - same as "develop"
 all: develop
@@ -35,7 +35,7 @@ clean:
 	   $(MAKE) -C $$dir clean; \
 	done
 
-#: Run py.test tests. You can environment variable "o" for pytest options
+#: Run py.test tests. You can set environment variable "o" for pytest options
 pytest:
 	py.test test $o
 

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@
 GIT2CL ?= admin-tools/git2cl
 PYTHON ?= python3
 PIP ?= pip3
-RM      ?= rm
+RM  ?= rm
 
-PHONY=all build check clean develop dist doc pytest test rmChangeLog
+PHONY: all build check clean develop dist doc pytest test rmChangeLog
 
 #: Default target - same as "develop"
 all: develop
@@ -28,7 +28,14 @@ install:
 
 check: pytest doctest
 
-# Run py.test tests. You can environment variable o for pytest options
+# FIXME More directories will be added as Makefiles get improved
+#: Remove derived files
+clean:
+	for dir in mathics/doc; do \
+	   $(MAKE) -C $$dir clean; \
+	done
+
+#: Run py.test tests. You can environment variable "o" for pytest options
 pytest:
 	py.test test $o
 
@@ -37,9 +44,9 @@ doctest:
 	$(PYTHON) mathics/test.py
 
 #: Make Mathics PDF manual
-doc:
-	(cd mathics && $(PYTHON) test.py -ot && \
-	cd doc/tex && make)
+latex doc:
+	(cd mathics && $(PYTHON) test.py -o && \
+	$(PYTHON) test.py -t && cd doc/tex && make)
 
 #: Remove ChangeLog
 rmChangeLog:

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ check: pytest doctest
 #: Remove derived files
 clean:
 	for dir in mathics/doc; do \
-	   $(MAKE) -C $$dir clean; \
+	   $(MAKE) -C "$$dir" clean; \
 	done
 
 #: Run py.test tests. You can set environment variable "o" for pytest options

--- a/mathics/Makefile
+++ b/mathics/Makefile
@@ -1,6 +1,6 @@
 # FIXME: We need to go over this. Much is obsolete
 
-.PHONY clearso restart release
+.PHONY: clearso restart release
 
 put:
 	rsync -av builtin core doc optional web __init__.py main.py manage.py profile.py server.py test.py tests.py urls.py --exclude "*.pyc" --exclude ".DS_Store" --exclude ".*" --exclude "*.c" --exclude "web/db" --exclude "doc/tex" jan@mathics.net:/home/jan/mathics

--- a/mathics/Makefile
+++ b/mathics/Makefile
@@ -1,3 +1,7 @@
+# FIXME: We need to go over this. Much is obsolete
+
+.PHONY clearso restart release
+
 put:
 	rsync -av builtin core doc optional web __init__.py main.py manage.py profile.py server.py test.py tests.py urls.py --exclude "*.pyc" --exclude ".DS_Store" --exclude ".*" --exclude "*.c" --exclude "web/db" --exclude "doc/tex" jan@mathics.net:/home/jan/mathics
 
@@ -7,7 +11,7 @@ restart:
 release:
 	make put
 	make restart
-	
+
 clearso:
 	rm -f builtin/*.so
 	rm -f core/*.so

--- a/mathics/doc/Makefile
+++ b/mathics/doc/Makefile
@@ -3,6 +3,10 @@
 # Note: This makefile include remake-style target comments.
 # These comments before the targets start with #:
 
+.PHONY: latex
+
+all: latex
+
 #: Forward the call to tex, Whatever it is you want to do
 %:
 	$(MAKE) -C tex $@

--- a/mathics/doc/tex/Makefile
+++ b/mathics/doc/tex/Makefile
@@ -1,3 +1,4 @@
+.PHONY: latex doc clean
 
 XETEX ?= xelatex
 LATEXMK ?= latexmk

--- a/pymathics/Makefile
+++ b/pymathics/Makefile
@@ -1,0 +1,34 @@
+# A GNU Makefile to run various tasks - compatibility for us old-timers.
+
+# Note: This makefile include remake-style target comments.
+# These comments before the targets start with #:
+# remake --tasks to shows the targets and the comments
+
+PYTHON ?= python3
+PIP ?= pip3
+RM  ?= rm
+
+.PHONY: all build check clean develop dist doc pytest test rmChangeLog
+
+#: Default target - same as "develop"
+all: develop
+
+#: build everything needed to install; (runs Cython)
+build:
+	$(PYTHON) ./setup.py build
+
+#: Set up to run from source
+develop:
+	$(PIP) install -e .
+
+#: Set up to run from source
+install:
+	$(PYTHON) setup.py install
+
+#: Run tests. For now there's not much here
+check:
+	python test.py
+
+#: Create a ChangeLog from git via git log and git2cl
+doc doctest ChangeLog:
+	$(MAKE) -C .. $@


### PR DESCRIPTION
We need to run python mathics/test.py *twice*
Once with -o, and *then* once with -t. We can't combine these options.

Add top-level "clean" target.
Add .PHONY targets and do it properly
Turn a make comment into a remake-style comment.