### PR TITLE
Add System`VersionNumber

### DIFF
--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -410,9 +410,9 @@ class VersionNumber(Predefined):
     """
 
     name = "$VersionNumber"
-    value = 12.1
+    value = 6.0
 
     def evaluate(self, evaluation) -> Real:
         # Make this be whatever the latest Mathematica release is,
         # assuming we are trying to be compatible with this.
-        return Real(12.1)
+        return Real(self.value)

--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -11,7 +11,14 @@ import platform
 import sys
 import re
 
-from mathics.core.expression import Expression, Integer, String, Symbol, strip_context
+from mathics.core.expression import (
+    Expression,
+    Integer,
+    Real,
+    String,
+    Symbol,
+    strip_context,
+)
 from mathics.builtin.base import Builtin, Predefined
 from mathics import version_string
 from mathics.builtin.strings import StringExpression, to_regex
@@ -167,8 +174,8 @@ class MachineName(Predefined):
 class Names(Builtin):
     """
     <dl>
-    <dt>'Names["$pattern$"]'
-        <dd>returns the list of names matching $pattern$.
+      <dt>'Names["$pattern$"]'
+      <dd>returns the list of names matching $pattern$.
     </dl>
 
     >> Names["List"]
@@ -389,3 +396,22 @@ class Version(Predefined):
 
     def evaluate(self, evaluation) -> String:
         return String(version_string.replace("\n", " "))
+
+
+class VersionNumber(Predefined):
+    r"""
+    <dl>
+      <dt>'$VersionNumber'
+      <dd>is a real number which gives the current Wolfram Language kernel vesion number \Mathics tries to be compatible with.
+    </dl>
+
+    >> $VersionNumber
+    = ...
+    """
+
+    name = "$VersionNumber"
+
+    def evaluate(self, evaluation) -> String:
+        # Make this be whatever the latest Mathematica release is,
+        # assuming we are trying to be compatible with this.
+        return Real(12.1)

--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -402,7 +402,7 @@ class VersionNumber(Predefined):
     r"""
     <dl>
       <dt>'$VersionNumber'
-      <dd>is a real number which gives the current Wolfram Language kernel vesion number \Mathics tries to be compatible with.
+      <dd>is a real number which gives the current Wolfram Language version that \Mathics tries to be compatible with.
     </dl>
 
     >> $VersionNumber

--- a/test/helper.py
+++ b/test/helper.py
@@ -9,6 +9,6 @@ def check_evaluation(str_expr: str, str_expected: str, message=""):
     expected = session.evaluate(str_expected)
 
     if message:
-        assert result == expected, message
+        assert result == expected, "%s: got: %s" % (message, result)
     else:
         assert result == expected


### PR DESCRIPTION
Currently set to the most recent Mathematica release so that
packages that test on $VersionNumber are not thwarted.