### PR TITLE
Two bugs noticed...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - LLVM_CONFIG=/usr/bin/llvm-config-10  CXXFLAGS=-fPIC python -m pip install llvmlite
   - pip install ipywidgets ipykernel requests IPython==5.0.0 langid pycountry pyenchant lxml matplotlib
   - python travis.py
-  - pip install cython unittest2 pexpect scikit-image
+  - pip install cython unittest2 pexpect
 install:
   - sed -i "s/'sympy==[0-9]\.[0-9]\.[0-9]', //" setup.py
   - make develop

--- a/mathics/builtin/image.py
+++ b/mathics/builtin/image.py
@@ -1823,7 +1823,7 @@ class ImageData(_ImageBuiltin):
         elif stype == "Bit16":
             pixels = pixels_as_uint(pixels)
         elif stype == "Bit":
-            pixels = pixels.astype(numpy.bool)
+            pixels = pixels.astype(numpy.int)
         else:
             return evaluation.message("ImageData", "pixelfmt", stype)
         return from_python(numpy_to_matrix(pixels))

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ INSTALL_REQUIRES += [
     "python-dateutil",
     "llvmlite",
     "requests",
+    "wordcloud", # Used in builtin/image.py by WordCloud()
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -78,9 +78,6 @@ else:
     CMDCLASS = {"build_ext": build_ext}
     INSTALL_REQUIRES += ["cython>=0.15.1"]
 
-if sys.platform == "darwin":
-    INSTALL_REQUIRES += ["scikit-image"]
-
 # General Requirements
 INSTALL_REQUIRES += [
     "sympy>=1.6, < 1.7",
@@ -92,6 +89,7 @@ INSTALL_REQUIRES += [
     "python-dateutil",
     "llvmlite",
     "requests",
+    "scikit-image",
     "wordcloud", # Used in builtin/image.py by WordCloud()
 ]
 


### PR DESCRIPTION
setup.py: builtin/image.py directly imports wordcloud but that is not in setup.py
Not sure why this wasn't seen before. Maybe some other package pulls it
it in implicity? However if it is imported here, it should be mentioned
in setup.py

mathics/builtin/image.py: now that from_python distinguishs ints from
bools image data needs to be converted to an "int" not a "bool".

Otherwise, we get:

1867 ( 4): TEST ImageData[Image[{{0, 1}, {1, 0}, {1, 1}}], "Bit"]
Test failed: ImageData in Reference of Built-in Symbols / Image[] and image related functions.
ImageData[Image[{{0, 1}, {1, 0}, {1, 1}}], "Bit"]
Result: {{False, True}, {True, False}, {True, True}}
Wanted: {{0, 1}, {1, 0}, {1, 1}}