### PR TITLE
Fix bug in the Cross implementation

### DIFF
--- a/mathics/builtin/linalg.py
+++ b/mathics/builtin/linalg.py
@@ -136,12 +136,14 @@ class Cross(Builtin):
                   'their length.'),
     }
 
-    # TODO Vectors of length other than 3
-
     def apply(self, a, b, evaluation):
         'Cross[a_, b_]'
         a = to_sympy_matrix(a)
         b = to_sympy_matrix(b)
+
+        if a is None or b is None:
+            return evaluation.message('Cross', 'nonn1')
+
         try:
             res = a.cross(b)
         except sympy.ShapeError:


### PR DESCRIPTION
Here's the stack-trace for the bug in question:

```
Traceback (most recent call last):
  File "/home/pablo/.local/bin/mathics", line 361, in <module>
    main()
  File "/home/pablo/.local/bin/mathics", line 344, in main
    result = evaluation.evaluate(query, timeout=settings.TIMEOUT)
  File "/home/pablo/Documents/Mathics/mathics/core/evaluation.py", line 286, in evaluate
    result = run_with_timeout_and_stack(evaluate, timeout)
  File "/home/pablo/Documents/Mathics/mathics/core/evaluation.py", line 95, in run_with_timeout_and_stack
    return request()
  File "/home/pablo/Documents/Mathics/mathics/core/evaluation.py", line 264, in evaluate
    result = query.evaluate(self)
  File "/home/pablo/Documents/Mathics/mathics/core/expression.py", line 863, in evaluate
    expr, reevaluate = expr.evaluate_next(evaluation)
  File "/home/pablo/Documents/Mathics/mathics/core/expression.py", line 985, in evaluate_next
    result = rule.apply(new, evaluation, fully=False)
  File "/home/pablo/Documents/Mathics/mathics/core/rules.py", line 62, in apply
    yield_match, expression, {}, evaluation, fully=fully)
  File "/home/pablo/Documents/Mathics/mathics/core/pattern.py", line 206, in match
    yield_head, expression.get_head(), vars, evaluation)
  File "/home/pablo/Documents/Mathics/mathics/core/pattern.py", line 135, in match
    yield_func(vars, None)
  File "/home/pablo/Documents/Mathics/mathics/core/pattern.py", line 198, in yield_head
    yield_choice, expression, attributes, head_vars)
  File "/home/pablo/Documents/Mathics/mathics/core/pattern.py", line 321, in get_pre_choices
    yield_func(vars)
  File "/home/pablo/Documents/Mathics/mathics/core/pattern.py", line 187, in yield_choice
    wrap_oneid=expression.get_head_name() != 'System`MakeBoxes')
  File "/home/pablo/Documents/Mathics/mathics/core/pattern.py", line 482, in match_leaf
    include_flattened=include_flattened)
  File "/home/pablo/Documents/Mathics/mathics/core/pattern.py", line 342, in get_wrappings
    yield_func(items[0])
  File "/home/pablo/Documents/Mathics/mathics/core/pattern.py", line 478, in yield_wrapping
    leaf_count=leaf_count, wrap_oneid=wrap_oneid)
  File "/home/pablo/Documents/Mathics/mathics/builtin/patterns.py", line 767, in match
    self.pattern.match(yield_func, expression, new_vars, evaluation)
  File "/home/pablo/Documents/Mathics/mathics/builtin/patterns.py", line 952, in match
    yield_func(vars, None)
  File "/home/pablo/Documents/Mathics/mathics/core/pattern.py", line 470, in match_yield
    leaf_count=leaf_count, wrap_oneid=wrap_oneid)
  File "/home/pablo/Documents/Mathics/mathics/core/pattern.py", line 482, in match_leaf
    include_flattened=include_flattened)
  File "/home/pablo/Documents/Mathics/mathics/core/pattern.py", line 342, in get_wrappings
    yield_func(items[0])
  File "/home/pablo/Documents/Mathics/mathics/core/pattern.py", line 478, in yield_wrapping
    leaf_count=leaf_count, wrap_oneid=wrap_oneid)
  File "/home/pablo/Documents/Mathics/mathics/builtin/patterns.py", line 767, in match
    self.pattern.match(yield_func, expression, new_vars, evaluation)
  File "/home/pablo/Documents/Mathics/mathics/builtin/patterns.py", line 952, in match
    yield_func(vars, None)
  File "/home/pablo/Documents/Mathics/mathics/core/pattern.py", line 473, in match_yield
    yield_func(new_vars, items_rest)
  File "/home/pablo/Documents/Mathics/mathics/core/pattern.py", line 462, in leaf_yield
    (rest_expression[0] + items_rest[0], next_rest[1]))
  File "/home/pablo/Documents/Mathics/mathics/core/rules.py", line 38, in yield_match
    new_expression = self.do_replace(expression, vars, options, evaluation)
  File "/home/pablo/Documents/Mathics/mathics/core/rules.py", line 128, in do_replace
    return self.function(evaluation=evaluation, **vars_noctx)
  File "/home/pablo/Documents/Mathics/mathics/builtin/linalg.py", line 146, in apply
    res = a.cross(b)
AttributeError: 'NoneType' object has no attribute 'cross'
```