### PR TITLE
Add Cylinder

### DIFF
--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -29,7 +29,6 @@ from mathics.core.expression import (
     SymbolList,
     SymbolN,
     SymbolMakeBoxes,
-    strip_context,
     system_symbols,
     system_symbols_dict,
     from_python,
@@ -3716,20 +3715,21 @@ class Large(Builtin):
 
 element_heads = frozenset(
     system_symbols(
-        "Rectangle",
-        "Disk",
-        "Line",
         "Arrow",
-        "FilledCurve",
         "BezierCurve",
-        "Point",
         "Circle",
-        "Polygon",
-        "RegularPolygon",
+        "Cylinder",
+        "Disk",
+        "FilledCurve",
         "Inset",
-        "Text",
+        "Line",
+        "Point",
+        "Polygon",
+        "Rectangle",
+        "RegularPolygon",
         "Sphere",
         "Style",
+        "Text",
     )
 )
 

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -1440,10 +1440,12 @@ class _ArcBox(_RoundBox):
 
 
 class DiskBox(_ArcBox):
+    """Internal Python class used when Boxing a in 2D a 'Disk'."""
     face_element = True
 
 
 class CircleBox(_ArcBox):
+    """Internal Python class used when Boxing in 2D 'Circle'."""
     face_element = False
 
 


### PR DESCRIPTION
Apparently even the way old version of Three.js we have supports cylinders. 

There will be a change on the Mathics-Django side as well. 

Haven't considered asymptote or TeX yet though. 

Feel free to just make commits on top of this.