### PR TITLE
Fix Mathematica syntax warning in Import.m

### DIFF
--- a/mathics/autoload/formats/Base64/Import.m
+++ b/mathics/autoload/formats/Base64/Import.m
@@ -5,7 +5,7 @@ Options[B64Import] = {
     "CharacterEncoding" :> $CharacterEncoding
 };
 
-B64Import[filename_, OptionsPattern[]] := 
+B64Import[filename_, OptionsPattern[]] :=
     Module[{strm,data, grid},
 	strm = OpenRead[filename];
 	If[strm === $Failed, Return[$Failed]];
@@ -22,7 +22,7 @@ ImportExport`RegisterImport[
     AvailableElements -> {"Data"},
     DefaultElement -> "Data",
     Options -> {
-        "CharacterEncoding",
+        "CharacterEncoding"
     }
 ]
 


### PR DESCRIPTION
In Mathematica, There shouldn't be a trailing "," in a List.