### PR TITLE
Remove some Python dependencies from the Mathics package

### DIFF
--- a/mathics/builtin/quantities.py
+++ b/mathics/builtin/quantities.py
@@ -180,7 +180,6 @@ class Quantity(Builtin):
 
     def apply_n(self, mag, unit, evaluation):
         'Quantity[mag_, unit_?StringQ]'
-        Expression('Quantity', mag, unit)
 
         if(self.validate(unit, evaluation)):
             if(mag.has_form("List", None)):

--- a/mathics/web/media/js/inout.js
+++ b/mathics/web/media/js/inout.js
@@ -193,6 +193,7 @@ function showGallery() {
 	    'N[E, 30] (* 30-digit Numeric approximation of E *)',
 	    '30!',
 	    '30! // N',
+	    'Sum[2 i + 1, {i, 0, 10}] (* Sum of 1st n odd numbers (n+1)**2 *)',
 	    'n = 8; 2 ^ # & /@ Range[0, n] (* Powers of 2 *)',
 	    'Total[%] (* Sum is 2 ^ n - 1 *)',
 	    '(* Symbolic Manipulation *)',


### PR DESCRIPTION
* pyplot is used by graphs.py but that won't come back here
* colorama is used by the CLI main, but here I think we only need  minimal stuff.  For color terminal, and syntax coloring, command history across sessions and probably eventually handling graphics better, use  tmathics, and all but the first, isn't handled currently in this package.

Some linting and removing non-essentail trailing blanks was also done (largely by my environtment).