### PR TITLE
Fix ldots

### DIFF
--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -1114,7 +1114,8 @@ class Repeated(PostfixOperator, PatternObject):
         self.min = min
         if len(expr.leaves) == 2:
             leaf_1 = expr.leaves[1]
-            if (leaf_1.has_form('List', 1, 2) and all(leaf.get_int_value() for leaf in leaf_1.leaves)):
+            allnumbers = all(not (leaf.get_int_value() is None) for leaf in leaf_1.get_leaves())
+            if (leaf_1.has_form('List', 1, 2) and allnumbers ):
                 self.max = leaf_1.leaves[-1].get_int_value()
                 self.min = leaf_1.leaves[0].get_int_value()
             elif leaf_1.get_int_value():

--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -208,7 +208,6 @@ class Replace(Builtin):
             evaluation.message('General', 'level', ls)
         except PatternError as e:
             evaluation.message('Replace','reps', rules)
-            
 
 
 class ReplaceAll(BinaryOperator):
@@ -280,9 +279,6 @@ class ReplaceAll(BinaryOperator):
             return result
         except PatternError as e:
             evaluation.message('Replace','reps', rules)
-        
-
-
 
 
 class ReplaceRepeated(BinaryOperator):
@@ -323,7 +319,7 @@ class ReplaceRepeated(BinaryOperator):
         except PatternError as e:
             evaluation.message('Replace','reps', rules)
             return None
-            
+
         if ret:
             return rules
 

--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -206,7 +206,7 @@ class Replace(Builtin):
             return result
         except InvalidLevelspecError:
             evaluation.message('General', 'level', ls)
-        except PatternError as e:
+        except PatternError:
             evaluation.message('Replace','reps', rules)
 
 
@@ -277,7 +277,7 @@ class ReplaceAll(BinaryOperator):
 
             result, applied = expr.apply_rules(rules, evaluation)
             return result
-        except PatternError as e:
+        except PatternError:
             evaluation.message('Replace','reps', rules)
 
 
@@ -316,7 +316,7 @@ class ReplaceRepeated(BinaryOperator):
         'ReplaceRepeated[expr_, rules_]'
         try:
             rules, ret = create_rules(rules, expr, 'ReplaceRepeated', evaluation)
-        except PatternError as e:
+        except PatternError:
             evaluation.message('Replace','reps', rules)
             return None
 
@@ -386,7 +386,7 @@ class ReplaceList(Builtin):
         try:
             rules, ret = create_rules(
                 rules, expr, 'ReplaceList', evaluation, extra_args=[max])
-        except PatternError as e:
+        except PatternError:
             evaluation.message('Replace','reps', rules)
             return None
 
@@ -1127,8 +1127,8 @@ class Repeated(PostfixOperator, PatternObject):
         self.min = min
         if len(expr.leaves) == 2:
             leaf_1 = expr.leaves[1]
-            allnumbers = all(not (leaf.get_int_value() is None) for leaf in leaf_1.get_leaves())
-            if (leaf_1.has_form('List', 1, 2) and allnumbers ):
+            allnumbers = not any(leaf.get_int_value() is None for leaf in leaf_1.get_leaves())
+            if leaf_1.has_form('List', 1, 2) and allnumbers:
                 self.max = leaf_1.leaves[-1].get_int_value()
                 self.min = leaf_1.leaves[0].get_int_value()
             elif leaf_1.get_int_value():

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -348,7 +348,7 @@ class BaseExpression(KeyComparable):
             leaves = self.get_leaves()
             include_form = False
             if head in formats and len(leaves) == 1:
-                expr = leaves
+                expr = leaves[0]
                 if not (form == 'System`OutputForm' and head == 'System`StandardForm'):
                     form = head
 

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -390,12 +390,10 @@ class BaseExpression(KeyComparable):
                                       ),"...",170))
                     else:
                         return Expression("System`HoldForm",expr)
-                
+
                 formatted = format_expr(expr)
                 if formatted is not None:
-                    print("   formated: ",formatted)
                     result = formatted.do_format(evaluation, form)
-                    print("   result: ", result)                    
                     if include_form:
                         result = Expression(form, result)
                     result.unformatted = unformatted
@@ -405,8 +403,7 @@ class BaseExpression(KeyComparable):
                 if head in formats:
                     expr = expr.do_format(evaluation, form)
                 elif (head != 'System`NumberForm' and not expr.is_atom() and
-                      head != 'System`Graphics' and
-                      not head in ("Repeat", "RepeatNull") ):
+                      head != 'System`Graphics'):
                     new_leaves = [leaf.do_format(evaluation, form)
                                   for leaf in expr.leaves]
                     expr = Expression(


### PR DESCRIPTION
This PR fixes the behavior of Repeated and RepeatedNull and introduce catch exceptions for wrong formatted patterns.
`Import@"https://raw.githubusercontent.com/jkuczm/MathematicaCellsToTeX/master/NoInstall.m"`
 now still does not loads, but at least do not kill the interpreter... 

@rocky please have a look at this.