### PR TITLE
decoupling from mathics.builtin.builtins

### DIFF
--- a/mathics/builtin/__init__.py
+++ b/mathics/builtin/__init__.py
@@ -43,7 +43,7 @@ for module_name in module_names:
         continue
     modules.append(module)
 
-builtins = []
+_builtins = []
 builtins_by_module = {}
 
 
@@ -75,7 +75,7 @@ for module in modules:
                 # This set the default context for symbols in mathics.builtins
                 if not type(instance).context:
                     type(instance).context = "System`"
-                builtins.append( (instance.get_name(), instance))
+                _builtins.append( (instance.get_name(), instance))
                 builtins_by_module[module.__name__].append(instance)
 
 
@@ -107,12 +107,18 @@ def add_builtins(new_builtins):
             builtins_precedence[name] = builtin.precedence
         if isinstance(builtin, PatternObject):
             pattern_objects[name] = builtin.__class__
-    builtins.update(dict(new_builtins))
+    _builtins.update(dict(new_builtins))
 
 
-new_builtins = builtins
-builtins = {}
+new_builtins = _builtins
+_builtins = {}
 add_builtins(new_builtins)
+
+
+def builtins_dict():
+    return { builtin.get_name() : builtin
+             for modname, builtins in builtins_by_module.items()
+             for builtin in builtins}
 
 
 def get_module_doc(module):
@@ -134,8 +140,8 @@ def get_module_doc(module):
 
 def contribute(definitions):
     # let MakeBoxes contribute first
-    builtins["System`MakeBoxes"].contribute(definitions)
-    for name, item in builtins.items():
+    _builtins["System`MakeBoxes"].contribute(definitions)
+    for name, item in _builtins.items():
         if name != "System`MakeBoxes":
             item.contribute(definitions)
 

--- a/mathics/builtin/assignment.py
+++ b/mathics/builtin/assignment.py
@@ -1751,7 +1751,7 @@ class LoadModule(Builtin):
      : Python module nomodule does not exist.
      = $Failed
     >> LoadModule["sys"]
-     : Python module sys is not a pymathics module.
+     : Python module sys does not exist.
      = $Failed
     """
     name = "LoadModule"

--- a/mathics/builtin/assignment.py
+++ b/mathics/builtin/assignment.py
@@ -1751,7 +1751,7 @@ class LoadModule(Builtin):
      : Python module nomodule does not exist.
      = $Failed
     >> LoadModule["sys"]
-     : Python module sys does not exist.
+     : Python module sys is not a pymathics module.
      = $Failed
     """
     name = "LoadModule"
@@ -1767,9 +1767,6 @@ class LoadModule(Builtin):
             return SymbolFailed
         except ImportError as e:
             evaluation.message(self.get_name(), 'notfound', module)
-            return SymbolFailed
-        except PyMathicsLoadException as e:
-            evaluation.message(self.get_name(), 'notmathicslib', module)
             return SymbolFailed
         else:
         # Add Pymathics` to $ContextPath so that when user don't

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -104,8 +104,7 @@ class Builtin(object):
                 # used, so it won't work.
                 if option not in definitions.builtin:
                     definitions.builtin[option] = Definition(
-                        name=name, attributes=set()
-                    )
+                        name=name, attributes=set())
 
         # Check if the given options are actually supported by the Builtin.
         # If not, we might issue an optx error and abort. Using '$OptionSyntax'
@@ -249,8 +248,7 @@ class Builtin(object):
                 # used, so it won't work.
                 if option not in definitions.builtin:
                     definitions.builtin[option] = Definition(
-                        name=name, attributes=set()
-                    )
+                        name=name, attributes=set())
         defaults = []
         for spec, value in self.defaults.items():
             value = parse_builtin_rule(value)

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -2169,12 +2169,12 @@ class Precedence(Builtin):
     def apply(self, expr, evaluation) -> Real:
         'Precedence[expr_]'
 
-        from mathics.builtin import builtins
-
         name = expr.get_name()
         precedence = 1000
         if name:
-            builtin = builtins.get(name)
+            builtin = evaluation.definitions.get_definition(name, only_if_exists=True)
+            if builtin:
+                builtin = builtin.builtin
             if builtin is not None and isinstance(builtin, Operator):
                 precedence = builtin.precedence
             else:

--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -429,7 +429,7 @@ class PatternTest(BinaryOperator, PatternObject):
         self.test = expr.leaves[1]
         self.test_name = self.test.get_name()
 
-    def quick_pattern_test(self, candidate, test):
+    def quick_pattern_test(self, candidate, test, evaluation):
         if test == 'System`NumberQ':
             return isinstance(candidate, Number)
         elif test == 'System`Negative':
@@ -448,10 +448,11 @@ class PatternTest(BinaryOperator, PatternObject):
                 isinstance(candidate.leaves[1], (Integer, Rational, Real)) and
                 candidate.leaves[1].value < 0)
         else:
-            from mathics.builtin import builtins
             from mathics.builtin.base import Test
-
-            builtin = builtins.get(test)
+            builtin = None
+            builtin = evaluation.definitions.get_definition(test)
+            if builtin:
+                builtin = builtin.builtin
             if builtin is not None and isinstance(builtin, Test):
                 return builtin.test(candidate)
         return None
