### PR TITLE
Revise docker setup instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ To run the command-line interface using docker image:
 
 To run the Django web interface using docker image:
 ::
-   $docker run --rm -it --name mathics-web -p 8000:8000 -v /tmp:/usr/src/app/data mathicsorg/mathics --mode ui
+   $ docker run --rm -it --name mathics-web -p 8000:8000 -v /tmp:/usr/src/app/data mathicsorg/mathics --mode ui
 
 
 This dockeriztion was modified from `sealemar/mathics-dockerized <https://github.com/sealemar/mathics-dockerized>`_. See that for more details on how this works.

--- a/README.rst
+++ b/README.rst
@@ -44,15 +44,15 @@ For an experiemental Jupyter-based consoles and web interfaces see `iwolfram <ht
 Docker
 ------
 
-Another way to run ``mathics`` is via `docker <https://www.docker.com/>`_ and the `Mathics docker image <https://hub.docker.com/repository/docker/rockyb/mathics>`_ on dockerhub.
+Another way to run ``mathics`` is via `docker <https://www.docker.com/>`_ and the `Mathics docker image <https://hub.docker.com/repository/docker/mathicsorg/mathics>`_ on dockerhub.
 
 To run the command-line interface using docker image:
 ::
-   $ docker run --rm -it --name mathics-cli -v /tmp:/usr/src/app/data rockyb:mathics --mode cli
+   $ docker run --rm -it --name mathics-cli -v /tmp:/usr/src/app/data mathicsorg/mathics --mode cli
 
 To run the Django web interface using docker image:
 ::
-   $docker run --rm -it --name mathics-web -p 8000:8000 -v /tmp:/usr/src/app/data rockyb/mathics --mode ui
+   $docker run --rm -it --name mathics-web -p 8000:8000 -v /tmp:/usr/src/app/data mathicsorg/mathics --mode ui
 
 
 This dockeriztion was modified from `sealemar/mathics-dockerized <https://github.com/sealemar/mathics-dockerized>`_. See that for more details on how this works.

--- a/README.rst
+++ b/README.rst
@@ -50,12 +50,17 @@ To run the command-line interface using docker image:
 ::
    $ docker run --rm -it --name mathics-cli -v /tmp:/usr/src/app/data mathicsorg/mathics --mode cli
 
+If you want to add options add them at then end preceded with `--`: for example:
+
+::
+   $ docker run --rm -it --name mathics-cli -v /tmp:/usr/src/app/data mathicsorg/mathics --mode cli -- --help
+
 To run the Django web interface using docker image:
 ::
    $ docker run --rm -it --name mathics-web -p 8000:8000 -v /tmp:/usr/src/app/data mathicsorg/mathics --mode ui
 
 
-This dockeriztion was modified from `sealemar/mathics-dockerized <https://github.com/sealemar/mathics-dockerized>`_. See that for more details on how this works.
+This dockerization was modified from `sealemar/mathics-dockerized <https://github.com/sealemar/mathics-dockerized>`_. See that for more details on how this works.
 
 Contributing
 ------------

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,18 @@ For an experiemental Jupyter-based consoles and web interfaces see `iwolfram <ht
 Docker
 ------
 
-Alternatively to the installation step above, ``mathics`` can be installed and run via `docker <https://www.docker.com/>`_. Please refer to `sealemar/mathics-dockerized <https://github.com/sealemar/mathics-dockerized>`_ repo for instructions.
+Another way to run ``mathics`` is via `docker <https://www.docker.com/>`_ and the `Mathics docker image <https://hub.docker.com/repository/docker/rockyb/mathics>`_ on dockerhub.
+
+To run the command-line interface using docker image:
+::
+   $ docker run --rm -it --name mathics-cli -v /tmp:/usr/src/app/data rockyb:mathics --mode cli
+
+To run the Django web interface using docker image:
+::
+   $docker run --rm -it --name mathics-web -p 8000:8000 -v /tmp:/usr/src/app/data rockyb/mathics --mode ui
+
+
+This dockeriztion was modified from `sealemar/mathics-dockerized <https://github.com/sealemar/mathics-dockerized>`_. See that for more details on how this works.
 
 Contributing
 ------------

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,31 @@
+FROM python:3.7-buster
+
+ENV MATHICS_HOME=/usr/src/app
+ENV ENTRYPOINT_COMMAND="docker run -it {MATHICS_IMAGE}"
+
+WORKDIR $MATHICS_HOME
+
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+
+COPY requirements.txt ./
+RUN apt-get update
+RUN apt-get install -qq liblapack-dev llvm-dev gfortran
+RUN pip install --no-cache-dir -r requirements.txt
+RUN cd pymathics && pip install
+RUN python -m nltk.downloader wordnet omw
+COPY requirements-tmathics.txt ./
+RUN pip install --no-cache-dir -r requirements-tmathics.txt
+
+EXPOSE 8000
+
+RUN groupadd mathics && \
+    useradd -d $MATHICS_HOME -g mathics -m -s /bin/bash mathics && \
+    mkdir -p $MATHICS_HOME/data && \
+    chown -R mathics:mathics $MATHICS_HOME
+
+USER mathics
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["--help"]

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -12,8 +12,7 @@ COPY requirements.txt ./
 RUN apt-get update
 RUN apt-get install -qq liblapack-dev llvm-dev gfortran
 RUN pip install --no-cache-dir -r requirements.txt
