### PR TITLE
Fix bug that converts `=` to `\uf7d9` in `replace_unicode_with_wl`

### DIFF
--- a/mathics/core/util.py
+++ b/mathics/core/util.py
@@ -261,7 +261,7 @@ WL_TO_UNICODE = {
     '\uf603': '|', # \[LeftBracketingBar] -> VERTICAL LINE
     '\uf605': '‖', # \[LeftDoubleBracketingBar] -> DOUBLE VERTICAL LINE
     '\uf761': '«', # \[LeftSkeleton] -> LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
-    '\uf7d9': '=', # \[LongEqual] -> EQUALS SIGN
+    '\uf7d9': '=', # \[LongEqual] -> EQUALS SIGN + EQUALS SIGN
     '\uf724': '#', # \[NumberSign] -> NUMBER SIGN
     '\uf3de': '⊙', # \[PermutationProduct] -> CIRCLED DOT OPERATOR
     '\uf528': '⎕', # \[Placeholder] -> APL FUNCTIONAL SYMBOL QUAD
@@ -576,7 +576,8 @@ UNICODE_TO_WL = {
     '⟹': '\uf523', # LONG RIGHTWARDS DOUBLE ARROW -> \[Implies]
     '|': '\uf3d0', # VERTICAL LINE -> 
     '«': '\uf761', # LEFT-POINTING DOUBLE ANGLE QUOTATION MARK -> \[LeftSkeleton]
-    '=': '\uf7d9', # EQUALS SIGN -> \[LongEqual]
+    # The following is ommited so that `a := b` or `a = b` don't get converted to `a :\uf7d9 b` or `a \uf7d9 b`
+    # '=': '\uf7d9', # EQUALS SIGN -> \[LongEqual]
     '#': '\uf724', # NUMBER SIGN -> \[NumberSign]
     '⊙': '\uf3de', # CIRCLED DOT OPERATOR -> \[PermutationProduct]
     '⎕': '\uf528', # APL FUNCTIONAL SYMBOL QUAD -> \[Placeholder]

--- a/mathics/core/util.py
+++ b/mathics/core/util.py
@@ -261,7 +261,7 @@ WL_TO_UNICODE = {
     '\uf603': '|', # \[LeftBracketingBar] -> VERTICAL LINE
     '\uf605': '‖', # \[LeftDoubleBracketingBar] -> DOUBLE VERTICAL LINE
     '\uf761': '«', # \[LeftSkeleton] -> LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
-    '\uf7d9': '=', # \[LongEqual] -> EQUALS SIGN + EQUALS SIGN
+    '\uf7d9': '=', # \[LongEqual] -> EQUALS SIGN
     '\uf724': '#', # \[NumberSign] -> NUMBER SIGN
     '\uf3de': '⊙', # \[PermutationProduct] -> CIRCLED DOT OPERATOR
     '\uf528': '⎕', # \[Placeholder] -> APL FUNCTIONAL SYMBOL QUAD


### PR DESCRIPTION
This a fix for the first issue described in #1107. The issue was my fault, it's an error in the `UNICODE_TO_WL` dict.