### PR TITLE
Remove dependency on six

### DIFF
--- a/mathics/builtin/numeric.py
+++ b/mathics/builtin/numeric.py
@@ -17,7 +17,6 @@ import math
 import hashlib
 import zlib
 import math
-import six
 from collections import namedtuple
 from contextlib import contextmanager
 from itertools import chain
@@ -936,7 +935,7 @@ def convert_float_base(x, base, precision=10):
         fexps = list(range(-1, -int(precision + 1), -1))
         real_part = convert_float(x - int(x), base, precision + 1)
         return int_part + real_part
-    elif isinstance(x, six.integer_types):
+    elif isinstance(x, int):
         return int_part
     else:
         raise TypeError(x)

--- a/pymathics/setup.py
+++ b/pymathics/setup.py
@@ -75,7 +75,6 @@ INSTALL_REQUIRES += [
     "mpmath>=1.1.0",
     "python-dateutil",
     "colorama",
-    "six>=1.10",
 ]
 
 

--- a/pymathics/testpymathicsmodule/__init__.py
+++ b/pymathics/testpymathicsmodule/__init__.py
@@ -4,7 +4,6 @@ Pymathics TestPyMathics
 This is an example of an external mathics module. It just defines a function and a symbol, in the same way is done for  builtin symbols.
 """
 
-import six
 from mathics.builtin.base import Builtin, Symbol, String, AtomBuiltin
 
 # To be recognized as an external mathics module, the following variable


### PR DESCRIPTION
We don't do Python 2.x anymore, so we don't need six.