### PR TITLE
Default name for pymathics modules

### DIFF
--- a/mathics/doc/doc.py
+++ b/mathics/doc/doc.py
@@ -762,7 +762,10 @@ class PyMathicsDocumentation(Documentation):
 
         try:
             mainfolder = self.pymathicsmodule.__path__[0]
-            self.name = self.pymathicsmodule.pymathics_version_data['name']
+            if "name" in self.pymathicsmodule.pymathics_version_data:
+                self.name = self.version = self.pymathicsmodule.pymathics_version_data['name']
+            else:
+                self.name = (self.pymathicsmodule.__package__)[10:]
             self.version = self.pymathicsmodule.pymathics_version_data['version']
             self.author = self.pymathicsmodule.pymathics_version_data['author']
         except (AttributeError, KeyError, IndexError):


### PR DESCRIPTION
I implemented now a "default" name, based on the name of the python module, without the prefix "pymathics".