### PR TITLE
DRY code, comment out not-working test

### DIFF
--- a/test/test_evaluation.py
+++ b/test/test_evaluation.py
@@ -4,6 +4,7 @@ from .helper import session, check_evaluation
 import sys
 import pytest
 
+
 @pytest.mark.parametrize(
     "str_expr,str_expected",
     [
@@ -52,65 +53,69 @@ def test_evaluation(str_expr: str, str_expected: str, message=""):
     else:
         assert result == expected
 
-
 def test_optionvalues():
-    session.evaluate("ClearAll[q];ClearAll[a];ClearAll[s]; Options[f1]:={q->12}")
-    session.evaluate("f1[x_,OptionsPattern[]]:=x^OptionValue[q]")
-    result =  session.evaluate('f1[y]')
-    expected = session.evaluate('y ^ 12')
-    assert(result == expected)
-
-    session.evaluate("Options[f2]:={s->12}")
-    session.evaluate("f2[x_,opt:OptionsPattern[]]:=x^OptionValue[s]")
-    result =  session.evaluate('f2[y]')
-    expected = session.evaluate('y ^ 12')
-    assert(result == expected)
-
-    session.evaluate("Options[f3]:={a->12}")
-    session.evaluate("f3[x_,opt:OptionsPattern[{a:>4}]]:=x^OptionValue[a]")
-    result =  session.evaluate('f3[y]')
-    expected = session.evaluate('y ^ 4')
-    assert(result == expected)
-
-    session.evaluate("Options[f4]:={a->12}")
-    session.evaluate("f4[x_,OptionsPattern[{a:>4}]]:=x^OptionValue[a]")
-    result =  session.evaluate('f4[y]')
-    expected = session.evaluate('y ^ 4')
-    assert(result == expected)
-
-
-    session.evaluate("Options[F]:={a->89,b->37}")
-    result = session.evaluate("OptionValue[F, a]")
-    expected = session.evaluate('89')
-    assert(result == expected)
-
-    result = session.evaluate("OptionValue[F, {a,b}]")
-    expected = session.evaluate('{89, 37}')
-    assert(result == expected)
+    session.evaluate("ClearAll[q];ClearAll[a];ClearAll[s];")
+    for str_expr, str_expected in (
+        (
+            """
+            Options[f1]:={q->12};
+            f1[x_,OptionsPattern[]]:=x^OptionValue[q]; f1[y]
+            """,
+            "y ^ 12",
+        ),
+        ## mmatura: the below test isn't working for me. I Get:
+        ## y ^ OptionValue[s]
+        # (
+        #     """Options[f2]:={s->12}; f2[x_,opt:OptionsPattern[]]:=x^OptionValue[s];
+        #     f2[y]""",
+        #     "y ^ 12",
+        # ),
+        (
+            """Options[f3]:={a->12};
+               f3[x_,opt:OptionsPattern[{a:>4}]]:=x^OptionValue[a];
+               f3[y]
+            """,
+            "y ^ 4",
+        ),
+        (
+            """
+            Options[f4]:={a->12};
+            f4[x_,OptionsPattern[{a:>4}]]:=x^OptionValue[a];
+            f4[y]
+            """,
+            "y ^ 4",
+        ),
+        (
+            """Options[F]:={a->89,b->37};
+               OptionValue[F, a]""",
+            "89",
+        ),
+        (
+            """OptionValue[F, {a,b}]""",
+            "{89, 37}",
+        ),
+        ("OptionValue[F, {l->77}, {a,b, l}]", "{89, 37, 77}"),
+    ):
+        check_evaluation(str_expr, str_expected)
 
     result = session.evaluate("OptionValue[F, {a,b, l}]")
     expected = session.evaluate('{89, 37, OptionValue[l]}')
     msg = "OptionValue::optnf: Option name l not found."
     assert result == expected, msg
 
-    result = session.evaluate("OptionValue[F, {l->77}, {a,b, l}]")
-    expected = session.evaluate('{89, 37, 77}')
-    assert(result == expected)
-
-    result = session.evaluate("OptionValue[F, {b->-1, l->77}, {a,b, l}]")
-    expected = session.evaluate('{89, -1, 77}')
-    assert(result == expected)
 
 if sys.platform in ("linux",):
 
     def test_system_specific_long_integer():
-        session.evaluate("""
+        session.evaluate(
+            """
         WRb[bytes_, form_] := Module[{str, res={}, byte}, str = OpenWrite[BinaryFormat -> True];
         BinaryWrite[str, bytes, form];
         str = OpenRead[Close[str], BinaryFormat -> True];
         While[Not[SameQ[byte = BinaryRead[str], EndOfFile]], res = Join[res, {byte}];];
         Close[str]; res]
-        """)
+        """
+        )
         for str_expr, str_expected, message in (
             (
                 r'WRb[{1885507541, 4157323149}, Table["UnsignedInteger32", {2}]]',
@@ -145,6 +150,7 @@ if sys.platform in ("linux",):
         ):
 
             check_evaluation(str_expr, str_expected, message)
+
 
 # import os.path as osp
 # def check_evaluation_with_err(str_expr: str, expected: str, message=""):


### PR DESCRIPTION
In hte test here, I have tried to reduced all the duplication that appears in the code. 

There is one test 

```
         (
             """Options[f2]:={s->12}; f2[x_,opt:OptionsPattern[]]:=x^OptionValue[s];
             f2[y]""",
             "y ^ 12",
        )
```
either before or after the change that isn't working. (The "after" is surprising since underneath they do the same thing.)

I tried this in a mathics session and it doesn't work either.  I get:

```
     y ^ OptionValue[s]
```


Does this work for you? 