-RUN cd pymathics && pip install
-RUN python -m nltk.downloader wordnet omw
+# RUN python -m nltk.downloader wordnet omw
 COPY requirements-tmathics.txt ./
 RUN pip install --no-cache-dir -r requirements-tmathics.txt
 

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+script_cmd="${ENTRYPOINT_COMMAND:-$(basename $0)}"
+
+function help() {
+    cat <<EOF
+
+Usage:
+    $script_cmd [arg] [-- params, ...]
+
+Arg:
+
+    -h | --help               Print this help and exit
+
+    --pythonpath              This will be added to PYTHONPATH. Example use-case - absolute path to
+                              basedir of mathics source code inside container, ie:
+                                 mathics src = /usr/src/app/mathics
+                                 --pythonpaht /usr/src/app
+
+    -m | --mode {cli|ui}      Start mathics in web-ui mode (ui), or in cli mode (cli). Default is cli.
+                              See: https://github.com/mathics/Mathics/wiki/Installing#running-mathics
+
+Params:
+
+    Everything passed after '--' will be passed to mathics as is.
+
+EOF
+}
+
+mathics_mode=cli
+
+while (( $# )) ; do
+    case "$1" in
+        -h | --help)  help ; exit ;;
+        -m | --mode)  mathics_mode="$2" ; shift 2 ;;
+        --pythonpath) export PYTHONPATH="$2":$PYTHONPATH ; shift 2 ;;
+        --)           shift ; break ;;
+        *)            echo "Can't parse '$@'. See '$0 --help'" ; exit 1 ;;
+    esac
+done
+
+echo
+echo "~~~~ app/data has been mounted to $MATHICS_HOME/data ~~~~"
+echo "$ ls $MATHICS_HOME/data"
+ls -p $MATHICS_HOME/data
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+echo
+
+case $mathics_mode in
+    cli) tmathics $@ ;;
+    ui)  mathicsserver -e $@ ;;
+    *)   echo "unknown mathics_mode=$mathics_mode. See '$script_cmd --help'" ; exit 2 ;;
+esac

--- a/app/requirements-tmathics.txt
+++ b/app/requirements-tmathics.txt
@@ -1,0 +1,4 @@
+mathics
+colorama
+pygments
+git+https://github.com/Mathics3/tmathics

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -22,4 +22,5 @@ pyenchant
 lxml
 matplotlib
 networkx
+# git+https://github.com/mathics/Mathics@6ec25fafd488d71e6576e2d94ad0071443a096d0
 git+https://github.com/mathics/Mathics

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,0 +1,25 @@
+sympy>=1.6, < 1.7
+django >= 1.8, < 1.12
+mpmath>=1.1.0
+numpy
+palettable
+pint
+pydot
+python-dateutil
+colorama
+llvmlite
+requests
+cython
+scikit-image
+ipywidgets
+ipykernel
+requests
+IPython==5.0.0
+nltk
+langid
+pycountry
+pyenchant
+lxml
+matplotlib
+networkx
+git+https://github.com/mathics/Mathics

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '2'
+
+services:
+    mathics:
+        build: ./app
+        image: mathicsorg/mathics:latest
+
+        volumes:
+            - ./app/data:/usr/src/app/data
+
+        ports:
+            - "8000:8000"

--- a/mathics/settings.py
+++ b/mathics/settings.py
@@ -113,7 +113,9 @@ MIDDLEWARE_CLASSES = (
 
 ROOT_URLCONF = 'mathics.urls'
 
-default_pymathics_modules = ["pymathics.natlang",]
+# Rocky: this is probably a hack. LoadModule[] needs to handle
+# whatever it is that setting this thing did.
+default_pymathics_modules = []
 
 TEMPLATES = [
     {


### PR DESCRIPTION
https://hub.docker.com/repository/docker/rockyb/mathics has a more recent docker contrainer for 1.1-dev.

The natlang module isn't built, but I don't think right now that's important. Never let perfection get in the way of progress.

Issue #927 has been created to track remaining steps.

@suhr @GarkGarcia @mmatera  If you have docker and get a chance, I'd appreciate it if you could try out the instructions to verify this works. 

