### PR TITLE
mglyph -> mtext broke some images

### DIFF
--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -3226,14 +3226,15 @@ clip(%s);
             svg,
         )
 
-        return (
-            '<mtext><img width="%dpx" height="%dpx" src="data:image/svg+xml;base64,%s"/></mtext>'
-            % (
+        # mglyph, which is what we have been using, is bad because MathML standard changed.
+        # metext does not work beacause the way in which we produce the svg images is also based on this outdated mglyph behaviour.
+        # format = "<mtext><img width="%dpx" height="%dpx" src="data:image/svg+xml;base64,%s"/></mtext>"
+        template = '<mglyph width="%dpx" height="%dpx" src="data:image/svg+xml;base64,%s"/>'
+        return template % (
                 int(width),
                 int(height),
                 base64.b64encode(svg_xml.encode("utf8")).decode("utf8"),
             )
-        )
 
     def axis_ticks(self, xmin, xmax):
         def round_to_zero(value):


### PR DESCRIPTION
@mmatera I used [`git bisect`](https://thoughtbot.com/blog/git-bisect) and tracked the graphics misbehaving to 616dbbae9c9480878c0752488724a74b61640b99  and specificlly the one-line change here. 

What does this change make possible? If we can't figure out something that accomodates both concerns, maybe we can add a setting so both ways are possible.

BTW This PR is the kind of thing I was mentioning about large PR's that are hard to follow. 

The title of  #1173 is "adds FileNames, a symbol required in the FeynCalc package"  and I don't see how this change which is about graphics has anything to do with ByteArray or FileNames. Even the commit message "fix write"  isn't suggestive. 
