### PR TITLE
mpmath fns and more...

### DIFF
--- a/admin-tools/pyenv-versions
+++ b/admin-tools/pyenv-versions
@@ -5,4 +5,4 @@ if [[ $0 == ${BASH_SOURCE[0]} ]] ; then
     echo "This script should be *sourced* rather than run directly through bash"
     exit 1
 fi
-export PYVERSIONS='3.6.12 3.7.9 3.8.6 3.9.0'
+export PYVERSIONS='3.6.12 3.7.9 3.8.7 3.9.1'

--- a/admin-tools/time-mathmp-sympy-fns.py
+++ b/admin-tools/time-mathmp-sympy-fns.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+"""
+Program to time mpmath pi vs sympy pi
+"""
+
+from timeit import timeit
+import mpmath
+import math
+import sympy
+
+PRECISION = 100
+mpmath.mp.dps = PRECISION
+ITERATIONS = 2000
+
+# print(mpmath.pi, "\n")
+
+def math_pi():
+    return math.pi
+
+
+def mpmath_pi():
+    return mpmath.pi
+
+
+def sympy_pi():
+    return sympy.pi.n(PRECISION)
+
+
+def mpmath_e():
+    return mpmath.e
+
+
+def sympy_e():
+    return sympy.E.n(PRECISION)
+
+
+def mpmath_degree():
+    return mpmath.degree
+
+
+def sympy_degree():
+    return (sympy.pi / 180).n(PRECISION)
+
+
+# print(timeit(math_pi, number=ITERATIONS))
+
+for sympy_fn, mpmath_fn, fn_name in (
+    (sympy_pi, mpmath_pi, "pi"),
+    (sympy_e, mpmath_e, "e"),
+    (sympy_degree, mpmath_degree, "degree"),
+):
+    print(fn_name + ":")
+    print(timeit(mpmath_fn, number=ITERATIONS), "seconds for mpmath")
+    print(timeit(sympy_fn, number=ITERATIONS), "seconds for sympy")
+    print("\n", mpmath_fn(), "\n", sympy_fn())
+    print()

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -43,7 +43,6 @@ from mathics.core.numbers import min_prec, dps, SpecialValueError
 from mathics.builtin.lists import _IterationFunction
 from mathics.core.convert import from_sympy
 
-
 class _MPMathFunction(SympyFunction):
 
     attributes = ("Listable", "NumericFunction")

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -1791,8 +1791,7 @@ class Symbol(Atom):
         if (builtin is None or not builtin.sympy_name or    # nopep8
             not builtin.is_constant()):
             return sympy.Symbol(sympy_symbol_prefix + self.name)
-        else:
-            return builtin.to_sympy(self)
+        return builtin.to_sympy(self, **kwargs)
 
     def to_python(self, *args, **kwargs):
         if self == SymbolTrue:
@@ -2246,11 +2245,13 @@ class MachineReal(Real):
 
 
 class PrecisionReal(Real):
-    '''
+    """
     Arbitrary precision real number.
 
     Stored internally as a sympy.Float.
-    '''
+
+    Note: Plays nicely with the mpmath.mpf (float) type.
+    """
     value: sympy.Float
 
     def __new__(cls, value) -> 'PrecisionReal':

--- a/mathics/test.py
+++ b/mathics/test.py
@@ -164,12 +164,13 @@ def create_output(tests, output_xml, output_tex):
             }
 
 
-def test_section(section, quiet=False, stop_on_failure=False):
+def test_section(sections: set, quiet=False, stop_on_failure=False):
     failed = 0
     index = 0
-    print("Testing section %s" % section)
+    print("Testing section(s): %s" % ", ".join(sections))
+    sections |= {"$" + s for s in sections}
     for tests in documentation.get_tests():
-        if tests.section == section or tests.section == "$" + section:
+        if tests.section in sections:
             found = True
             for test in tests.tests:
                 if test.ignore:
@@ -336,7 +337,8 @@ def main():
         "--version", "-v", action="version", version="%(prog)s " + mathics.__version__
     )
     parser.add_argument(
-        "--section", "-s", dest="section", metavar="SECTION", help="only test SECTION"
+        "--sections", "-s", dest="section", metavar="SECTION", help="only test SECTION(s). "
+        "You can list multiple sections by adding a comma (and no space) in between section names."
     )
     parser.add_argument(
         "--pymathics",
@@ -399,10 +401,11 @@ def main():
     # If a test for a specific section is called
     # just test it
     if args.section:
+        sections = set(args.section.split(","))
         if args.pymathics:  # in case the section is in a pymathics module...
             documentation.load_pymathics_doc()
 
-        test_section(args.section, stop_on_failure=args.stop_on_failure)
+        test_section(sections, stop_on_failure=args.stop_on_failure)
     else:
         # if we want to check also the pymathics modules
         if args.pymathics:


### PR DESCRIPTION
This probably should be spit up.

The main part of it adds more mpmath constants and DRY's code
In particular

* the EulerGamma constant was added.
* Classes MPMathConstant and NumpyMathConstant were added
* We start to keep track of dictionaries for mapping between names
  automatically now. More will be added later
* `get_constant()` added. When looking up a constant we can decide
  whether to evaluate the value or leave in symbolic form.

Misc things not so directly related to the above...

* test.py --sections now can take a list of sections separated with commas (and no space). For example:
```
python test.py --sections=Catalan,Pi,GoldenRatio
```

* super(<ClassName>, self) ->  super() a number of places
* admin testing uses 3.7.9 now
* add `admin-tools/time-mathmp-sympy-fns.py` program to time sympy vs. mpmath