### PR TITLE
Add from_python option and bug fix

### DIFF
--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -670,7 +670,7 @@ class InterpretationBox(Builtin):
     """
     <dl>
     <dt>'InterpretationBox[{...}]'
-        <dd> is a low-level box construct that displays as 
+        <dd> is a low-level box construct that displays as
     boxes but is interpreted on input as expr.
     </dl>
     """
@@ -706,7 +706,7 @@ class TagBox(Builtin):
     """
     <dl>
     <dt>'TagBox[boxes, tag]'
-        <dd> is a low-level box construct that displays as 
+        <dd> is a low-level box construct that displays as
     boxes but is interpreted on input as expr
     </dl>
     """
@@ -720,7 +720,7 @@ class TemplateBox(Builtin):
     </dl>
     """
     attributes =  ('HoldAllComplete', 'Protected', 'ReadProtected')
-    
+
 
 class Row(Builtin):
     """
@@ -2030,7 +2030,7 @@ class MathMLForm(Builtin):
 
 
 class PythonForm(Builtin):
-    """
+    r"""
     <dl>
       <dt>'PythonForm[$expr$]'
       <dd>returns an approximate equivalent of $expr$ in Python, when that is possible. We assume
@@ -2045,6 +2045,9 @@ class PythonForm(Builtin):
     = sympy.E
     >> {1, 2, 3} // PythonForm
     = [1, 2, 3]
+
+    >> PythonForm["a\"bc'd"]
+     = 'a"bc\'d'
     """
     # >> PythonForm[HoldForm[Sqrt[a^3]]]
     #  = sympy.sqrt{a**3} # or something like this

--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -59,10 +59,10 @@ class ByteOrdering(Predefined):
 
 
 class CommandLine(Predefined):
-    """
+    r"""
     <dl>
     <dt>'$CommandLine'
-      <dd>is a list of strings passed on the command line to launch the Mathics session.
+      <dd>is a list of strings passed on the command line to launch the \Mathics session.
     </dl>
     >> $CommandLine
      = {...}
@@ -141,10 +141,10 @@ class GetEnvironment(Builtin):
 
 
 class Machine(Predefined):
-    """
+    r"""
     <dl>
     <dt>'$Machine'
-        <dd>returns a string describing the type of computer system on which the Mathics is being run.
+        <dd>returns a string describing the type of computer system on which the \Mathics is being run.
     </dl>
     X> $Machine
      = linux
@@ -176,7 +176,7 @@ class MathicsVersion(Predefined):
     r"""
     <dl>
       <dt>'MathicsVersion'
-      <dd>this string is the version of Mathics we are running.
+      <dd>this string is the version of \Mathics we are running.
     </dl>
 
     >> MathicsVersion
@@ -239,10 +239,10 @@ class Names(Builtin):
 
 
 class Packages(Predefined):
-    """
+    r"""
     <dl>
       <dt>'$Packages'
-      <dd>returns a list of the contexts corresponding to all packages which have been loaded into Mathics.
+      <dd>returns a list of the contexts corresponding to all packages which have been loaded into \Mathics.
     </dl>
 
     X> $Packages
@@ -411,10 +411,10 @@ class UserName(Predefined):
 
 
 class Version(Predefined):
-    """
+    r"""
     <dl>
       <dt>'$Version'
-      <dd>returns a string with the current Mathics version and the versions of relevant libraries.
+      <dd>returns a string with the current \Mathics version and the versions of relevant libraries.
     </dl>
 
     >> $Version

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -87,7 +87,7 @@ class ExpressionPointer(object):
         return '%s[[%s]]' % (self.parent, self.position)
 
 
-def from_python(arg):
+def from_python(arg, omit_surrounding_quotes=False):
     number_type = get_type(arg)
     if arg is None:
         return Symbol('Null')
@@ -117,7 +117,7 @@ def from_python(arg):
     elif isinstance(arg, list) or isinstance(arg, tuple):
         return Expression('List', *[from_python(leaf) for leaf in arg])
     else:
-        raise NotImplementedError
+        raise NotImplementedError(f"{arg} can't be converted to Mathics")
 
 
 class KeyComparable(object):
@@ -2620,7 +2620,12 @@ class String(Atom):
         return None
 
     def to_python(self, *args, **kwargs) -> str:
-        return '"%s"' % self.value  # add quotes to distinguish from Symbols
+        if kwargs.get("omit_surrounding_quotes", False):
+            return self.value
+        else:
+            # Add quotes to distinguish from Symbols.
+            # We use __repr__ instead of repr() to make the Cython compiler happy
+            return self.value.__repr__()
 
     def __hash__(self):
         return hash(("String", self.value))


### PR DESCRIPTION
Add Mathics option OmitSurroundingQuotes and omit_surrounding_quotes in from_python to indicate whether we want to add surrounding quotes when converting from python.

Also we had a bug in formatting from a python string to Mathics String. Previously we slapped a double quote (") around the outside. However that assumes internally there isn't a double quote.

Instead we now use Python's repr() which handles this.

However it can produce a string that starts out with a single quote ('). But we shouldn't explect the output of PythonForm to be something that can be then input into Mathics.