### PR TITLE
Start a settings file...

### DIFF
--- a/mathics/autoload/settings.m
+++ b/mathics/autoload/settings.m
@@ -1,0 +1,10 @@
+(*****************************)
+(* Settings for Mathics Core *)
+(*****************************)
+
+Settings`$TraceGet::usage = "If this Boolean variable is set True, 'Get' traces the lines it reads that start a new expression";
+Settings`$TraceGet = False
+Unprotect[Settings`$TraceGet]
+
+System`MathicsVersion::usage = "This string is the version of Mathics we are running."
+(* System`MathicsVersion = "xxx" - set inside Mathics *)

--- a/mathics/builtin/files.py
+++ b/mathics/builtin/files.py
@@ -2156,23 +2156,24 @@ class Get(PrefixOperator):
         "Trace": "False",
     }
 
-    def check_options(self, options):
-        # Options
-        # TODO Proper error messages
-
-        result = {}
-        if options["System`Trace"].to_python():
-            result["TraceFn"] = print
-        else:
-            result["TraceFn"] = None
-
-        return result
-
     def apply(self, path, evaluation, options):
         "Get[path_String, OptionsPattern[Get]]"
         from mathics.core.parser import parse, TranslateError, FileLineFeeder
 
-        py_options = self.check_options(options)
+        def check_options(options):
+            # Options
+            # TODO Proper error messages
+
+            result = {}
+            trace_get = evaluation.parse('Settings`$TraceGet')
+            if options["System`Trace"].to_python() or trace_get.evaluate(evaluation) == SymbolTrue:
+                result["TraceFn"] = print
+            else:
+                result["TraceFn"] = None
+
+            return result
+
+        py_options = check_options(options)
         trace_fn = py_options["TraceFn"]
         result = None
         pypath = path.get_string_value()

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -12,6 +12,7 @@ from collections import defaultdict
 
 import typing
 
+from mathics.version import __version__
 from mathics.core.expression import (
     Expression,
     Symbol,
@@ -70,6 +71,8 @@ class Definitions(object):
             from mathics.builtin import modules, contribute
             from mathics.core.evaluation import Evaluation
             from mathics.settings import ROOT_DIR
+
+            self.set_ownvalue("System`MathicsVersion", String(__version__))
 
             loaded = False
             if builtin_filename is not None:


### PR DESCRIPTION
Put in it MathicsVersion usage
Add TraceGet for tracing Get
definition.py: Sets MathicsVersion

We could probably put $UseSansSerif in here as well.