@@ -462,7 +463,7 @@ class PatternTest(BinaryOperator, PatternObject):
             items = expression.get_sequence()
             for item in items:
                 item = item.evaluate(evaluation)
-                quick_test = self.quick_pattern_test(item, self.test_name)
+                quick_test = self.quick_pattern_test(item, self.test_name, evaluation)
                 if quick_test is not None:
                     if not quick_test:
                         break

--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -407,7 +407,11 @@ class UserName(Predefined):
     name = "$UserName"
 
     def evaluate(self, evaluation) -> String:
-        return String(os.getlogin())
+        try:
+            return String(os.getlogin())
+        except:
+            import pwd
+            return String(pwd.getpwuid(os.getuid())[0])
 
 
 class Version(Predefined):

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -82,13 +82,8 @@ class Definitions(object):
                         )
                     except PyMathicsLoadException as e:
                         raise
-                        # print(e.module + " is not a valid pymathics module.")
-                        #continue
                     except ImportError as e:
                         raise
-                        #print(e.__repr__())
-                        #continue
-                    # print(module + loaded_module.pymathics_version_data['version'] + "  by " + loaded_module.pymathics_version_data['author'])
 
                 if builtin_filename is not None:
                     builtin_file = open(builtin_filename, "wb")
@@ -167,17 +162,13 @@ class Definitions(object):
     def clear_pymathics_modules(self):
         from mathics.builtin import builtins, builtins_by_module
 
-        # Remove all modules that are not in mathics
-        # print("cleaning pymathics modules")
         for key in list(builtins_by_module.keys()):
             if not key.startswith("mathics."):
-                print(f'removing module "{key}" not in mathics.')
                 del builtins_by_module[key]
         for key in pymathics:
             del self.pymathics[key]
 
         self.pymathics = {}
-        # print("everything is clean")
         return None
 
     def clear_cache(self, name=None):
@@ -416,10 +407,14 @@ class Definitions(object):
         builtin = self.builtin.get(name, None)
 
         candidates = [user] if user else []
+        builtin_instance = None
         if pymathics:
+            builtin_instance = pymathics
             candidates.append(pymathics)
         if builtin:
             candidates.append(builtin)
+            if builtin_instance is None:
+                builtin_instance = builtin
 
         definition = candidates[0] if len(candidates)==1 else None
         if len(candidates)>0 and not definition:
@@ -456,6 +451,7 @@ class Definitions(object):
                 options=options,
                 nvalues=sum((c.nvalues for c in candidates),[]),
                 defaultvalues=sum((c.defaultvalues for c in candidates),[]),
+                builtin=builtin_instance
             )
 
         if definition is not None:

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -115,7 +115,7 @@ class Definitions(object):
         from an external Python module in the pymathics module namespace.
         """
         import importlib
-        from mathics.builtin import is_builtin, builtins, builtins_by_module, Builtin
+        from mathics.builtin import is_builtin, builtins_by_module, Builtin
         # Ensures that the pymathics module be reloaded
         import sys
         if module in sys.modules:

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -2561,13 +2561,15 @@ class String(Atom):
 
     def boxes_to_xml(self, show_string_characters=False, **options) -> str:
         from mathics.core.parser import is_symbol_name
-        from mathics.builtin import builtins
+        from mathics.builtin import builtins_by_module
 
         operators = set()
-        for name, builtin in builtins.items():
-            operator = builtin.get_operator_display()
-            if operator is not None:
-                operators.add(operator)
+        for modname, builtins in builtins_by_module.items():
+            for builtin in builtins:
+                # name = builtin.get_name()
+                operator = builtin.get_operator_display()
+                if operator is not None:
+                    operators.add(operator)
 
         text = self.value
 
@@ -2603,13 +2605,15 @@ class String(Atom):
                 return outtext
 
     def boxes_to_tex(self, show_string_characters=False, **options) -> str:
-        from mathics.builtin import builtins
+        from mathics.builtin import builtins_by_module
 
         operators = set()
-        for name, builtin in builtins.items():
-            operator = builtin.get_operator_display()
-            if operator is not None:
-                operators.add(operator)
+
+        for modname, builtins in builtins_by_module.items():
+            for builtin in builtins:
+                operator = builtin.get_operator_display()
+                if operator is not None:
+                    operators.add(operator)
 
         text = self.value
 

--- a/mathics/test.py
+++ b/mathics/test.py
@@ -13,7 +13,9 @@ import mathics
 from mathics.core.definitions import Definitions
 from mathics.core.evaluation import Evaluation, Output
 from mathics.core.parser import MathicsSingleLineFeeder
-from mathics.builtin import builtins
+from mathics.builtin import builtins_dict
+
+builtins = builtins_dict()
 
 from mathics import version_string
 from mathics import settings


### PR DESCRIPTION
This PR has the aim of continuing to remove hard-linked objects in the mathics core. In particular, this removes mathics.builtin.builtins
This dictionary was used in some formating operations, the definition of certain Test symbols, and in the doctest mechanism.  The problem with this comes up when we implemented the pymathics mechanism. Then, to fulfill the functionality of true built-in symbols, the global dictionary should be modified, which also has consequences if we want to make to coexist two instances of MathicsSession objects. 
In any case, with the present changes, this global object would be not necessary anymore. 