### PR TITLE
Start to more Handle FindRoot forms...

### DIFF
--- a/mathics/builtin/calculus.py
+++ b/mathics/builtin/calculus.py
@@ -1101,6 +1101,7 @@ class FindRoot(Builtin):
 
     rules = {
         "FindRoot[lhs_ == rhs_, {x_, xs_}]": "FindRoot[lhs - rhs, {x, xs}]",
+        "FindRoot[lhs_ == rhs_, x__]": "FindRoot[lhs - rhs, x]",
     }
 
     def apply(self, f, x, x0, evaluation):
@@ -1150,3 +1151,17 @@ class FindRoot(Builtin):
             evaluation.message("FindRoot", "maxiter")
 
         return Expression(SymbolList, Expression(SymbolRule, x, x0))
+
+    def apply_with_x_tuple(self, f, xtuple, evaluation):
+        "FindRoot[f_, xtuple_]"
+        f_val = f.evaluate(evaluation)
+
+        # This is not seem quite right.
+        if f_val.get_head_name() == "System`Equal":
+            f = Expression("Minus", *f_val.leaves)
+
+        xtuple_value = xtuple.evaluate(evaluation)
+        if xtuple_value.has_form("List", 2):
+            x, x0 = xtuple.evaluate(evaluation).leaves
+            return self.apply(f, x, x0, evaluation)
+        return

--- a/mathics/builtin/calculus.py
+++ b/mathics/builtin/calculus.py
@@ -1156,8 +1156,7 @@ class FindRoot(Builtin):
         "FindRoot[f_, xtuple_]"
         f_val = f.evaluate(evaluation)
 
-        # This is not seem quite right.
-        if f_val.get_head_name() == "System`Equal":
+        if f_val.has_form("Equal", 2):
             f = Expression("Minus", *f_val.leaves)
 
         xtuple_value = xtuple.evaluate(evaluation)

--- a/test/test_calculus.py
+++ b/test/test_calculus.py
@@ -24,5 +24,10 @@ def test_calculus():
             "{{a -> 1}}",
             "Issue #1168",
         ),
+        (
+            "v1 := Exp[x] - 3x; v2 = {x, 2}; FindRoot[v1, v2]",
+            "{x->1.51213}",
+            "Issue #1235",
+        ),
     ):
         check_evaluation(str_expr, str_expected, message)


### PR DESCRIPTION
In particular where the second parameter is a variable containing a list of two items, _x_,  _x0_. 

We are still failing when the 1st parameter is a variable expression involving `Equal[]`.

See #1235