### PR TITLE
ColorNegate support for colors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ New builtins
 Enhancements
 ++++++++++++
 
+* ``ColorNegate`` for colors is supported.
 * ``D`` and ``Derivative`` improvements.
 * ``Table`` [*expr*, *n*] is supported.
 * ``ToString`` accepts an optional *form* parameter.

--- a/mathics/builtin/image.py
+++ b/mathics/builtin/image.py
@@ -1444,14 +1444,30 @@ class Binarize(_SkimageBuiltin):
 class ColorNegate(_ImageBuiltin):
     """
     <dl>
-    <dt>'ColorNegate[$image$]'
-      <dd>Gives a version of $image$ with all colors negated.
+      <dt>'ColorNegate[$image$]'
+      <dd>returns the negative of $image$ in which colors have been negated.
+
+      <dt>'ColorNegate[$color$]'
+      <dd>returns the negative of a color.
+
+      Yellow is RGBColor[1.0, 1.0, 0.0]
+      >> ColorNegate[Yellow]
+       = RGBColor[0., 0., 1.]
     </dl>
     """
 
-    def apply(self, image, evaluation):
+    def apply_for_image(self, image, evaluation):
         "ColorNegate[image_Image]"
         return image.filter(lambda im: PIL.ImageOps.invert(im))
+
+    def apply_for_color(self, color, evaluation):
+        "ColorNegate[color_RGBColor]"
+        # Get components
+        r, g, b = [leaf.to_python() for leaf in color.leaves]
+        # Invert
+        r, g, b = (1.0 - r, 1.0 - g, 1.0 - b)
+        # Reconstitute
+        return Expression("RGBColor", Real(r), Real(g), Real(b))
 
 
 class ColorSeparate(_ImageBuiltin):


### PR DESCRIPTION
As part of my advocacy campaign, I have been adding to the default list of worksheets in the Omnibus Image the examples from "An Elementary Introduction to the Wolfram Language". 

I came across this from https://www.wolfram.com/language/elementary-introduction/2nd-ed/07-colors-and-styles.html and this is an easy fix.

Also as part of advocacy I added Mathics to https://en.wikipedia.org/wiki/List_of_computer_algebra_systems