### PR TITLE
Fixing  llvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,9 @@ matrix:
 services:
   - xvfb
 before_install:
-  - sudo apt-get update -qq && sudo apt-get install -qq liblapack-dev llvm-dev
+  - sudo apt-get update -qq && sudo apt-get install -qq liblapack-dev llvm-10 llvm-10-dev
   - sudo apt-get install -qq gfortran
+  - LLVM_CONFIG=/usr/bin/llvm-config-10  CXXFLAGS=-fPIC python -m pip install llvmlite
   - pip install numpy
   - if [[ "$ALL_MODULES" == "true" ]]; then
       sudo apt-get install -qq &&


### PR DESCRIPTION
I have finally found the problem: pypy3 needs to compile the llvmlite package, and needs the version 10 of the llvm package. But to do that, we need to set up first an environment variable to tell the system to use that version instead of the default (version 7).
