### PR TITLE
Fix missing space on README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ mathicsserver: a Django-based Web interface
 Installing and Running
 ----------------------
 
-See the `readthe docs guide <https://mathics-development-guide.readthedocs.io/en/latest/>`_ for instructions on `installing <https://mathics-development-guide.readthedocs.io/en/latest/installing.html>`_ and `running <https://mathics-development-guide.readthedocs.io/en/latest/running.html>`_.
+See the `read the docs guide <https://mathics-development-guide.readthedocs.io/en/latest/>`_ for instructions on `installing <https://mathics-development-guide.readthedocs.io/en/latest/installing.html>`_ and `running <https://mathics-development-guide.readthedocs.io/en/latest/running.html>`_.
 
 Contributing
 ------------


### PR DESCRIPTION
I was reading the README and I think there is a missing space on `readthe docs guide`.

Feel free to close if this is not the case.