### PR TITLE
Handle Compress/Uncompress checks better..

### DIFF
--- a/test/helper.py
+++ b/test/helper.py
@@ -1,18 +1,30 @@
+# -*- coding: utf-8 -*-
 import time
-from mathics.core.parser import parse, MathicsSingleLineFeeder
-from mathics.core.definitions import Definitions
-from mathics.core.evaluation import Evaluation
 from mathics.session import MathicsSession
 
 session = MathicsSession(add_builtin=True, catch_interrupt=False)
 
-def check_evaluation(str_expr: str, str_expected: str, message=""):
-    """Helper function to test that a WL expression against
+
+def check_evaluation(
+    str_expr: str,
+    str_expected: str,
+    message="",
+    to_string_expr=True,
+    to_string_expected=True,
+):
+    """Helper function to test Mathics expression against
     its results"""
-    result = session.evaluate("ToString[" + str_expr + "]").value
-    print("result=",result)
-    expected = session.evaluate("ToString[" + str_expected + "]").value
-    print("expected=",expected)
+    if to_string_expr:
+        str_expr = f'ToString[{str_expr}]'
+    if to_string_expected:
+        str_expected = f'ToString[{str_expected}]'
+    # print(str_expr)
+    # print(str_expected)
+
+    result = session.evaluate(str_expr).value
+    print("result=", result)
+    expected = session.evaluate(str_expected).value
+    print("expected=", expected)
     print(time.asctime())
     print(message)
     if message:

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -4,7 +4,6 @@ from mathics.core.parser import parse, MathicsSingleLineFeeder
 from mathics.core.definitions import Definitions
 from mathics.core.evaluation import Evaluation
 import pathlib
-import os
 import sys
 
 
@@ -17,23 +16,13 @@ def _evaluate(str_expression):
     return expr.evaluate(evaluation)
 
 
-# FIXME: see if we can refine this better such as
-# by running some Python code and looking for a failure.
-limited_characterset = (
-    sys.platform
-    not in {
-        "win32",
-    }
-    and not os.environ.get("CI")
-)
-if limited_characterset:
-
-    def test_non_win32_compress():
-        for str_expr, str_expected, message in (
-            (r'Compress[" "]', '"eJxTetQwVQkABwMCPA=="', ""),
-            (r'Uncompress["eJxTetQwVQkABwMCPA=="]', r'" "', ""),
-        ):
-            check_evaluation(str_expr, str_expected, message)
+def test_compress():
+    for text in ("", "abc", " "):
+        str_expr = f'Uncompress[Compress["{text}"]]'
+        str_expected = f'"{text}"'
+        check_evaluation(
+            str_expr, str_expected, to_string_expr=False, to_string_expected=False
+        )
 
 
 def test_unprotected():


### PR DESCRIPTION
That is, in a way that doesn't depend on OS characteristics or
specifics of how Compress compresses things.

Simplify test/helper.py and remove unused imports.

BTW: I think ToString should be the exception not the rule.
In other words the defaults to_string_expr and to_string_expected should
be opposite of what it currently is.