### PR TITLE
`StringSplit`: adding support for handling lists as a first argument

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,7 @@ Enhancements
   as a Python function.
 * ``Equal[]`` now compares complex against other numbers properly.
 * Improvements in handling products with infinite factors: ``0 Infinity``-> ``Indeterminate``, and ``expr Infinity``-> ``DirectedInfinite[expr]``
+* `StringSplit` not support lists as a first argument.
 
 Bug fixes
 +++++++++

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,7 +27,7 @@ Enhancements
   as a Python function.
 * ``Equal[]`` now compares complex against other numbers properly.
 * Improvements in handling products with infinite factors: ``0 Infinity``-> ``Indeterminate``, and ``expr Infinity``-> ``DirectedInfinite[expr]``
-* `StringSplit` not support lists as a first argument.
+* `StringSplit` now supports lists as a first argument.
 * ``SetDelayed`` now accept several conditions impossed both at LHS as well as RHS.
 
 Bug fixes

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -868,7 +868,7 @@ class StringSplit(Builtin):
         <dd>splits $s$ at the delimiter $d$.
     <dt>'StringSplit[$s$, {"$d1$", "$d2$", ...}]'
         <dd>splits $s$ using multiple delimiters.
-    <dt>'StringSplit[{$s_1$, $s_2, $\ldots$}, {"$d1$", "$d2$", ...}]'
+    <dt>'StringSplit[{$s_1$, $s_2, ...}, {"$d1$", "$d2$", ...}]'
         <dd>returns a list with the result of applying the function to 
             each element.
     </dl>

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -868,6 +868,9 @@ class StringSplit(Builtin):
         <dd>splits $s$ at the delimiter $d$.
     <dt>'StringSplit[$s$, {"$d1$", "$d2$", ...}]'
         <dd>splits $s$ using multiple delimiters.
+    <dt>'StringSplit[{$s_1$, $s_2, $\ldots$}, {"$d1$", "$d2$", ...}]'
+        <dd>returns a list with the result of applying the function to 
+            each element.
     </dl>
 
     >> StringSplit["abc,123", ","]
@@ -884,6 +887,9 @@ class StringSplit(Builtin):
 
     >> StringSplit["a  b    c", RegularExpression[" +"]]
      = {a, b, c}
+
+    >> StringSplit[{"a  b", "c  d"}, RegularExpression[" +"]]
+     = {{a, b}, {c, d}}
 
     #> StringSplit["x", "x"]
      = {}
@@ -921,6 +927,11 @@ class StringSplit(Builtin):
 
     def apply(self, string, patt, evaluation, options):
         "StringSplit[string_, patt_, OptionsPattern[%(name)s]]"
+
+        if string.get_head_name() == "System`List":
+            leaves = [self.apply(s, patt, evaluation, options) for s in string._leaves]
+            return Expression("List", *leaves)
+
         py_string = string.get_string_value()
 
         if py_string is None:


### PR DESCRIPTION
From #1199