### PR TITLE
adding onload hook to pymathics

### DIFF
--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -162,6 +162,12 @@ class Definitions(object):
         for name, item in newsymbols.items():
             if name != "System`MakeBoxes":
                 item.contribute(self, is_pymodule=True)
+
+
+        onload = loaded_module.pymathics_version_data.get("onload", None)
+        if onload:
+            onload(self)
+            
         return loaded_module
 
     def clear_pymathics_modules(self):


### PR DESCRIPTION
The aim of this PR is to add a hook in the pymathics_load function in a way that once a module is loaded, we can add some definitions (for example, adding Import/Export formats) that require access to the Definitions object who is loading the module.