### PR TITLE
Unicode replace strings symbols mmatera

### DIFF
--- a/mathics/builtin/logic.py
+++ b/mathics/builtin/logic.py
@@ -137,7 +137,7 @@ class Implies(BinaryOperator):
     If an expression does not evaluate to 'True' or 'False', 'Implies'
     returns a result in symbolic form:
     >> Implies[a, Implies[b, Implies[True, c]]]
-     = a \uF523 b \uF523 c
+     = a ⟹ b ⟹ c
     """
 
     operator = "\uF523"
@@ -171,7 +171,7 @@ class Equivalent(BinaryOperator):
      If all expressions do not evaluate to 'True' or 'False', 'Equivalent'
      returns a result in symbolic form:
      >> Equivalent[a, b, c]
-      = a \u29E6 b \u29E6 c
+      = a ⇔ b ⇔ c
       Otherwise, 'Equivalent' returns a result in DNF
      >> Equivalent[a, b, True, c]
       = a && b && c

--- a/mathics/core/evaluation.py
+++ b/mathics/core/evaluation.py
@@ -228,7 +228,12 @@ class Output(object):
 
 class Evaluation(object):
     def __init__(
-        self, definitions=None, output=None, format="text", catch_interrupt=True
+            self,
+            definitions=None,
+            output=None,
+            format="text",
+            catch_interrupt=True,
+            use_unicode=True
     ) -> None:
         from mathics.core.definitions import Definitions
         from mathics.core.expression import Symbol
@@ -242,6 +247,7 @@ class Evaluation(object):
         self.stopped = False
         self.out = []
         self.output = output if output else Output()
+        self.use_unicode = use_unicode
         self.listeners = {}
         self.options = None
         self.predetermined_out = None

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -12,6 +12,7 @@ from itertools import chain
 from bisect import bisect_left
 from functools import lru_cache
 
+from mathics_scanner.characters import replace_wl_with_plain_text
 
 from mathics.core.numbers import get_type, dps, prec, min_prec, machine_precision
 from mathics.core.convert import sympy_symbol_prefix, SympyExpression
@@ -1906,7 +1907,16 @@ class Symbol(Atom):
         return Symbol(self.name)
 
     def boxes_to_text(self, **options) -> str:
-        return str(self.name)
+        name = str(self.name)
+
+        if "evaluation" in options:
+            e = options["evaluation"]
+            return replace_wl_with_plain_text(name, use_unicode=e.use_unicode)
+        else:
+            return name
+
+    def boxes_to_xml(self, **options) -> str:
+        return replace_wl_with_plain_text(str(self.name))
 
     def atom_to_boxes(self, f, evaluation) -> "String":
         return String(evaluation.definitions.shorten_name(self.name))
@@ -2725,6 +2735,10 @@ class String(Atom):
         ):
             value = value[1:-1]
 
+        if "evaluation" in options:
+            e = options["evaluation"]
+            value = replace_wl_with_plain_text(value, e.use_unicode)
+
         return value
 
     def boxes_to_xml(self, show_string_characters=False, **options) -> str:
@@ -2742,7 +2756,7 @@ class String(Atom):
         text = self.value
 
         def render(format, string):
-            encoded_text = encode_mathml(string)
+            encoded_text = encode_mathml(replace_wl_with_plain_text(string))
             return format % encoded_text
 
         if text.startswith('"') and text.endswith('"'):

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -1911,12 +1911,22 @@ class Symbol(Atom):
 
         if "evaluation" in options:
             e = options["evaluation"]
+            if e.use_unicode is None:
+                return name
             return replace_wl_with_plain_text(name, use_unicode=e.use_unicode)
         else:
             return name
 
     def boxes_to_xml(self, **options) -> str:
-        return replace_wl_with_plain_text(str(self.name))
+        name = str(self.name)
+
+        if "evaluation" in options:
+            e = options["evaluation"]
+            if e.use_unicode is None:
+                return name            
+            return replace_wl_with_plain_text(name, use_unicode=e.use_unicode)
+        else:
+            return name
 
     def atom_to_boxes(self, f, evaluation) -> "String":
         return String(evaluation.definitions.shorten_name(self.name))
@@ -2737,6 +2747,8 @@ class String(Atom):
 
         if "evaluation" in options:
             e = options["evaluation"]
+            if e.use_unicode is None:
+                return value
             value = replace_wl_with_plain_text(value, e.use_unicode)
 
         return value
@@ -2754,9 +2766,16 @@ class String(Atom):
                     operators.add(operator)
 
         text = self.value
-
+        if "evaluation" in options:
+            use_unicode = options["evaluation"].use_unicode
+        else:
+            use_unicode = None
+            
         def render(format, string):
-            encoded_text = encode_mathml(replace_wl_with_plain_text(string))
+            if use_unicode is None:
+                encoded_text = encode_mathml(string)
+            else:
+                encoded_text = encode_mathml(replace_wl_with_plain_text(string, use_unicode))
             return format % encoded_text
 
         if text.startswith('"') and text.endswith('"'):


### PR DESCRIPTION
This implements some of the changes I think are necessary to make this PR acceptable:
* Always check if `Evaluation.use_unicode` is set to a boolean value, and pass this value to `replace_wl_with_plain_text`
* Allows the possibility to set `Evaluation.use_unicode=None`. In this case, replace_wl_with_plain_text is not called. Now the default is `True`. But if we put `None` as the default, the default behavior would be the current (without this PR).

Something that I didn't implement, but is a possibility, is to accept a function in `use_unicode`, in a way that the control of how the strings are formated be completely determined in the frontends.
