### PR TITLE
Fix runtime bugs seen from GS3.m in per_expr()

### DIFF
--- a/mathics/core/pattern.py
+++ b/mathics/core/pattern.py
@@ -322,7 +322,7 @@ class ExpressionPattern(Pattern):
 
                         if expr_groups:
                             expr, count = expr_groups.popitem()
-                            max_per_pattern = count / len(patterns)
+                            max_per_pattern = count // len(patterns)
                             for per_pattern in range(max_per_pattern, -1, -1):
                                 for next in per_expr(   # nopep8
                                     expr_groups, sum + per_pattern):
@@ -330,9 +330,14 @@ class ExpressionPattern(Pattern):
                         else:
                             if sum >= match_count[0]:
                                 yield_expr([])
+                            # FIXME: Is this right?
+                            # For now we'll return basically no match.
+                            yield None
 
                     # for sequence in per_expr(expr_groups.items()):
                     def yield_expr(sequence):
+                        # FIXME: this call is wrong and needs a
+                        # wrapper_function as the 1st parameter.
                         wrappings = self.get_wrappings(
                             sequence, match_count[1], expression, attributes)
                         for wrapping in wrappings:

--- a/mathics/core/pattern.py
+++ b/mathics/core/pattern.py
@@ -330,8 +330,7 @@ class ExpressionPattern(Pattern):
                         else:
                             if sum >= match_count[0]:
                                 yield_expr([])
-                            # FIXME: Is this right?
-                            # For now we'll return basically no match.
+                            # Until we learn that the below is incorrect, we'll return basically no match.
                             yield None
 
                     # for sequence in per_expr(expr_groups.items()):


### PR DESCRIPTION
per_expr() needs to return a in interator return, not the default implied
`return None` as can happen.

In Python 3, // is used for truncated integer division. In Python 2 it
was /. That now returns float in Python 3.

Note the brokenness of self.get_wrappings

To reproduce brokenness before build, in `mathics` run:
```
   <<"https://raw.githubusercontent.com/rebcabin/Mathics/master/mathics/packages/GS3.m"
```