### PR TITLE
Small tweaks, more tests

### DIFF
--- a/mathics/builtin/control.py
+++ b/mathics/builtin/control.py
@@ -751,6 +751,7 @@ class Catch(Builtin):
      = 24
 
     """
+    attributes = ("HoldAll",)
 
     def apply1(self, expr, evaluation):
         'Catch[expr_]'
@@ -759,9 +760,9 @@ class Catch(Builtin):
         except WLThrowInterrupt as e:
             return e.value
         return ret
- 
+
     def apply3(self, expr, form, f, evaluation):
-        'Catch[expr_, form_, f__:Identity]'
+        "Catch[expr_, form_, f__:Identity]"
         try:
             ret = expr.evaluate(evaluation)
         except WLThrowInterrupt as e:
@@ -771,7 +772,9 @@ class Catch(Builtin):
             if match.is_true():
                 return Expression(f, e.value)
             else:
-                raise e
+                # A plain raise hide, this path and preserves the traceback
+                # of the call that was originally given.
+                raise
         return ret
 
 
@@ -804,6 +807,3 @@ class Throw(Builtin):
     def apply2(self, value, tag, evaluation):
         'Throw[value_, tag_]'
         raise WLThrowInterrupt(value, tag)
-        
-
-

--- a/test/test_control.py
+++ b/test/test_control.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+from .helper import session, check_evaluation
+
+import sys
+from mathics.core.parser import parse, SingleLineFeeder
+from mathics.core.definitions import Definitions
+from mathics.core.evaluation import Evaluation
+import pytest
+
+
+def test_control():
+    session.evaluate(
+        """
+        (* Define a function that can "throw an exception": *)
+
+         f[x_] := If[x > 10, Throw[overflow], x!]
+        """
+    )
+    for str_expr, str_expected, message in (
+        (
+            "Catch[a; b; Throw[c]; d; e]",
+            "c",
+            "Exit to the enclosing Catch as soon as the Throw is evaluated",
+        ),
+        (
+            "Catch[f[2] + f[11]]",
+            "overflow",
+            "The result of the Catch is just what is thrown by Throw in f[]",
+        ),
+        (
+            "Catch[f[2] + f[3]]",
+            "8",
+            "A Catch[] where nothing is thrown",
+        ),
+        (
+            "Catch[Do[If[i! > 10^10, Throw[i]], {i, 100}]]",
+            "14",
+            "Use Throw to exit a loop when a criterion is satisfied",
+        ),
+        (
+            "Catch[If[# < 0, Throw[#]] & /@ {1, 2, 0, -1, 5, 6}]",
+            "-1",
+            "Catch can catch a Throw from inside essentially any function (1)",
+        ),
+        (
+            "Catch[{a, Throw[b], c}]",
+            "b",
+            "Catch can catch a Throw from inside essentially any function (2)",
+        ),
+        (
+            "Catch[a^2 + b^2 + c^2 /. b :> Throw[bbb]]",
+            "bbb",
+            "Catch can catch a Throw from inside essentially any function (3)",
+        ),
+        (
+            "Catch[{Catch[{a, Throw[b], c}], d, e}]",
+            "{b, d, e}",
+            "The nearest enclosing Catch catches the Throw",
+        ),
+        (
+            "Catch[{Throw[a], Throw[b], Throw[c]}]",
+            "a",
+            "Catch picks up the first Throw that is evaluated (1)",
+        ),
+        (
+            "Catch[Throw /@ {a, b, c}]",
+            "a",
+            "Catch picks up the first Throw that is evaluated (2)",
+        ),
+
+    ):
+        check_evaluation(str_expr, str_expected, message)


### PR DESCRIPTION
"Catch[] needs to make sure it controls the expression evaluation
rather than having its expression get evaluated before it has a
change to wrap it in a `try`.

Internally, a plain `raise` is a bit more tidy Python wise
since the Python traceback will the path from raise to handler without
intervening tests of inappropriate exception handlers. This is a
matter of taste though.

Add more unit test tests.