### PR TITLE
Fix to svg

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,7 @@ Enhancements
 * Improvements in handling products with infinite factors: ``0 Infinity``-> ``Indeterminate``, and ``expr Infinity``-> ``DirectedInfinite[expr]`.
 * ``SetDelayed`` now accept several conditions impossed both at LHS as well as RHS.
 
+  
 Bug fixes
 +++++++++
 
@@ -53,6 +54,13 @@ Miscellanea
 Windows under MSYS.
 * Include numpy version in version string. Show in CLI
 * Small CLI tweaks ``--colors=None`` added to match mathicsscript.
+* In the ``BaseExpression`` and derivated classes, the method ``boxes_to_xml`` now are called ``boxes_to_mathml``.
+* In the ``format`` method of the class ``Evaluation``,  the builtin ``ToString`` is called instead of  ``boxes_to_text``
+  In order to control the final form of boxes from the user space in specific symbols and contexts.
+* ``GraphicsBox`` now have two methods:  ``to_svg`` and  ``to_mathml``. The first produces SVG plain text while the second produces ``<mglyph ...>``
+  tags with base64 encoded svgs.
+* Improving the support for ``Inset`` and  ``InsetBox``.
+
 
 2.0.0
 -----

--- a/mathics/autoload/formats/SVG/Export.m
+++ b/mathics/autoload/formats/SVG/Export.m
@@ -4,13 +4,17 @@ Begin["System`Convert`TextDump`"]
 
 
 SVGExport[filename_, expr_, opts___] := 
