### PR TITLE
Review docs system; no trailing blanks required

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ RM  ?= rm
 #: Default target - same as "develop"
 all: develop
 
-#: build everything needed to install; (runs Cython)
+#: build everything needed to install
 build:
 	$(PYTHON) ./setup.py build
 
@@ -26,6 +26,10 @@ develop:
 install:
 	$(PYTHON) setup.py install
 
+#: Run Django-based server in development mode. Use environment variable "o" for manage options
+runserver:
+	$(PYTHON) mathics/manage.py runserver $o
+
 check: pytest doctest djangotest
 
 #: Remove derived files
@@ -35,7 +39,7 @@ clean:
 	   ($(MAKE) -C "$$dir" clean); \
 	done;
 
-#: Run py.test tests. You can set environment variable "o" for pytest options
+#: Run py.test tests. Use environment variable "o" for pytest options
 pytest:
 	py.test test $o
 
@@ -48,7 +52,7 @@ doc-data mathics/doc/tex/data: mathics/builtin/*.py mathics/doc/documentation/*.
 doctest:
 	$(PYTHON) mathics/test.py $(output)
 
-#: Run django tests
+#: Run Django tests
 djangotest:
 	cd mathics && $(PYTHON) manage.py test test_django
 

--- a/mathics/__init__.py
+++ b/mathics/__init__.py
@@ -51,6 +51,7 @@ server_version_string = version_string + ", django {django}".format(**version_in
 
 if "cython" in version_info:
     server_version_string += f", cython {version_info['cython']}"
+    version_string += f", cython {version_info['cython']}"
 
 license_string = """\
 Copyright (C) 2011-2020 The Mathics Team.

--- a/mathics/builtin/assignment.py
+++ b/mathics/builtin/assignment.py
@@ -839,15 +839,11 @@ class Information(PrefixOperator):
     >> f[x_] := x ^ 2
     >> g[f] ^:= 2
     >> f::usage = "f[x] returns the square of x";
-    >> Information[f]
+    X> Information[f]
      = f[x] returns the square of x
-     .
-     . f[x_] = x ^ 2
-     .
-     . g[f] ^= 2
 
     >> ? Table
-     =
+     = 
      .   'Table[expr, {i, n}]'
      .     evaluates expr with i ranging from 1 to n, returning
      . a list of the results.
@@ -860,7 +856,7 @@ class Information(PrefixOperator):
      .
 
     >> Information[Table]
-     =
+     = 
      .   'Table[expr, {i, n}]'
      .     evaluates expr with i ranging from 1 to n, returning
      . a list of the results.

--- a/mathics/builtin/assignment.py
+++ b/mathics/builtin/assignment.py
@@ -847,7 +847,7 @@ class Information(PrefixOperator):
      . g[f] ^= 2
 
     >> ? Table
-     = 
+     =
      .   'Table[expr, {i, n}]'
      .     evaluates expr with i ranging from 1 to n, returning
      . a list of the results.
@@ -860,7 +860,7 @@ class Information(PrefixOperator):
      .
 
     >> Information[Table]
-     = 
+     =
      .   'Table[expr, {i, n}]'
      .     evaluates expr with i ranging from 1 to n, returning
      . a list of the results.
@@ -1657,9 +1657,9 @@ class Decrement(PostfixOperator):
     </dl>
 
     >> a = 5;
-    >> a--
+    X> a--
      = 5
-    >> a
+    X> a
      = 4
     """
 

--- a/mathics/builtin/datentime.py
+++ b/mathics/builtin/datentime.py
@@ -560,7 +560,7 @@ class TimeZone(Predefined):
     """
     <dl>
     <dt>'$TimeZone'
-      <dd> gives the current time zone to asseme for dates and times.
+      <dd> gives the current time zone to assume for dates and times.
     </dl>
 
     >> $TimeZone

--- a/mathics/builtin/datentime.py
+++ b/mathics/builtin/datentime.py
@@ -541,7 +541,7 @@ class AbsoluteTime(_DateFormat):
 class SystemTimeZone(Predefined):
     """
     <dl>
-    <dt>'$SystemTimeZone'
+      <dt>'$SystemTimeZone'
       <dd> gives the current time zone for the computer system on which Mathics is being run.
     </dl>
 
@@ -560,7 +560,7 @@ class TimeZone(Predefined):
     """
     <dl>
     <dt>'$TimeZone'
-      <dd> gives the current time zone.
+      <dd> gives the current time zone to asseme for dates and times.
     </dl>
 
     >> $TimeZone

--- a/mathics/builtin/evaluation.py
+++ b/mathics/builtin/evaluation.py
@@ -83,20 +83,23 @@ class RecursionLimit(Predefined):
 class IterationLimit(Predefined):
     """
     <dl>
-    <dt>'$IterationLimit'
-        <dd>specifies the maximum number of times a reevaluation may happen.
+        <dt>'$IterationLimit'
+
+        <dd>specifies the maximum number of times a reevaluation of an expression may happen.
+
     </dl>
 
     Calculations terminated by '$IterationLimit' return '$Aborted':
-    >> ClearAll[f]; f[x_] := f[x + 1];
-    >> f[x]
+
+    > $IterationLimit
+     = 1000
+    #> ClearAll[f]; f[x_] := f[x + 1];
+    #> f[x]
      : Iteration limit of 1000 exceeded.
      = $Aborted
-    >> $IterationLimit
-     = 1000
-    >> ClearAll[f];
+    #> ClearAll[f];
 
-    >> $IterationLimit = x;
+    #> $IterationLimit = x;
      : Cannot set $IterationLimit to x; value must be an integer between 20 and Infinity.
 
     #> ClearAll[f];

--- a/mathics/builtin/files.py
+++ b/mathics/builtin/files.py
@@ -4001,9 +4001,9 @@ class CopyFile(Builtin):
       <dd>copies $file1$ to $file2$.
     </dl>
 
-    >> CopyFile["ExampleData/sunflowers.jpg", "MathicsSunflowers.jpg"]
+    X> CopyFile["ExampleData/sunflowers.jpg", "MathicsSunflowers.jpg"]
      = MathicsSunflowers.jpg
-    >> DeleteFile["MathicsSunflowers.jpg"]
+    X> DeleteFile["MathicsSunflowers.jpg"]
     """
 
     messages = {

--- a/mathics/builtin/files.py
+++ b/mathics/builtin/files.py
@@ -20,7 +20,7 @@ import sympy
 import requests
 import tempfile
 
- 
+
 from itertools import chain
 
 
@@ -289,7 +289,7 @@ class Input(Predefined):
     </dl>
 
     >> $Input
-     = 
+     = #<--#
     """
 
     attributes = ('Protected', 'ReadProtected')
@@ -309,7 +309,7 @@ class InputFileName(Predefined):
 
     While in interactive mode, '$InputFileName' is "".
     >> $InputFileName
-     = 
+     = #<--#
     """
 
     name = '$InputFileName'
@@ -2085,25 +2085,25 @@ class OpenAppend(_OpenAction):
 class Get(PrefixOperator):
     r"""
     <dl>
-    <dt>'<<name'
+    <dt>'<<$name$'
       <dd>reads a file and evaluates each expression, returning only the last one.
     </dl>
 
-    >> Put[x + y, "example_file"]
-    >> <<"example_file"
+    S> Put[x + y, "tmp/example_file"]
+    S> <<"tmp/example_file"
      = x + y
 
-    >> Put[x + y, 2x^2 + 4z!, Cos[x] + I Sin[x], "example_file"]
-    >> <<"example_file"
+    S> Put[x + y, 2x^2 + 4z!, Cos[x] + I Sin[x], "tmp/example_file"]
+    S> <<"tmp/example_file"
      = Cos[x] + I Sin[x]
-    #> DeleteFile["example_file"]
+    #> DeleteFile["tmp/example_file"]
 
-    >> 40! >> "fourtyfactorial"
-    >> FilePrint["fourtyfactorial"]
+    S> 40! >> "tmp/fortyfactorial"
+    S> FilePrint["tmp/fortyfactorial"]
      | 815915283247897734345611269596115894272000000000
-    >> <<"fourtyfactorial"
+    S> <<"tmp/fortyfactorial"
      = 815915283247897734345611269596115894272000000000
-    #> DeleteFile["fourtyfactorial"]
+    #> DeleteFile["tmp/fortyfactorial"]
 
     ## TODO: Requires EndPackage implemented
     ## 'Get' can also load packages:
@@ -2163,57 +2163,62 @@ class Put(BinaryOperator):
     <dl>
     <dt>'$expr$ >> $filename$'
       <dd>write $expr$ to a file.
-    <dt>'Put[$expr1$, $expr2$, ..., $"filename"$]'
+    <dt>'Put[$expr1$, $expr2$, ..., $filename$]'
       <dd>write a sequence of expressions to a file.
     </dl>
 
-    >> 40! >> "fourtyfactorial"
-    >> FilePrint["fourtyfactorial"]
-     | 815915283247897734345611269596115894272000000000
-    #> 40! >> fourtyfactorial
-    #> FilePrint["fourtyfactorial"]
+    ## Note a lot of these tests are:
+    ## * a bit fragile, somewhat
+    ## * somewhat OS dependent,
+    ## * can leave crap in the filesystem
+    ##
+    ## For these reasons this should be done a a pure test
+    ## rather than intermingled with the doc system.
+
+    S> 40! >> tmp/fortyfactorial
+    S> FilePrint["tmp/fortyfactorial"]
      | 815915283247897734345611269596115894272000000000
 
-    #> Put[40!, fourtyfactorial]
-     : fourtyfactorial is not string, InputStream[], or OutputStream[]
-     = 815915283247897734345611269596115894272000000000 >> fourtyfactorial
+    S> Put[40!, fortyfactorial]
+     : fortyfactorial is not string, InputStream[], or OutputStream[]
+     = 815915283247897734345611269596115894272000000000 >> fortyfactorial
     ## FIXME: final line should be
-    ## = Put[815915283247897734345611269596115894272000000000, fourtyfactorial]
-    #> DeleteFile["fourtyfactorial"]
+    ## = Put[815915283247897734345611269596115894272000000000, fortyfactorial]
+    #> DeleteFile["tmp/fortyfactorial"]
 
-    >> Put[50!, "fiftyfactorial"]
-    >> FilePrint["fiftyfactorial"]
+    S> Put[50!, "tmp/fiftyfactorial"]
+    S> FilePrint["tmp/fiftyfactorial"]
      | 30414093201713378043612608166064768844377641568960512000000000000
-    #> DeleteFile["fiftyfactorial"]
+    S> DeleteFile["tmp/fiftyfactorial"]
 
-    >> Put[10!, 20!, 30!, "factorials"]
-    >> FilePrint["factorials"]
+    S> Put[10!, 20!, 30!, "tmp/factorials"]
+    S> FilePrint["tmp/factorials"]
      | 3628800
      | 2432902008176640000
      | 265252859812191058636308480000000
 
-    #> DeleteFile["factorials"]
+    S> DeleteFile["tmp/factorials"]
      =
 
-    #> Put[x + y, 2x^2 + 4z!, Cos[x] + I Sin[x], "example_file"]
-    #> FilePrint["example_file"]
+    S> Put[x + y, 2x^2 + 4z!, Cos[x] + I Sin[x], "tmp/example_file"]
+    S> FilePrint["tmp/example_file"]
      | x + y
      | 2*x^2 + 4*z!
      | Cos[x] + I*Sin[x]
-    #> DeleteFile["example_file"]
+    S> DeleteFile["tmp/example_file"]
 
     ## writing to dir
-    #> x >> /var/
+    S> x >> /var/
      : Cannot open /var/.
      = x >> /var/
 
     ## writing to read only file
-    #> x >> /proc/uptime
+    S> x >> /proc/uptime
      : Cannot open /proc/uptime.
      = x >> /proc/uptime
 
     ## writing to full file
-    #> x >> /dev/full
+    S> x >> /dev/full
      : No space left on device.
     """
 
@@ -2550,9 +2555,9 @@ class FileExtension(Builtin):
      = gz
 
     #> FileExtension["file."]
-     = 
+     = #<--#
     #> FileExtension["file"]
-     = 
+     = #<--#
     """
 
     attributes = ('Protected')
@@ -4558,7 +4563,7 @@ class FileType(Builtin):
     """
     <dl>
     <dt>'FileType["$file$"]'
-      <dd>returns the type of a file, from 'File', 'Directory' or 'None'.
+      <dd>gives the type of a file, a string. This is typically 'File', 'Directory' or 'None'.
     </dl>
 
     >> FileType["ExampleData/sunflowers.jpg"]

--- a/mathics/builtin/functional.py
+++ b/mathics/builtin/functional.py
@@ -204,7 +204,7 @@ class Identity(Builtin):
     </dl>
     >> Identity[x]
      = x
-    >> Identity[x, y]
+    X> Identity[x, y]
      = Identity[x, y]
     """
 

--- a/mathics/builtin/functional.py
+++ b/mathics/builtin/functional.py
@@ -22,11 +22,11 @@ class Function(PostfixOperator):
     </dl>
 
     >> f := # ^ 2 &
-    >> f[3]
+    X> f[3]
      = 9
-    >> #^3& /@ {1, 2, 3}
+    X> #^3& /@ {1, 2, 3}
      = {1, 8, 27}
-    >> #1+#2&[4, 5]
+    X> #1+#2&[4, 5]
      = 9
 
     You can use 'Function' with named parameters:
@@ -93,13 +93,13 @@ class Slot(Builtin):
     <dl>
     <dt>'#$n$'
         <dd>represents the $n$th argument to a pure function.
-    <dt>'#'
+        <dt>'#'
         <dd>is short-hand for '#1'.
-    <dt>'#0'
+        <dt>'#0'
         <dd>represents the pure function itself.
     </dl>
 
-    >> #
+    X> #
      = #1
 
     Unused arguments are simply ignored:
@@ -199,10 +199,10 @@ class Composition(Builtin):
 class Identity(Builtin):
     """
     <dl>
-    <dt>'Identity[$x$]'
-        <dd>is the identity function, which returns $x$ unchanged.
+      <dt>'Identity[$x$]'
+      <dd>is the identity function, which returns $x$ unchanged.
     </dl>
-    >> Identity[x]
+    X> Identity[x]
      = x
     X> Identity[x, y]
      = Identity[x, y]

--- a/mathics/builtin/plot.py
+++ b/mathics/builtin/plot.py
@@ -1056,8 +1056,8 @@ class PieChart(_Chart):
 class BarChart(_Chart):
     """
     <dl>
-    <dt>'BarChart[{$p1$, $p2$ ...}]'
-        <dd>draws a bar chart.
+        <dt>'BarChart[{$p1$, $p2$ ...}]'
+        <dd>makes a bar chart with lengths $b1$, $b2$, ....
     </dl>
 
     >> BarChart[{1, 4, 2}]
@@ -1175,8 +1175,8 @@ class BarChart(_Chart):
 class Histogram(Builtin):
     """
     <dl>
-    <dt>'Histogram[{$x1$, $x2$ ...}]'
-        <dd>gives a histogram using the values $x1$, $x2$, ....
+        <dt>'Histogram[{$x1$, $x2$ ...}]'
+        <dd>plots a histogram using the values $x1$, $x2$, ....
     </dl>
 
     >> Histogram[{3, 8, 10, 100, 1000, 500, 300, 200, 10, 20, 200, 100, 200, 300, 500}]

--- a/mathics/builtin/scoping.py
+++ b/mathics/builtin/scoping.py
@@ -414,7 +414,7 @@ class Contexts(Builtin):
     ## this assignment makes sure that a definition in Global` exists
     >> x = 5;
     >> Contexts[] // InputForm
-     = {"Combinatorica`", "Global`", "ImportExport`", "Internal`", "System`", "System`Convert`B64Dump`", "System`Convert`Image`", "System`Convert`JSONDump`", "System`Convert`TableDump`", "System`Convert`TextDump`", "System`Private`", "XML`", "XML`Parser`"}
+     = {"CombinatoricaOld`", "Global`", "ImportExport`", "Internal`", "System`", "System`Convert`B64Dump`", "System`Convert`Image`", "System`Convert`JSONDump`", "System`Convert`TableDump`", "System`Convert`TextDump`", "System`Private`", "XML`", "XML`Parser`"}
     """
 
     def apply(self, evaluation):

--- a/mathics/builtin/structure.py
+++ b/mathics/builtin/structure.py
@@ -179,44 +179,44 @@ class SortBy(Builtin):
 class BinarySearch(Builtin):
     """
     <dl>
-    <dt>'Combinatorica`BinarySearch[$l$, $k$]'
+    <dt>'CombinatoricaOld`BinarySearch[$l$, $k$]'
         <dd>searches the list $l$, which has to be sorted, for key $k$ and returns its index in $l$. If $k$ does not
         exist in $l$, 'BinarySearch' returns (a + b) / 2, where a and b are the indices between which $k$ would have
         to be inserted in order to maintain the sorting order in $l$. Please note that $k$ and the elements in $l$
         need to be comparable under a strict total order (see https://en.wikipedia.org/wiki/Total_order).
 
-    <dt>'Combinatorica`BinarySearch[$l$, $k$, $f$]'
+    <dt>'CombinatoricaOld`BinarySearch[$l$, $k$, $f$]'
         <dd>the index of $k in the elements of $l$ if $f$ is applied to the latter prior to comparison. Note that $f$
         needs to yield a sorted sequence if applied to the elements of $l.
     </dl>
 
-    >> Combinatorica`BinarySearch[{3, 4, 10, 100, 123}, 100]
+    >> CombinatoricaOld`BinarySearch[{3, 4, 10, 100, 123}, 100]
      = 4
 
-    >> Combinatorica`BinarySearch[{2, 3, 9}, 7] // N
+    >> CombinatoricaOld`BinarySearch[{2, 3, 9}, 7] // N
      = 2.5
 
-    >> Combinatorica`BinarySearch[{2, 7, 9, 10}, 3] // N
+    >> CombinatoricaOld`BinarySearch[{2, 7, 9, 10}, 3] // N
      = 1.5
 
-    >> Combinatorica`BinarySearch[{-10, 5, 8, 10}, -100] // N
+    >> CombinatoricaOld`BinarySearch[{-10, 5, 8, 10}, -100] // N
      = 0.5
 
-    >> Combinatorica`BinarySearch[{-10, 5, 8, 10}, 20] // N
+    >> CombinatoricaOld`BinarySearch[{-10, 5, 8, 10}, 20] // N
      = 4.5
 
-    >> Combinatorica`BinarySearch[{{a, 1}, {b, 7}}, 7, #[[2]]&]
+    >> CombinatoricaOld`BinarySearch[{{a, 1}, {b, 7}}, 7, #[[2]]&]
      = 2
     """
 
-    context = "Combinatorica`"
+    context = "CombinatoricaOld`"
 
     rules = {
-        "Combinatorica`BinarySearch[l_List, k_] /; Length[l] > 0": "Combinatorica`BinarySearch[l, k, Identity]"
+        "CombinatoricaOld`BinarySearch[l_List, k_] /; Length[l] > 0": "CombinatoricaOld`BinarySearch[l, k, Identity]"
     }
 
     def apply(self, l, k, f, evaluation):
-        "Combinatorica`BinarySearch[l_List, k_, f_] /; Length[l] > 0"
+        "CombinatoricaOld`BinarySearch[l_List, k_, f_] /; Length[l] > 0"
 
         leaves = l.leaves
 
@@ -1061,7 +1061,8 @@ class Null(Predefined):
     >> a:=b
     in contrast to the empty string:
     >> ""
-     = 
+     =
+
     (watch the empty line).
     """
 

--- a/mathics/builtin/structure.py
+++ b/mathics/builtin/structure.py
@@ -1061,9 +1061,7 @@ class Null(Predefined):
     >> a:=b
     in contrast to the empty string:
     >> ""
-     =
-
-    (watch the empty line).
+     = #<--#
     """
 
 

--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -209,8 +209,8 @@ class ParentProcessID(Predefined):
       <dd>gives the ID assigned to the process which invokes the Mathics by the operating system under which it is run.
     </dl>
 
-    X> $ParentProcessID
-     = 1955
+    >> $ParentProcessID
+     = ...
 
     #> Head[$ParentProcessID] == Integer
      = True
@@ -228,8 +228,8 @@ class ProcessID(Predefined):
       <dd>gives the ID assigned to the Mathics process by the operating system under which it is run.
     </dl>
 
-    X> $ProcessID
-     = 1955
+    >> $ProcessID
+     = ...
 
     #> Head[$ProcessID] == Integer
      = True

--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -98,6 +98,34 @@ class Failed(Predefined):
     name = "$Failed"
 
 
+class GetEnvironment(Builtin):
+    """
+    <dl>
+    <dt>'GetEnvironment["var$]"'
+        <dd>gives the setting corresponding to the variable "var" in the operating system environment.
+    </dl>
+
+    X> = GetEnvironment["HOME"]
+    = ...
+    """
+
+    def apply(self, var, evaluation):
+        "GetEnvironment[var___]"
+        if isinstance(var, String):
+            env_var = var.get_string_value()
+            tup = (
+                env_var,
+                "System`None" if env_var not in os.environ else String(os.environ[env_var]),
+            )
+
+            return Expression("Rule", *tup)
+
+        env_vars = var.get_sequence()
+        if len(env_vars) == 0:
+            rules = [Expression("Rule", name, value) for name, value in os.environ.items()]
+            return Expression("List", *rules)
+
+
 class Machine(Predefined):
     """
     <dl>

--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -29,11 +29,14 @@ class Aborted(Predefined):
 class ByteOrdering(Predefined):
     """
     <dl>
-    <dt>'$ByteOrdering'
-        <dd>returns the native ordering of bytes in binary data on your computer system.
+      <dt>'$ByteOrdering'
+      <dd>returns the native ordering of bytes in binary data on your computer system.
     </dl>
 
-    >> $ByteOrdering == -1 || $ByteOrdering == 1
+    X> $ByteOrdering
+     = 1
+
+    #> $ByteOrdering == -1 || $ByteOrdering == 1
      = True
     """
 
@@ -62,15 +65,11 @@ class CommandLine(Predefined):
 class Environment(Builtin):
     """
     <dl>
-    <dt>'Environment[$var$]'
-        <dd>gives the value of an operating system environment variable.
+      <dt>'Environment[$var$]'
+      <dd>gives the value of an operating system environment variable.
     </dl>
-
-    Example:
-    <pre>
-    In[1] = Environment["HOME"]
-    Out[1] = /home/rocky
-    </pre>
+    X> Environment["HOME"]
+     = rocky
     """
 
     def apply(self, var, evaluation):
@@ -91,43 +90,12 @@ class Failed(Predefined):
         <dd>is returned by some functions in the event of an error.
     </dl>
 
-    >> Get["nonexistent_file.m"]
+    #> Get["nonexistent_file.m"]
      : Cannot open nonexistent_file.m.
      = $Failed
     """
 
     name = "$Failed"
-
-
-class GetEnvironment(Builtin):
-    """
-    <dl>
-    <dt>'GetEnvironment["var$]"'
-        <dd>gives the setting corresponding to the variable "var" in the operating system environment.
-    </dl>
-
-    Example:
-    <pre>
-    In[1] = GetEnvironment["HOME"]
-    Out[1] = HOME -> /home/rocky
-    </pre>
-    """
-
-    def apply(self, var, evaluation):
-        "GetEnvironment[var___]"
-        if isinstance(var, String):
-            env_var = var.get_string_value()
-            tup = (
-                env_var,
-                "System`None" if env_var not in os.environ else String(os.environ[env_var]),
-            )
-
-            return Expression("Rule", *tup)
-
-        env_vars = var.get_sequence()
-        if len(env_vars) == 0:
-            rules = [Expression("Rule", name, value) for name, value in os.environ.items()]
-            return Expression("List", *rules)
 
 
 class Machine(Predefined):
@@ -136,12 +104,8 @@ class Machine(Predefined):
     <dt>'$Machine'
         <dd>returns a string describing the type of computer system on which the Mathics is being run.
     </dl>
-
-    Example:
-    <pre>
-    In[1] = $Machine
-    Out[1] = linux
-    </pre>
+    X> $Machine
+     = linux
     """
 
     name = "$Machine"
@@ -153,15 +117,11 @@ class Machine(Predefined):
 class MachineName(Predefined):
     """
     <dl>
-    <dt>'$MachineName'
-        <dd>returns a string that gives the assigned name of the computer on which Mathics is being run, if such a name is defined.
+      <dt>'$MachineName'
+      <dd>is a string that gives the assigned name of the computer on which Mathics is being run, if such a name is defined.
     </dl>
-
-    Example:
-    <pre>
-    In[1] = $MachineName
-    Out[1] = buster
-    </pre>
+    X> $MachineName
+     = buster
     """
 
     name = "$MachineName"
@@ -220,11 +180,13 @@ class Names(Builtin):
 class Packages(Predefined):
     """
     <dl>
-    <dt>'$Packages'
-        <dd>returns a list of the contexts corresponding to all packages which have been loaded into Mathics.
+      <dt>'$Packages'
+      <dd>returns a list of the contexts corresponding to all packages which have been loaded into Mathics.
     </dl>
 
-    >>> MemberQ[$Packages, "System`"]
+    X> $Packages
+    = {CombinatoricaOld,ImportExport,Internal,System,XML}
+    #> MemberQ[$Packages, "System"]
     = True
     """
 
@@ -233,18 +195,24 @@ class Packages(Predefined):
     def evaluate(self, evaluation):
         return Expression(
             "List",
-            *(String(name) for name in evaluation.definitions.get_package_names()),
+            *(
+                String(name)
+                for name in evaluation.definitions.get_package_names()
+            ),
         )
 
 
 class ParentProcessID(Predefined):
     """
     <dl>
-    <dt>'$ParentProcesID'
-        <dd>gives the ID assigned to the process which invokes the Mathics by the operating system under which it is run.
+      <dt>'$ParentProcesID'
+      <dd>gives the ID assigned to the process which invokes the Mathics by the operating system under which it is run.
     </dl>
 
-    >>> Head[$ParentProcessID] == Integer
+    X> $ParentProcessID
+     = 1955
+
+    #> Head[$ParentProcessID] == Integer
      = True
     """
 
@@ -253,15 +221,17 @@ class ParentProcessID(Predefined):
     def evaluate(self, evaluation):
         return Integer(os.getppid())
 
-
 class ProcessID(Predefined):
     """
     <dl>
-    <dt>'$ProcessID'
-        <dd>gives the ID assigned to the Mathics process by the operating system under which it is run.
+      <dt>'$ProcessID'
+      <dd>gives the ID assigned to the Mathics process by the operating system under which it is run.
     </dl>
 
-    >>> Head[$ProcessID] == Integer
+    X> $ProcessID
+     = 1955
+
+    #> Head[$ProcessID] == Integer
      = True
     """
 
@@ -270,19 +240,14 @@ class ProcessID(Predefined):
     def evaluate(self, evaluation):
         return Integer(os.getpid())
 
-
 class ProcessorType(Predefined):
     """
     <dl>
     <dt>'$ProcessorType'
         <dd>gives a string giving the architecture of the processor on which the Mathics is being run.
     </dl>
-
-    Example:
-    <pre>
-    In[1] = $ProcessorType
-    Out[1] = x86_64
-    </pre>
+    X> $ProcessorType
+    = x86_64
     """
 
     name = "$ProcessorType"
@@ -316,15 +281,11 @@ class ScriptCommandLine(Predefined):
 class SystemID(Predefined):
     """
     <dl>
-    <dt>'$SystemID'
-        <dd>returns a short string that identifies the type of computer system on which the Mathics is being run.
+       <dt>'$SystemID'
+       <dd>is a short string that identifies the type of computer system on which the Mathics is being run.
     </dl>
-
-    Example:
-    <pre>
-    In[1] = $SystemID
-    Out[1] = linux
-    </pre>
+    X> $SystemID
+     = linux
     """
 
     name = "$SystemID"
@@ -336,17 +297,13 @@ class SystemID(Predefined):
 class SystemWordLength(Predefined):
     """
     <dl>
-    <dt>'$SystemWordLength'
-        <dd>gives the effective number of bits in raw machine words on the computer system where Mathics is running.
+      <dt>'$SystemWordLength'
+      <dd>gives the effective number of bits in raw machine words on the computer system where Mathics is running.
     </dl>
+    X> $SystemWordLength
+    = 64
 
-    Example:
-    <pre>
-    In[1] = $SystemWordLength
-    Out[1] = 64
-    </pre>
-
-    >> Head[$SystemWordLength] == Integer
+    #> Head[$SystemWordLength] == Integer
      = True
     """
 
@@ -365,8 +322,8 @@ class SystemWordLength(Predefined):
 class Version(Predefined):
     """
     <dl>
-    <dt>'$Version'
-        <dd>returns a string with the current Mathics version and the versions of relevant libraries.
+      <dt>'$Version'
+      <dd>returns a string with the current Mathics version and the versions of relevant libraries.
     </dl>
 
     >> $Version

--- a/mathics/doc/doc.py
+++ b/mathics/doc/doc.py
@@ -1160,6 +1160,10 @@ class DocTest(object):
 
         self.test = testcase[1].strip()
 
+        # This allows a trailing blank at the end of the line for those ofus use use editors that like
+        # to strip trailing blanks at the ends of lines.
+        self.test = self.test.rstrip("#<--#")
+
         self.key = None
         outs = testcase[2].splitlines()
         for line in outs:

--- a/mathics/doc/doc.py
+++ b/mathics/doc/doc.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import re
-from os import listdir, path
+from os import getenv, listdir, path
 import pickle
 import importlib
 
@@ -23,7 +23,7 @@ SUBSECTION_END_RE = re.compile('</subsection>')
 
 TESTCASE_RE = re.compile(r'''(?mx)^
     ((?:.|\n)*?)
-    ^\s*(>|\#)>[ ](.*)
+    ^\s*([>#SX])>[ ](.*)
     ((?:\n\s*(?:[:|=.][ ]|\.).*)*)
 ''')
 TESTCASE_OUT_RE = re.compile(r'^\s*([:|=])(.*)$')
@@ -1026,8 +1026,7 @@ class Doc(object):
                 test = DocTest(index, testcase)
                 if tests is None:
                     tests = DocTests()
-                if not test.ignore:
-                    tests.tests.append(test)
+                tests.tests.append(test)
             if tests is not None:
                 self.items.append(tests)
                 tests = None
@@ -1131,14 +1130,16 @@ class DocTest(object):
     """
     DocTest formatting rules:
 
+    * `>>` Marks test case; it will also appear as part of
+           the documentation.
     * `#>` Marks test private or one that does not appear as part of
-           the documentation
-    * `X>` Shows the example in the docs, but disables testing the example
+           the documentation.
+    * `X>` Shows the example in the docs, but disables testing the example.
     * `S>` Shows the example in the docs, but disables testing if environment
-           variable SANDBOX is set
-    * `=`  Compares the result text
-    * `:`  Compares an (error) message
-      `|`  Prints output
+           variable SANDBOX is set.
+    * `=`  Compares the result text.
+    * `:`  Compares an (error) message.
+      `|`  Prints output.
     """
     def __init__(self, index, testcase):
         self.index = index
@@ -1150,7 +1151,7 @@ class DocTest(object):
 
         # Ignored test cases are NOT executed, but shown as part of the docs
         # Sandboxed test cases are NOT executed if environtment SANDBOX is set
-        if testcase[0] == 'X' or (testcase[0] == 'S' and os.getenv("SANDBOX", False)):
+        if testcase[0] == 'X' or (testcase[0] == 'S' and getenv("SANDBOX", False)):
             self.ignore = True
             # substitute '>' again so we get the correct formatting
             testcase[0] = '>'

--- a/mathics/test.py
+++ b/mathics/test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+
 import sys
 import re
 import pickle
@@ -264,46 +265,23 @@ def test_all(
         for part, chapter, section in sorted(failed_symbols):
             print("  - %s in %s / %s" % (section, part, chapter))
 
-    if failed == 0:
-def make_doc(quiet=False):
-    """
-    Write XML and TeX doc examples.
-    """
-    if not quiet:
-        print("Extracting doc %s" % version_string)
-
-    try:
-        output_xml = {}
-        output_tex = {}
-        for tests in documentation.get_tests():
-            create_output(tests, output_xml, output_tex)
-        builtin_count = len(builtins)
-    except KeyboardInterrupt:
-        print("\nAborted.\n")
-        return
-
-    print('Save XML')
-    with open_ensure_dir(settings.DOC_XML_DATA, 'wb') as output_file:
-        pickle.dump(output_xml, output_file, 0)
-        print('\nOK')
-
     if generate_output and (failed == 0 or doc_even_if_error):
         print("Save XML")
         with open_ensure_dir(settings.DOC_XML_DATA, "wb") as output_file:
             pickle.dump(output_xml, output_file, 0)
 
-        print("Save TEX")
+        print("Save TeX")
         with open_ensure_dir(settings.DOC_TEX_DATA, "wb") as output_file:
             pickle.dump(output_tex, output_file, 0)
         return True
         return False
-    else:
-        print('\nFAILED')
-        return sys.exit(1)      # Travis-CI knows the tests have failed
 
-    print('Save TeX')
-    with open_ensure_dir(settings.DOC_TEX_DATA, 'wb') as output_file:
-        pickle.dump(output_tex, output_file, 0)
+    if failed == 0:
+        print("\nOK")
+    else:
+        print("\nFAILED")
+        return sys.exit(1)  # Travis-CI knows the tests have failed
+
 
 def make_doc(quiet=False):
     """
@@ -322,13 +300,14 @@ def make_doc(quiet=False):
         print("\nAborted.\n")
         return
 
-    print('Save XML')
-    with open_ensure_dir(settings.DOC_XML_DATA, 'wb') as output_file:
+    print("Save XML")
+    with open_ensure_dir(settings.DOC_XML_DATA, "wb") as output_file:
         pickle.dump(output_xml, output_file, 0)
 
-    print('Save TEX')
-    with open_ensure_dir(settings.DOC_TEX_DATA, 'wb') as output_file:
+    print("Save TeX")
+    with open_ensure_dir(settings.DOC_TEX_DATA, "wb") as output_file:
         pickle.dump(output_tex, output_file, 0)
+
 
 def write_latex():
     print("Load data")
@@ -389,44 +368,14 @@ def main():
         help="generate TeX documentation file",
     )
     parser.add_argument(
-        "--version", "-v", action="version", version="%(prog)s " + mathics.__version__
-    )
-    parser.add_argument(
-        "--section", "-s", dest="section", metavar="SECTION", help="only test SECTION"
-    )
-    parser.add_argument(
-        "--pymathics",
-        "-l",
-        dest="pymathics",
-        action="store_true",
-        help="also checks pymathics modules.",
-    )
-
-    parser.add_argument(
-        "--output",
-        "-o",
-        dest="output",
-        action="store_true",
-        help="generate TeX and XML output data",
-    )
-    parser.add_argument(
-        "--doc-only",
-        dest="doc_only",
-        action="store_true",
-        help="generate TeX and XML output data without running tests",
-    )
-    parser.add_argument(
-        "--tex",
-        "-t",
-        dest="tex",
-        action="store_true",
-        help="generate TeX documentation file",
-    )
-    parser.add_argument(
         "--quiet", "-q", dest="quiet", action="store_true", help="hide passed tests"
     )
     parser.add_argument(
-        "--keep-going", "-k", dest="keep_going", action="store_true", help="create documentation even if there is a test failure"
+        "--keep-going",
+        "-k",
+        dest="keep_going",
+        action="store_true",
+        help="create documentation even if there is a test failure",
     )
     parser.add_argument(
         "--stop-on-failure", action="store_true", help="stop on failure"
@@ -476,10 +425,11 @@ def main():
                 doc_even_if_error=args.keep_going,
             )
             end_time = datetime.now()
-            print("Tests took ", end_time-start_time)
+            print("Tests took ", end_time - start_time)
     # If TeX output requested, try to build it:
     if args.tex:
         write_latex()
+
 
 if __name__ == "__main__":
     main()

--- a/mathics/test.py
+++ b/mathics/test.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-
 import sys
 import re
 import pickle
@@ -14,12 +13,11 @@ from mathics.core.definitions import Definitions
 from mathics.core.evaluation import Evaluation, Output
 from mathics.core.parser import SingleLineFeeder
 from mathics.builtin import builtins
-
+from mathics.doc import documentation
 from mathics import version_string
 from mathics import settings
 
-
-MAX_TESTS = 100000  # Number than the total number of tests
+definitions = Definitions(add_builtin=True)
 
 
 class TestOutput(Output):
@@ -27,11 +25,7 @@ class TestOutput(Output):
         return None
 
 
-sep = "-" * 70 + "\n"
-
-# Global variables
-definitions = None
-documentation = None
+sep = '-' * 70 + '\n'
 
 
 def compare(result, wanted):
@@ -47,33 +41,26 @@ def compare(result, wanted):
         return False
     for r, w in zip(result, wanted):
         wanted_re = re.escape(w.strip())
-        wanted_re = wanted_re.replace("\\.\\.\\.", ".*?")
-        wanted_re = "^%s$" % wanted_re
+        wanted_re = wanted_re.replace('\\.\\.\\.', '.*?')
+        wanted_re = '^%s$' % wanted_re
         if not re.match(wanted_re, r.strip()):
             return False
     return True
 
 
-stars = "*" * 10
-
-
-def test_case(test, tests, index=0, subindex=0, quiet=False, section=None):
+def test_case(test, tests, index=0, quiet=False):
     test, wanted_out, wanted = test.test, test.outs, test.result
+    part, chapter, section = tests.part, tests.chapter, tests.section
 
     def fail(why):
-        part, chapter, section = tests.part, tests.chapter, tests.section
-        print(
-            "%sTest failed: %s in %s / %s\n%s\n%s\n"
-            % (sep, section, part, chapter, test, why)
-        )
+        print("%sTest failed: %s in %s / %s\n%s\n%s\n" % (
+            sep, section, part, chapter, test, why))
         return False
 
     if not quiet:
-        if section:
-            print("%s %s / %s %s" % (stars, tests.chapter, section, stars))
-        print("%4d (%2d): TEST %s" % (index, subindex, test))
+        print('%4d. TEST %s' % (index, test))
 
-    feeder = SingleLineFeeder(test, "<test>")
+    feeder = SingleLineFeeder(test, '<test>')
     evaluation = Evaluation(definitions, catch_interrupt=False, output=TestOutput())
     try:
         query = evaluation.parse_feeder(feeder)
@@ -95,7 +82,7 @@ def test_case(test, tests, index=0, subindex=0, quiet=False, section=None):
         fail_msg = "Result: %s\nWanted: %s" % (result, wanted)
         if out:
             fail_msg += "\nAdditional output:\n"
-            fail_msg += "\n".join(str(o) for o in out)
+            fail_msg += '\n'.join(str(o) for o in out)
         return fail(fail_msg)
     output_ok = True
     if len(out) != len(wanted_out):
@@ -106,71 +93,57 @@ def test_case(test, tests, index=0, subindex=0, quiet=False, section=None):
                 output_ok = False
                 break
     if not output_ok:
-        return fail(
-            "Output:\n%s\nWanted:\n%s"
-            % ("\n".join(str(o) for o in out), "\n".join(str(o) for o in wanted_out))
-        )
+        return fail("Output:\n%s\nWanted:\n%s" % (
+            '\n'.join(str(o) for o in out),
+            '\n'.join(str(o) for o in wanted_out)))
     return True
 
 
-def test_tests(
-    tests, index, quiet=False, stop_on_failure=False, start_at=0, max_tests=MAX_TESTS
-):
+def test_tests(tests, index, quiet=False, stop_on_failure=False, start_at=0):
     definitions.reset_user_definitions()
-    total = failed = skipped = 0
+    count = failed = skipped = 0
     failed_symbols = set()
-    section = tests.section
-    count = 0
-    for subindex, test in enumerate(tests.tests):
-        index += 1
+    for test in tests.tests:
         if test.ignore:
             continue
+        count += 1
+        index += 1
         if index < start_at:
             skipped += 1
             continue
-        elif count >= max_tests:
-            break
-
-        total += 1
-        count += 1
-        if not test_case(test, tests, index, subindex + 1, quiet, section):
+        if not test_case(test, tests, index, quiet):
             failed += 1
             failed_symbols.add((tests.part, tests.chapter, tests.section))
             if stop_on_failure:
                 break
-
-        section = None
-    return total, failed, skipped, failed_symbols, index
+    return count, failed, skipped, failed_symbols, index
 
 
 def create_output(tests, output_xml, output_tex):
-    for format, output in [("xml", output_xml), ("tex", output_tex)]:
+    for format, output in [('xml', output_xml), ('tex', output_tex)]:
         definitions.reset_user_definitions()
         for test in tests.tests:
             if test.private:
                 continue
             key = test.key
-            evaluation = Evaluation(
-                definitions, format=format, catch_interrupt=False, output=TestOutput()
-            )
+            evaluation = Evaluation(definitions, format=format, catch_interrupt=False, output=TestOutput())
             result = evaluation.parse_evaluate(test.test)
             if result is None:
                 result = []
             else:
                 result = [result.get_data()]
             output[key] = {
-                "query": test.test,
-                "results": result,
+                'query': test.test,
+                'results': result,
             }
 
 
 def test_section(section, quiet=False, stop_on_failure=False):
     failed = 0
     index = 0
-    print("Testing section %s" % section)
+    print('Testing section %s' % section)
     for tests in documentation.get_tests():
-        if tests.section == section or tests.section == "$" + section:
-            found = True
+        if tests.section == section or tests.section == '$' + section:
             for test in tests.tests:
                 if test.ignore:
                     continue
@@ -182,9 +155,9 @@ def test_section(section, quiet=False, stop_on_failure=False):
 
     print()
     if failed > 0:
-        print("%d test%s failed." % (failed, "s" if failed != 1 else ""))
+        print('%d test%s failed.' % (failed, 's' if failed != 1 else ''))
     else:
-        print("OK")
+        print('OK')
 
 
 def open_ensure_dir(f, *args, **kwargs):
@@ -211,77 +184,41 @@ def test_all(
     if not quiet:
         print("Testing %s" % version_string)
 
-    if generate_output:
-        if xmldatafolder is None:
-            xmldatafolder = settings.DOC_XML_DATA
-        if texdatafolder is None:
-            texdatafolder = settings.DOC_TEX_DATA
     try:
         index = 0
-        total = failed = skipped = 0
+        count = failed = skipped = 0
         failed_symbols = set()
         output_xml = {}
         output_tex = {}
         for tests in documentation.get_tests():
-            sub_total, sub_failed, sub_skipped, symbols, index = test_tests(
-                tests,
-                index,
-                quiet=quiet,
-                stop_on_failure=stop_on_failure,
-                start_at=start_at,
-                max_tests=count,
-            )
+            sub_count, sub_failed, sub_skipped, symbols, index = test_tests(
+                tests, index, quiet=quiet, stop_on_failure=stop_on_failure,
+                start_at=start_at)
             if generate_output:
                 create_output(tests, output_xml, output_tex)
-            total += sub_total
+            count += sub_count
             failed += sub_failed
             skipped += sub_skipped
             failed_symbols.update(symbols)
             if sub_failed and stop_on_failure:
                 break
-            if total >= count:
-                break
-        builtin_total = len(builtins)
+        builtin_count = len(builtins)
     except KeyboardInterrupt:
         print("\nAborted.\n")
         return
 
     if failed > 0:
         print(sep)
-    if count == MAX_TESTS:
-        print(
-            "%d Tests for %d built-in symbols, %d passed, %d failed, %d skipped."
-            % (total, builtin_total, total - failed - skipped, failed, skipped)
-        )
-    else:
-        print(
-            "%d Tests, %d passed, %d failed, %d skipped."
-            % (total, total - failed, failed, skipped)
-        )
+    print("%d Tests for %d built-in symbols, %d passed, %d failed, %d skipped." % (
+        count, builtin_count, count - failed - skipped, failed, skipped))
     if failed_symbols:
         if stop_on_failure:
             print("(not all tests are accounted for due to --stop-on-failure)")
         print("Failed:")
         for part, chapter, section in sorted(failed_symbols):
-            print("  - %s in %s / %s" % (section, part, chapter))
+            print('  - %s in %s / %s' % (section, part, chapter))
 
     if failed == 0:
-        print("\nOK")
-    else:
-        print("\nFAILED")
-        if not doc_even_if_error:
-            return sys.exit(1)  # So Travis-CI knows that the tests have failed
-
-    if generate_output and (failed == 0 or doc_even_if_error):
-        print("Save XML")
-        with open_ensure_dir(settings.DOC_XML_DATA, "wb") as output_file:
-            pickle.dump(output_xml, output_file, 0)
-
-        print("Save TeX")
-        with open_ensure_dir(settings.DOC_TEX_DATA, "wb") as output_file:
-            pickle.dump(output_tex, output_file, 0)
-    return failed == 0
-
 def make_doc(quiet=False):
     """
     Write XML and TeX doc examples.
@@ -302,35 +239,67 @@ def make_doc(quiet=False):
     print('Save XML')
     with open_ensure_dir(settings.DOC_XML_DATA, 'wb') as output_file:
         pickle.dump(output_xml, output_file, 0)
+        print('\nOK')
+
+        if generate_output:
+            print('Save XML')
+            with open_ensure_dir(settings.DOC_XML_DATA, 'wb') as output_file:
+                pickle.dump(output_xml, output_file, 0)
+
+            print('Save TEX')
+            with open_ensure_dir(settings.DOC_TEX_DATA, 'wb') as output_file:
+                pickle.dump(output_tex, output_file, 0)
+    else:
+        print('\nFAILED')
+        return sys.exit(1)      # Travis-CI knows the tests have failed
 
     print('Save TeX')
     with open_ensure_dir(settings.DOC_TEX_DATA, 'wb') as output_file:
         pickle.dump(output_tex, output_file, 0)
 
+def make_doc(quiet=False, generate_output=False, stop_on_failure=False,
+             start_at=0):
+    if not quiet:
+        print("Extracting doc %s" % version_string)
+
+    try:
+        index = 0
+        count = failed = skipped = 0
+        failed_symbols = set()
+        output_xml = {}
+        output_tex = {}
+        for tests in documentation.get_tests():
+            if generate_output:
+                create_output(tests, output_xml, output_tex)
+        builtin_count = len(builtins)
+    except KeyboardInterrupt:
+        print("\nAborted.\n")
+        return
+
+    print('Save XML')
+    with open_ensure_dir(settings.DOC_XML_DATA, 'wb') as output_file:
+        pickle.dump(output_xml, output_file, 0)
+
+    print('Save TEX')
+    with open_ensure_dir(settings.DOC_TEX_DATA, 'wb') as output_file:
+        pickle.dump(output_tex, output_file, 0)
+
 def write_latex():
     print("Load data")
-    with open_ensure_dir(settings.DOC_TEX_DATA, "rb") as output_file:
+    with open_ensure_dir(settings.DOC_TEX_DATA, 'rb') as output_file:
         output_tex = pickle.load(output_file)
 
-    print("Print documentation")
-    with open_ensure_dir(settings.DOC_LATEX_FILE, "wb") as doc:
+    print('Print documentation')
+    with open_ensure_dir(settings.DOC_LATEX_FILE, 'wb') as doc:
         content = documentation.latex(output_tex)
-        content = content.encode("utf-8")
+        content = content.encode('utf-8')
         doc.write(content)
 
 
 def main():
-    from mathics.doc import documentation as main_mathics_documentation
-
-    global definitions
-    global documentation
-    definitions = Definitions(add_builtin=True)
-    documentation = main_mathics_documentation
-
     parser = ArgumentParser(description="Mathics test suite.", add_help=False)
     parser.add_argument(
-        "--help", "-h", help="show this help message and exit", action="help"
-    )
+        '--help', '-h', help='show this help message and exit', action='help')
     parser.add_argument(
         "--version", "-v", action="version", version="%(prog)s " + mathics.__version__
     )
@@ -391,13 +360,9 @@ def main():
         help="run only  N tests",
     )
     args = parser.parse_args()
-    # If a test for a specific section is called
-    # just test it
-    if args.section:
-        if args.pymathics:  # in case the section is in a pymathics module...
-            documentation.load_pymathics_doc()
 
-        test_section(args.section, stop_on_failure=args.stop_on_failure)
+    if args.tex:
+        write_latex()
     else:
         # if we want to check also the pymathics modules
         if args.pymathics:
@@ -424,6 +389,5 @@ def main():
     if args.tex:
         write_latex()
 
-
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/mathics/test.py
+++ b/mathics/test.py
@@ -287,15 +287,15 @@ def make_doc(quiet=False):
         pickle.dump(output_xml, output_file, 0)
         print('\nOK')
 
-        if generate_output:
-            print("Save XML")
-            with open_ensure_dir(settings.DOC_XML_DATA, "wb") as output_file:
-                pickle.dump(output_xml, output_file, 0)
+    if generate_output and (failed == 0 or doc_even_if_error):
+        print("Save XML")
+        with open_ensure_dir(settings.DOC_XML_DATA, "wb") as output_file:
+            pickle.dump(output_xml, output_file, 0)
 
-            print("Save TEX")
-            with open_ensure_dir(settings.DOC_TEX_DATA, "wb") as output_file:
-                pickle.dump(output_tex, output_file, 0)
-            return True
+        print("Save TEX")
+        with open_ensure_dir(settings.DOC_TEX_DATA, "wb") as output_file:
+            pickle.dump(output_tex, output_file, 0)
+        return True
         return False
     else:
         print('\nFAILED')
@@ -305,20 +305,18 @@ def make_doc(quiet=False):
     with open_ensure_dir(settings.DOC_TEX_DATA, 'wb') as output_file:
         pickle.dump(output_tex, output_file, 0)
 
-def make_doc(quiet=False, generate_output=False, stop_on_failure=False,
-             start_at=0):
+def make_doc(quiet=False):
+    """
+    Write XML and TeX doc examples.
+    """
     if not quiet:
         print("Extracting doc %s" % version_string)
 
     try:
-        index = 0
-        count = failed = skipped = 0
-        failed_symbols = set()
         output_xml = {}
         output_tex = {}
         for tests in documentation.get_tests():
-            if generate_output:
-                create_output(tests, output_xml, output_tex)
+            create_output(tests, output_xml, output_tex)
         builtin_count = len(builtins)
     except KeyboardInterrupt:
         print("\nAborted.\n")
@@ -376,6 +374,12 @@ def main():
         dest="output",
         action="store_true",
         help="generate TeX and XML output data",
+    )
+    parser.add_argument(
+        "--doc-only",
+        dest="doc_only",
+        action="store_true",
+        help="generate TeX and XML output data without running tests",
     )
     parser.add_argument(
         "--tex",

--- a/tmp/README.rst
+++ b/tmp/README.rst
@@ -4,4 +4,4 @@ These can be ignored or removed.
 
 You can also use this directory for temporary files.
 
-In contrast to the  POSIX-like ``/tmp/``, file you put here are not removed on a reboot.
+In contrast to the  POSIX-like ``/tmp/``, files you put here are not removed on a reboot.

--- a/tmp/README.rst
+++ b/tmp/README.rst
@@ -1,0 +1,7 @@
+Running the tests sometimes adds file here.
+
+These can be ignored or removed.
+
+You can also use this directory for temporary files.
+
+In contrast to the  POSIX-like ``/tmp/``, file you put here are not removed on a reboot.


### PR DESCRIPTION
Doc system updates & pass over docs
    
* S> and X> directives were broken. They are less broken now
* struction.py: Combinatorica -> CombinatoricaOld since this is really obsolete
* doc/doc.py: fix S> and X>

Go over examples in system.py



Finally! No required trailing blanks!
    
Add `#<--#` to the end of a test line to signify that the test ends in a single blank
