### PR TITLE
Remove "Protect" Attribute hackiness on Builtin

### DIFF
--- a/mathics/builtin/__init__.py
+++ b/mathics/builtin/__init__.py
@@ -114,14 +114,6 @@ def contribute(definitions):
         if name != 'System`MakeBoxes':
             item.contribute(definitions)
 
-    # Is there another way to Unprotect these symbols at initialization?
-    definitions.get_attributes('System`$PreRead').clear()
-    definitions.get_attributes('System`$Pre').clear()
-    definitions.get_attributes('System`$Post').clear()
-    definitions.get_attributes('System`$PrePrint').clear()
-    definitions.get_attributes('System`$SyntaxHandler').clear()
-    definitions.get_attributes('System`$TimeZone').clear()
-    definitions.get_attributes('System`$UseSansSerif').clear()
     from mathics.core.expression import ensure_context
     from mathics.core.parser import all_operator_names
     from mathics.core.definitions import Definition

--- a/mathics/builtin/assignment.py
+++ b/mathics/builtin/assignment.py
@@ -1712,7 +1712,7 @@ class LoadModule(Builtin):
             return Symbol('$Failed')
         else:
             # Add PyMathics` to $ContextPath so that when user don't
-            # have to qualify PyMathics variables and functions, 
+            # have to qualify PyMathics variables and functions,
             # as the those in teh module just loaded.
 
             # Following the example of $ContextPath in the WL

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -225,10 +225,13 @@ class Builtin(object):
             )
         )
 
-        if name == "System`MakeBoxes":
+        if "Unprotected" in self.attributes:
             attributes = []
+            self.attributes = list(self.attributes)
+            self.attributes.remove("Unprotected")
         else:
             attributes = ["System`Protected"]
+
         attributes += list(ensure_context(a) for a in self.attributes)
         options = {}
         for option, value in self.options.items():

--- a/mathics/builtin/datentime.py
+++ b/mathics/builtin/datentime.py
@@ -571,6 +571,7 @@ class TimeZone(Predefined):
 
     name = "$TimeZone"
     value = SystemTimeZone.value.copy()
+    attributes = ("Unprotected",)
 
     rules = {
         "$TimeZone": str(value),

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -46,6 +46,7 @@ class UseSansSerif(Predefined):
     """
     context = "System`"
     name = '$UseSansSerif'
+    attributes = ("Unprotected",)
     value = True
 
     rules = {
@@ -462,7 +463,7 @@ class MakeBoxes(Builtin):
      = RowBox[{a, ,, b}]
     """
 
-    attributes = ('HoldAllComplete',)
+    attributes = ('HoldAllComplete', "Unprotected")
 
     rules = {
         'MakeBoxes[Infix[head_[leaves___]], '

--- a/mathics/builtin/iohooks.py
+++ b/mathics/builtin/iohooks.py
@@ -6,18 +6,21 @@ from mathics.builtin.base import Builtin
 
 
 class IOHookPreRead(Builtin):
-    '''
+    """
     <dl>
     <dt>$PreRead
     <dt> is a global variable whose value, if set, is applied to the \
     text or box form of every input expression before it is fed to the parser.
     <dt>(Not implemented yet)
     </dl>
-    '''
+    """
+
     name = "$PreRead"
+    attributes = ("Unprotected",)
+
 
 class IOHookPre(Builtin):
-    '''
+    """
     <dl>
     <dt>$Pre
     <dt>is a global variable whose value, if set,
@@ -42,39 +45,47 @@ class IOHookPre(Builtin):
      | [Processing input...]
     >> 2 + 2
      = 4
-    '''
+    """
+
     name = "$Pre"
+    attributes = ("Unprotected",)
 
 
 class IOHookPost(Builtin):
-    '''
+    """
     <dl>
     <dt>$Post
     <dt>is a global variable whose value, if set,
     is applied to every output expression.
     </dl>
-    '''
+    """
+
     name = "$Post"
+    attributes = ("Unprotected",)
 
 
 class IOHookPrePrint(Builtin):
-    '''
+    """
     <dl>
     <dt>$PrePrint
     <dt>is a global variable whose value, if set,
     is applied to every output expression before it is printed.
     </dl>
-    '''
+    """
+
     name = "$PrePrint"
+    attributes = ("Unprotected",)
 
 
 class IOHookSyntaxHandler(Builtin):
-    '''
+    """
     <dl>
     <dt>$SyntaxHandler
     <dt>is a global variable whose value, if set,
     is applied to  any input string that is found to contain a syntax error.
     <dt>(Not implemented yet)
     </dl>
-    '''
+    """
+
     name = "$SyntaxHandler"
+    attributes = ("Unprotected",)


### PR DESCRIPTION
There are a number of built-ins that don't want to be Protected by default, and we currently have no way to indicate that.

Currently "MakeBoxes" is hacked in to change this and "assignment" has another hack to change this as well. And they do this using the `List#clear()` function which removes *all* attributes, not just Protect.

In this change, setting the `attribute = ("Unprotect", ...)`  indicates to Builtin we don't want to add the "Protect" attribute.

Note however this isn't a true attribute like "Protect" is - it only means something in the declaration of a Builtin, and doesn't exist at run time.

The need for this change becomes all the more important as we move things into PyMathics because a growing number of these for variable-like definition will be desired.

Another Note: in the future we may want to add a class specificaly for variable-like definition.