-  Module[{strm, data}, 
+  Module[{strm, data, p, q, expr2}, 
     strm = OpenWrite[filename];
     If[strm === $Failed, Return[$Failed]];
-    If[System`$UseSansSerif,
-	    data = StringTake[ToString[MathMLForm[expr]],{23,-8}],
-	    data = StringTake[ToString[MathMLForm[expr]],{23,-8}]];
-    WriteString[strm, "<svg>" <> data <> "</svg>"];
+    expr2 = If[Head[expr]=!=System`Graphics, System`Graphics[{System`Inset[ToString[expr]]}], expr];
+	 expr2= MathMLForm[expr2];
+    data=ToString[expr2];
+    p = StringPosition[data, "data:image/svg+xml;base64"][[1]][[2]];
+    (*Let's assume that the end of the string is reached just before the last quote. *)
+    q = StringPosition[data,"\""][[-1]][[-2]];
+    data = StringTake[data  ,{p+2,q-1}];
+    WriteString[strm, System`Convert`B64Dump`B64Decode[data]];
     Close[strm];
   ]
 

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -710,7 +710,7 @@ class BoxConstruct(InstanceableBuiltin):
     def boxes_to_text(self, leaves, **options) -> str:
         raise BoxConstructError
 
-    def boxes_to_xml(self, leaves, **options) -> str:
+    def boxes_to_mathml(self, leaves, **options) -> str:
         raise BoxConstructError
 
     def boxes_to_tex(self, leaves, **options) -> str:

--- a/mathics/builtin/compilation.py
+++ b/mathics/builtin/compilation.py
@@ -198,7 +198,7 @@ class CompiledCodeBox(BoxConstruct):
             leaves = self._leaves
         return leaves[0].value
 
-    def boxes_to_xml(self, leaves=None, **options):
+    def boxes_to_mathml(self, leaves=None, **options):
         if leaves is None:
             leaves = self._leaves
         return leaves[0].value

--- a/mathics/builtin/graphics3d.py
+++ b/mathics/builtin/graphics3d.py
@@ -625,7 +625,7 @@ currentlight=light(rgb(0.5,0.5,1), specular=red, (2,0,2), (2,2,2), (0,2,2));
         )
         return tex
 
-    def boxes_to_xml(self, leaves=None, **options):
+    def boxes_to_mathml(self, leaves=None, **options):
         if not leaves:
             leaves = self._leaves
 

--- a/mathics/builtin/image.py
+++ b/mathics/builtin/image.py
@@ -2105,7 +2105,7 @@ class ImageBox(BoxConstruct):
     def boxes_to_text(self, leaves=None, **options):
         return "-Image-"
 
-    def boxes_to_xml(self, leaves=None, **options):
+    def boxes_to_mathml(self, leaves=None, **options):
         if leaves is None:
             leaves = self._leaves
         # see https://tools.ietf.org/html/rfc2397

--- a/mathics/builtin/importexport.py
+++ b/mathics/builtin/importexport.py
@@ -1917,8 +1917,8 @@ class ExportString(Builtin):
      . 2,
      . 3,
      . 4,
-    >> ExportString[Integrate[f[x],{x,0,2}], "SVG"]
-     = ...
+    >> ExportString[Integrate[f[x],{x,0,2}], "SVG"]//Head
+     = String
     """
 
     options = {

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -845,7 +845,7 @@ class GridBox(BoxConstruct):
         result += r"\end{array}"
         return result
 
-    def boxes_to_xml(self, leaves=None, **box_options) -> str:
+    def boxes_to_mathml(self, leaves=None, **box_options) -> str:
         if not leaves:
             leaves = self._leaves
         evaluation = box_options.get("evaluation")
@@ -872,7 +872,7 @@ class GridBox(BoxConstruct):
             for item in row:
                 result += "<mtd {0}>{1}</mtd>".format(
                     joined_attrs,
-                    item.evaluate(evaluation).boxes_to_xml(**new_box_options),
+                    item.evaluate(evaluation).boxes_to_mathml(**new_box_options),
                 )
             result += "</mtr>\n"
         result += "</mtable>"
@@ -2084,7 +2084,7 @@ class MathMLForm(Builtin):
 
         boxes = MakeBoxes(expr).evaluate(evaluation)
         try:
-            xml = boxes.boxes_to_xml(evaluation=evaluation)
+            xml = boxes.boxes_to_mathml(evaluation=evaluation)
         except BoxError:
             evaluation.message(
                 "General",
@@ -2092,12 +2092,15 @@ class MathMLForm(Builtin):
                 Expression("FullForm", boxes).evaluate(evaluation),
             )
             xml = ""
+        is_a_picture = xml[:6] == "<mtext"
+
         # mathml = '<math><mstyle displaystyle="true">%s</mstyle></math>' % xml
         # #convert_box(boxes)
         query = evaluation.parse("System`$UseSansSerif")
         usesansserif = query.evaluate(evaluation).to_python()
-        if usesansserif:
-            xml = '<mstyle mathvariant="sans-serif">%s</mstyle>' % xml
+        if not is_a_picture:
+            if usesansserif:
+                xml = '<mstyle mathvariant="sans-serif">%s</mstyle>' % xml
 
         mathml = '<math display="block">%s</math>' % xml  # convert_box(boxes)
         return Expression("RowBox", Expression(SymbolList, String(mathml)))

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -1468,10 +1468,10 @@ class Expression(BaseExpression):
         else:
             raise BoxError(self, "text")
 
-    def boxes_to_xml(self, **options) -> str:
+    def boxes_to_mathml(self, **options) -> str:
         is_style, options = self.process_style_box(options)
         if is_style:
-            return self._leaves[0].boxes_to_xml(**options)
+            return self._leaves[0].boxes_to_mathml(**options)
         name = self._head.get_name()
         if (
             name == "System`RowBox"
@@ -1510,36 +1510,36 @@ class Expression(BaseExpression):
                 options["inside_row"] = True
 
             for leaf in self._leaves[0].get_leaves():
-                result.append(leaf.boxes_to_xml(**options))
+                result.append(leaf.boxes_to_mathml(**options))
             return "<mrow>%s</mrow>" % " ".join(result)
         else:
             options = options.copy()
             options["inside_row"] = True
             if name == "System`SuperscriptBox" and len(self._leaves) == 2:
                 return "<msup>%s %s</msup>" % (
-                    self._leaves[0].boxes_to_xml(**options),
-                    self._leaves[1].boxes_to_xml(**options),
+                    self._leaves[0].boxes_to_mathml(**options),
+                    self._leaves[1].boxes_to_mathml(**options),
                 )
             if name == "System`SubscriptBox" and len(self._leaves) == 2:
                 return "<msub>%s %s</msub>" % (
-                    self._leaves[0].boxes_to_xml(**options),
-                    self._leaves[1].boxes_to_xml(**options),
+                    self._leaves[0].boxes_to_mathml(**options),
+                    self._leaves[1].boxes_to_mathml(**options),
                 )
             if name == "System`SubsuperscriptBox" and len(self._leaves) == 3:
                 return "<msubsup>%s %s %s</msubsup>" % (
-                    self._leaves[0].boxes_to_xml(**options),
-                    self._leaves[1].boxes_to_xml(**options),
-                    self._leaves[2].boxes_to_xml(**options),
+                    self._leaves[0].boxes_to_mathml(**options),
+                    self._leaves[1].boxes_to_mathml(**options),
+                    self._leaves[2].boxes_to_mathml(**options),
                 )
             elif name == "System`FractionBox" and len(self._leaves) == 2:
                 return "<mfrac>%s %s</mfrac>" % (
-                    self._leaves[0].boxes_to_xml(**options),
-                    self._leaves[1].boxes_to_xml(**options),
+                    self._leaves[0].boxes_to_mathml(**options),
+                    self._leaves[1].boxes_to_mathml(**options),
                 )
             elif name == "System`SqrtBox" and len(self._leaves) == 1:
-                return "<msqrt>%s</msqrt>" % (self._leaves[0].boxes_to_xml(**options))
+                return "<msqrt>%s</msqrt>" % (self._leaves[0].boxes_to_mathml(**options))
             elif name == "System`GraphBox":
-                return "<mi>%s</mi>" % (self._leaves[0].boxes_to_xml(**options))
+                return "<mi>%s</mi>" % (self._leaves[0].boxes_to_mathml(**options))
             else:
                 raise BoxError(self, "xml")
 
@@ -2108,8 +2108,8 @@ class Integer(Number):
     def boxes_to_text(self, **options) -> str:
         return str(self.value)
 
-    def boxes_to_xml(self, **options) -> str:
-        return self.make_boxes("MathMLForm").boxes_to_xml(**options)
+    def boxes_to_mathml(self, **options) -> str:
+        return self.make_boxes("MathMLForm").boxes_to_mathml(**options)
 
     def boxes_to_tex(self, **options) -> str:
         return str(self.value)
@@ -2294,8 +2294,8 @@ class Real(Number):
     def boxes_to_text(self, **options) -> str:
         return self.make_boxes("System`OutputForm").boxes_to_text(**options)
 
-    def boxes_to_xml(self, **options) -> str:
-        return self.make_boxes("System`MathMLForm").boxes_to_xml(**options)
+    def boxes_to_mathml(self, **options) -> str:
+        return self.make_boxes("System`MathMLForm").boxes_to_mathml(**options)
 
     def boxes_to_tex(self, **options) -> str:
         return self.make_boxes("System`TeXForm").boxes_to_tex(**options)
@@ -2727,7 +2727,7 @@ class String(Atom):
 
         return value
 
-    def boxes_to_xml(self, show_string_characters=False, **options) -> str:
+    def boxes_to_mathml(self, show_string_characters=False, **options) -> str:
         from mathics.core.parser import is_symbol_name
         from mathics.builtin import builtins_by_module
 
@@ -2897,7 +2897,7 @@ class ByteArrayAtom(Atom):
     def boxes_to_text(self, **options) -> str:
         return '"' + self.__str__() + '"'
 
-    def boxes_to_xml(self, **options) -> str:
+    def boxes_to_mathml(self, **options) -> str:
         return encode_mathml(String('"' + self.__str__() + '"'))
 
     def boxes_to_tex(self, **options) -> str:

--- a/mathics/test.py
+++ b/mathics/test.py
@@ -25,7 +25,6 @@ MAX_TESTS = 100000  # Number than the total number of tests
 
 logfile = None
 
-
 class TestOutput(Output):
     def max_stored_size(self, settings):
         return None
@@ -44,7 +43,6 @@ def print_and_log(*args):
     print(string)
     if logfile:
         logfile.write(string)
-
 
 def compare(result, wanted):
     if result == wanted:
@@ -106,13 +104,13 @@ def test_case(test, tests, index=0, subindex=0, quiet=False, section=None):
         print("out=-----------------")
         for rr in out:
             for line in rr.text.splitlines():
-                print("  <", line, ">")
+                print("  <",line,">")
         print("wanted_out=-------------------")
         for rr in wanted_out:
             for line in rr.text.splitlines():
-                print("  <", line, ">")
+                print("  <",line,">")
         print("---------------------------------")
-
+    
     if not compare(result, wanted):
         print("result =!=wanted")
         fail_msg = "Result: %s\nWanted: %s" % (result, wanted)
@@ -126,7 +124,7 @@ def test_case(test, tests, index=0, subindex=0, quiet=False, section=None):
     else:
         for got, wanted in zip(out, wanted_out):
             if False:
-                print("got=<", got, "> wanted=<", wanted, ">")
+                print("got=<",got,"> wanted=<",wanted,">")
             if not got == wanted:
                 output_ok = False
                 break
@@ -363,19 +361,11 @@ def main():
         "--version", "-v", action="version", version="%(prog)s " + mathics.__version__
     )
     parser.add_argument(
-        "--sections",
-        "-s",
-        dest="section",
-        metavar="SECTION",
-        help="only test SECTION(s). "
-        "You can list multiple sections by adding a comma (and no space) in between section names.",
+        "--sections", "-s", dest="section", metavar="SECTION", help="only test SECTION(s). "
+        "You can list multiple sections by adding a comma (and no space) in between section names."
     )
     parser.add_argument(
-        "--logfile",
-        "-f",
-        dest="logfilename",
-        metavar="LOGFILENAME",
-        help="stores the output in [logfilename]. ",
+        "--logfile", "-f", dest="logfilename", metavar="LOGFILENAME", help="stores the output in [logfilename]. "
     )
     parser.add_argument(
         "--pymathics",
@@ -438,7 +428,7 @@ def main():
     # If a test for a specific section is called
     # just test it
     if args.logfilename:
-        logfile = open(args.logfilename, "wt")
+        logfile = open(args.logfilename,"wt")
 
     if args.section:
         sections = set(args.section.split(","))
@@ -452,7 +442,9 @@ def main():
             print("Building pymathics documentation object")
             documentation.load_pymathics_doc()
         elif args.doc_only:
-            make_doc(quiet=args.quiet,)
+            make_doc(
+                quiet=args.quiet,
+            )
         else:
             start_at = args.skip + 1
             start_time = datetime.now()

--- a/test/test_custom_boxconstruct.py
+++ b/test/test_custom_boxconstruct.py
@@ -16,7 +16,7 @@ class CustomBoxConstruct(BoxConstruct):
             leaves = self._leaves
         return 'CustomBoxConstruct<<' + self._leaves.__str__()   + '>>'
 
-    def boxes_to_xml(self, leaves=None, **options):
+    def boxes_to_mathml(self, leaves=None, **options):
         if not leaves:
             leaves = self._leaves
         return 'CustomBoxConstruct<<' + self._leaves.__str__()   + '>>'
@@ -60,7 +60,7 @@ class CustomGraphicsBox(BoxConstruct):
     def boxes_to_tex(self, leaves=None, **options):
         return "--custom graphics--: I should plot " + self._leaves.__str__() +" items" 
 
-    def boxes_to_xml(self, leaves=None, **options):
+    def boxes_to_mathml(self, leaves=None, **options):
         return "--custom graphics--: I should plot " + self._leaves.__str__() +" items"
 
     def boxes_to_svg(self, evaluation):
@@ -75,7 +75,7 @@ def test_custom_boxconstruct():
     instance_custom_atom = CustomAtom(expression=False)
     instance_custom_atom.contribute(defs, is_pymodule=True)
     expr = session.evaluate("MakeBoxes[CustomAtom, InputForm]")
-    formatted = session.format_result().boxes_to_xml()
+    formatted = session.format_result().boxes_to_mathml()
     assert formatted == "CustomBoxConstruct<<[1, 2, 3]>>"
 
 
@@ -85,5 +85,5 @@ def test_custom_graphicsbox_constructor():
     instance_customgb_atom = CustomGraphicsBox(expression=False, evaluation=session.evaluation)
     instance_customgb_atom.contribute(defs, is_pymodule=True)
     expr = session.evaluate("MakeBoxes[Graphics[{Circle[{0,0},1]}], OutputForm]")
-    formatted = session.format_result().boxes_to_xml()
+    formatted = session.format_result().boxes_to_mathml()
     assert formatted == "--custom graphics--: I should plot (<Expression: System`Circle[System`List[0, 0], 1]>,) items"


### PR DESCRIPTION
This PR fixes 
* the internal generation of SVG images from the internal generator (to_svg) including text inside (like labels)
* the Export of graphics (and symbols) to a valid SVG.
This is achieved by using `boxes_to_text` instead of `boxes_to_xml` in the `InsetBox.to_svg` method. 

This still does not fixes the issue with the Django's interface: if we use `<mtext><img ...><\mtext>`, images are not properly bounded in the front end. On the other hand, this trick does not helps if we use `<mglyph ...>`: boundaries are correct in this case, but labels does not appears. I keep this last form, that can be handled making small modifications to `mathics.js` in the Django frontend (the change in  the corresponding PR).


![image](https://user-images.githubusercontent.com/2862288/113045363-22718c00-9175-11eb-9cd4-321fbfae208b.png)







