### PR TITLE
Set with OneIdentity LHS

### DIFF
--- a/mathics/builtin/assignment.py
+++ b/mathics/builtin/assignment.py
@@ -159,7 +159,6 @@ class _SetOperator(object):
         message = False
 
         allow_custom_tag = False
-
         focus = lhs
 
         if name == "System`N":
@@ -205,8 +204,12 @@ class _SetOperator(object):
         else:
             allow_custom_tag = True
 
+        # TODO: the following provides a hacky fix for 1259. I know @rocky loves
+        # this kind of things, but otherwise we need to work on rebuild the pattern
+        # matching mechanism...
+        evaluation.ignore_oneidentity = True
         focus = focus.evaluate_leaves(evaluation)
-
+        evaluation.ignore_oneidentity = False
         if tags is None and not upset:
             name = focus.get_lookup_name()
             if not name:
@@ -374,7 +377,6 @@ class _SetOperator(object):
             ),
             Expression("OptionValue", lhs.get_head(), Symbol("$cond$")),
         )
-
         rhs_name = rhs.get_head_name()
         while rhs_name == "System`Condition":
             if len(rhs.leaves) != 2:
@@ -394,7 +396,6 @@ class _SetOperator(object):
                 lhs,
                 condition.leaves[1].apply_rules([rulopc], evaluation)[0],
             )
-
         rule = Rule(lhs, rhs)
         count = 0
         defs = evaluation.definitions
@@ -425,7 +426,6 @@ class _SetOperator(object):
                     defs.add_rule(tag, rule)
         if count == 0:
             return False
-
         return True
 
     def assign(self, lhs, rhs, evaluation):

--- a/mathics/core/evaluation.py
+++ b/mathics/core/evaluation.py
@@ -255,6 +255,9 @@ class Evaluation(object):
         # status of last evaluate
         self.exc_result = self.SymbolNull
         self.last_eval = None
+        # Necesary to handle OneIdentity on
+        # lhs in assignment
+        self.ignore_oneidentity = False
 
     def parse(self, query):
         "Parse a single expression and print the messages."

--- a/mathics/core/pattern.py
+++ b/mathics/core/pattern.py
@@ -293,6 +293,7 @@ class ExpressionPattern(Pattern):
                 return
         if (
             wrap_oneid
+            and not evaluation.ignore_oneidentity
             and "System`OneIdentity" in attributes
             and expression.get_head() != self.head  # nopep8
             and expression != self.head

--- a/test/helper.py
+++ b/test/helper.py
@@ -27,7 +27,6 @@ def check_evaluation(
         expected = session.evaluate(str_expected)
 
     print(time.asctime())
-    print(message)
     if message:
         print((result, expected))
         assert result == expected, message

--- a/test/test_assignment.py
+++ b/test/test_assignment.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from .helper import check_evaluation
+import pytest
+
+from mathics_scanner.errors import IncompleteSyntaxError
+
+
+
+str_test_set_with_oneidentity = """
+SetAttributes[SUNIndex, {OneIdentity}];
+SetAttributes[SUNFIndex, {OneIdentity}];
+
+SUNIndex[SUNFIndex[___]]:=
+	(Print["This error shouldn't be triggered here!"];
+	Abort[]);
+
+SUNFIndex[SUNIndex[___]]:=
+	(Print["This error shouldn't be triggered here!"];
+	Abort[]);
+
+SUNIndex /: MakeBoxes[SUNIndex[p_], TraditionalForm]:=ToBoxes[p, TraditionalForm];
+
+SUNFIndex /: MakeBoxes[SUNFIndex[p_], TraditionalForm]:=ToBoxes[p, TraditionalForm];
+"""
+
+
+def test_setdelayed_oneidentity():
+    expr = ""
+    for line in str_test_set_with_oneidentity.split("\n"):
+        if line in ("", "\n"):
+            continue
+        expr = expr + line
+        try:
+            check_evaluation(expr, "Null", to_string_expr=False, to_string_expected=False)
+            expr = ""
+        except IncompleteSyntaxError:
+            continue


### PR DESCRIPTION
This should fix #1259. @rocky, I know that this adds more "hackiness" to the method `assign_elementary`, but other solutions would require a huge re-factory of the Pattern matching system.

Once we have a working version of `assign_elementary` that covers all these weird special cases, I promise to start with the re- factory.