### PR TITLE
Added calls to replace_wl_with_plain_text in boxes_to_text and boxes_to_xml for String and Symbol

### DIFF
--- a/mathics/core/evaluation.py
+++ b/mathics/core/evaluation.py
@@ -233,7 +233,8 @@ class Evaluation(object):
             definitions=None,
             output=None,
             format="text",
-            catch_interrupt=True
+            catch_interrupt=True,
+            use_unicode=True
     ) -> None:
         from mathics.core.definitions import Definitions
         from mathics.core.expression import Symbol
@@ -247,6 +248,7 @@ class Evaluation(object):
         self.stopped = False
         self.out = []
         self.output = output if output else Output()
+        self.use_unicode = use_unicode
         self.listeners = {}
         self.options = None
         self.predetermined_out = None

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -14,7 +14,7 @@ import typing
 from typing import Any
 from itertools import chain
 from bisect import bisect_left
-
+from mathics_scanner.characters import replace_wl_with_plain_text
 
 from mathics.core.numbers import get_type, dps, prec, min_prec, machine_precision
 from mathics.core.convert import sympy_symbol_prefix, SympyExpression
@@ -1793,7 +1793,16 @@ class Symbol(Atom):
         return Symbol(self.name)
 
     def boxes_to_text(self, **options) -> str:
-        return str(self.name)
+        name = str(self.name)
+
+        if "evaluation" in options:
+            e = options["evaluation"]
+            return replace_wl_with_plain_text(name, use_unicode=e.use_unicode)
+        else:
+            return name
+
+    def boxes_to_xml(self, **options) -> str:
+        return replace_wl_with_plain_text(str(self.name))
 
     def atom_to_boxes(self, f, evaluation) -> 'String':
         return String(evaluation.definitions.shorten_name(self.name))
@@ -2528,6 +2537,10 @@ class String(Atom):
             value.startswith('"') and value.endswith('"')):
             value = value[1:-1]
 
+        if "evaluation" in options:
+            e = options["evaluation"]
+            value = replace_wl_with_plain_text(value, e.use_unicode)
+
         return value
 
     def boxes_to_xml(self, show_string_characters=False, **options) -> str:
@@ -2543,7 +2556,7 @@ class String(Atom):
         text = self.value
 
         def render(format, string):
-            encoded_text = encode_mathml(string)
+            encoded_text = encode_mathml(replace_wl_with_plain_text(string))
             return format % encoded_text
 
         if text.startswith('"') and text.endswith('"'):


### PR DESCRIPTION
This is a follow up to https://github.com/orgs/mathics/teams/maintainers/discussions/20/comments/32. This PR makes it so that named characters are only replaced selectively (inside of strings or symbols). This makes calling `replace_wl_with_plain_text` from the clients unnecessary (we only need to set `use_unicode` field of `Evaluation` appropriately). 

After this is merged, PRs to the clients will follow.