### PR TITLE
basic implementation of ConditionalExpression, Assuming and

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ New builtins
 
 * ``Arg``
 * ``Dispatch``
+* ``FullSimplify``
 * ``LetterNumber`` #1298. The ``alphabet`` parameter supports only a minimal number of languages.
 * ``Nand`` and ``Nor`` logical functions.
 * ``Series``,  ``O`` and ``SeriesData``
@@ -21,19 +22,23 @@ New builtins
 Enhancements
 ++++++++++++
 
+* a function `evaluate_predicate` allows for a basic predicate evaluation using `$Assumptions`.
 * ``Attributes`` accepts a string parameter.
 * ``ColorNegate`` for colors is supported.
 * ``D`` and ``Derivative`` improvements.
 * ``FileNames`` returns a sorted list (#1250).
 * ``FindRoot`` now receives several optional parameters like ``Method`` and ``MaxIterations``.
-* ``FixedPoint`` now supports the ``SameTest`` option.
+* ``FixedPoint`` now supports the ``SameTest`` option.  
 * ``Prime`` and ``PrimePi`` now accept a list parameter and have the ``NumericFunction`` attribute.
 * ``ReplaceRepeated`` and ``FixedPoint`` now supports the ``MaxIteration`` option (#1260).
+* ``Simplify`` performs a more sophisticated set of simplifications.
+* ``Simplify`` accepts a second parameter that temporarily overwrites ``$Assumptions``.
 * ``StringTake`` now accepts form containing a list of strings and specification (#1297).
 * ``Table`` [*expr*, *n*] is supported.
 * ``ToString`` accepts an optional *form* parameter.
 * ``ToExpression`` handles multi-line string input
 * The implementation of Streams was redone.
+  
 
 
 Bug fixes

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -42,13 +42,16 @@ from mathics.core.expression import (
     SymbolFalse,
     SymbolUndefined,
     SymbolSequence,
+    SymbolList,
     from_mpmath,
     from_python,
 )
 from mathics.core.numbers import min_prec, dps, SpecialValueError
 
 from mathics.builtin.lists import _IterationFunction
-from mathics.core.convert import from_sympy, SympyExpression
+from mathics.core.convert import from_sympy, SympyExpression, sympy_symbol_prefix
+from mathics.builtin.scoping import dynamic_scoping
+from mathics.builtin.inference import get_assumptions_list, evaluate_predicate
 
 
 @lru_cache(maxsize=1024)
@@ -741,7 +744,7 @@ class Times(BinaryOperator, SympyFunction):
         elif number.sameQ(Integer(-1)) and leaves and leaves[0].has_form("Plus", None):
             leaves[0] = Expression(
                 leaves[0].get_head(),
-                *[Expression("Times", Integer(-1), leaf) for leaf in leaves[0].leaves]
+                *[Expression("Times", Integer(-1), leaf) for leaf in leaves[0].leaves],
             )
             number = None
 
@@ -1298,12 +1301,26 @@ class Abs(_MPMathFunction):
 
 class Arg(_MPMathFunction):
     """
-    <dl>
-    <dt>'Arg[$z$]'
-        <dd>returns the argument of a complex value $z$.
-    </dl>
-    >> Arg[-3]
-     = Pi
+     <dl>
+       <dt>'Arg'[$z$, $method_option$]</dt>
+       <dd>returns the argument of a complex value $z$.</dd>
+
+       <ul>
+         <li>'Arg'[$z$] is left unevaluated if $z$ is not a numeric quantity.
+         <li>'Arg'[$z$] gives the phase angle of $z$ in radians.
+         <li>The result from 'Arg'[$z$] is always between -Pi and +Pi.
+         <li>'Arg'[$z$] has a branch cut discontinuity in the complex $z$ plane running from -Infinity to 0.
+         <li>'Arg'[0] is 0.
+      </ul>
+     </dl>
+
+     >> Arg[-3]
+      = Pi
+
+     Same as above using sympy's method:
+     >> Arg[-3, Method->"sympy"]
+      = Pi
+
     >> Arg[1-I]
      = -Pi / 4
 
@@ -1313,14 +1330,39 @@ class Arg(_MPMathFunction):
      = Pi / 4
     >> Arg[DirectedInfinity[]]
      = 1
+    Arg for 0 is assumed to be 0:
+    >> Arg[0]
+     = 0
     """
-    rules = {"Arg[DirectedInfinity[]]": "1",
-             "Arg[DirectedInfinity[a_]]": "Arg[a]",
+    rules = {
+        "Arg[0]": "0",
+        "Arg[DirectedInfinity[]]": "1",
+        "Arg[DirectedInfinity[a_]]": "Arg[a]",
     }
-    attributes = ("Listable", "NumericFunction")
 
+    attributes = ("Listable", "NumericFunction")
+    options = {"Method": "Automatic"}
+
+    numpy_name = "angle" # for later
     mpmath_name = "arg"
     sympy_name = "arg"
+
+    def apply(self, z, evaluation, options={}):
+        "%(name)s[z_, OptionsPattern[%(name)s]]"
+        if Expression("PossibleZeroQ", z).evaluate(evaluation) == SymbolTrue:
+            return Integer0
+        preference = self.get_option(options, "Method", evaluation).get_string_value()
+        if preference is None or preference == "Automatic":
+            return super(Arg, self).apply(z, evaluation)
+        elif preference == "mpmath":
+            return _MPMathFunction.apply(self, z, evaluation)
+        elif preference == "sympy":
+            return SympyFunction.apply(self, z)
+        # TODO: add NumpyFunction
+        evaluation.message(
+            "meth", f'Arg Method {preference} not in ("sympy", "mpmath")'
+        )
+        return
 
 
 class Sign(SympyFunction):
@@ -2183,7 +2225,7 @@ class Piecewise(SympyFunction):
     ## Piecewise({{0, Or[x < 0, x > 0]}}, Indeterminate).
 
     >> Integrate[Piecewise[{{1, x <= 0}, {-1, x > 0}}], x]
-     = Piecewise[{{x, x <= 0}, {-x, True}}]
+     = Piecewise[{{x, x <= 0}}, -x]
 
     >> Integrate[Piecewise[{{1, x <= 0}, {-1, x > 0}}], {x, -1, 2}]
      = -1
@@ -2205,15 +2247,18 @@ class Piecewise(SympyFunction):
 
     def apply(self, items, evaluation):
         "%(name)s[items__]"
-        result = self.to_sympy(Expression("Piecewise", *items.get_sequence()))
+        result = self.to_sympy(Expression("Piecewise", *items.get_sequence()),
+                               evaluation=evaluation
+        )
         if result is None:
             return
         if not isinstance(result, sympy.Piecewise):
-            return from_sympy(result)
+            result = from_sympy(result)
+            return result
 
     def to_sympy(self, expr, **kwargs):
         leaves = expr.leaves
-
+        evaluation = kwargs.get("evaluation", None)
         if len(leaves) not in (1, 2):
             return
 
@@ -2224,6 +2269,8 @@ class Piecewise(SympyFunction):
             if len(case.leaves) != 2:
                 return
             then, cond = case.leaves
+            if evaluation:
+                cond = evaluate_predicate(cond, evaluation)
 
             sympy_cond = None
             if isinstance(cond, Symbol):
@@ -2281,11 +2328,11 @@ class Boole(Builtin):
 
 class Assumptions(Predefined):
     """
-    <dl>
-    <dt>'$Assumptions'
-      <dd>is the default setting for the Assumptions option used in such
-   functions as Simplify, Refine, and Integrate.
-    </dl>
+     <dl>
+     <dt>'$Assumptions'
+       <dd>is the default setting for the Assumptions option used in such
+    functions as Simplify, Refine, and Integrate.
+     </dl>
     """
 
     name = "$Assumptions"
@@ -2299,63 +2346,49 @@ class Assuming(Builtin):
     """
     <dl>
     <dt>'Assuming[$cond$, $expr$]'
-      <dd>Evaluates $expr$ assuming the conditions $cond$
+      <dd>Evaluates $expr$ assuming the conditions $cond$.
     </dl>
     >> $Assumptions = { x > 0 }
      = {x > 0}
-    >> Assuming[y>0, $Assumptions]
-     = {x > 0, y > 0}
+    >> Assuming[y>0, ConditionalExpression[y x^2, y>0]//Simplify]
+     = x ^ 2 y
+    >> Assuming[Not[y>0], ConditionalExpression[y x^2, y>0]//Simplify]
+     = Undefined
+    >> ConditionalExpression[y x ^ 2, y > 0]//Simplify
+     = ConditionalExpression[x ^ 2 y, y > 0]
     """
 
     attributes = ("HoldRest",)
 
-    def apply_assuming(self, cond, expr, evaluation):
-        "Assuming[cond_, expr_]"
-        cond = cond.evaluate(evaluation)
-        if cond.is_true():
+    def apply_assuming(self, assumptions, expr, evaluation):
+        "Assuming[assumptions_, expr_]"
+        assumptions = assumptions.evaluate(evaluation)
+        if assumptions.is_true():
             cond = []
-        elif cond.is_symbol() or not cond.has_form("List", None):
-            cond = [cond]
+        elif assumptions.is_symbol() or not assumptions.has_form("List", None):
+            cond = [assumptions]
         else:
-            cond = cond.leaves
-        assumptions = evaluation.definitions.get_definition(
-            "System`$Assumptions", only_if_exists=True
+            cond = assumptions._leaves
+        cond = tuple(cond) + get_assumptions_list(evaluation)
+        list_cond = Expression("List", *cond)
+        # TODO: reduce the list of predicates
+        return dynamic_scoping(
+            lambda ev: expr.evaluate(ev), {"System`$Assumptions": list_cond}, evaluation
         )
-
-        if assumptions:
-            assumptions = assumptions.ownvalues
-            if len(assumptions) > 0:
-                assumptions = assumptions[0].replace
-            else:
-                assumptions = None
-        if assumptions:
-            if assumptions.is_symbol() or not assumptions.has_form("List", None):
-                assumptions = [assumptions]
-            else:
-                assumptions = assumptions.leaves
-            cond = assumptions + tuple(cond)
-        Expression(
-            "Set", Symbol("System`$Assumptions"), Expression("List", *cond)
-        ).evaluate(evaluation)
-        ret = expr.evaluate(evaluation)
-        if assumptions:
-            Expression(
-                "Set", Symbol("System`$Assumptions"), Expression("List", *assumptions)
-            ).evaluate(evaluation)
-        else:
-            Expression(
-                "Set", Symbol("System`$Assumptions"), Expression("List", SymbolTrue)
-            ).evaluate(evaluation)
-        return ret
 
 
 class ConditionalExpression(Builtin):
     """
     <dl>
-    <dt>'ConditionalExpression[$expr$, $cond$]'
-      <dd>returns $expr$ if $cond$ evaluates to $True$, $Undefined$ if
-          $cond$ evaluates to $False$.
+      <dt>'ConditionalExpression[$expr$, $cond$]'
+      <dd>returns $expr$ if $cond$ evaluates to $True$, $Undefined$ if $cond$ evaluates to $False$.
     </dl>
+
+    >> ConditionalExpression[x^2, True]
+     = x ^ 2
+
+     >> ConditionalExpression[x^2, False]
+     = Undefined
 
     >> f = ConditionalExpression[x^2, x>0]
      = ConditionalExpression[x ^ 2, x > 0]
@@ -2363,16 +2396,36 @@ class ConditionalExpression(Builtin):
      = 4
     >> f /. x -> -2
      = Undefined
+    'ConditionalExpression' uses assumptions to evaluate the condition:
+    >> $Assumptions = x > 0;
+    >> ConditionalExpression[x ^ 2, x>0]//Simplify
+     = x ^ 2
+    >> $Assumptions = True;
+    # >> ConditionalExpression[ConditionalExpression[s,x>a], x<b]
+    # = ConditionalExpression[s, And[x>a, x<b]]
     """
+
+    sympy_name = "Piecewise"
 
     rules = {
         "ConditionalExpression[expr_, True]": "expr",
         "ConditionalExpression[expr_, False]": "Undefined",
+        "ConditionalExpression[ConditionalExpression[expr_, cond1_], cond2_]": "ConditionalExpression[expr, And@@Flatten[{cond1, cond2}]]",
+        "ConditionalExpression[expr1_, cond_] + expr2_": "ConditionalExpression[expr1+expr2, cond]",
+        "ConditionalExpression[expr1_, cond_]  expr2_": "ConditionalExpression[expr1 expr2, cond]",
+        "ConditionalExpression[expr1_, cond_]^expr2_": "ConditionalExpression[expr1^expr2, cond]",
+        "expr1_ ^ ConditionalExpression[expr2_, cond_]": "ConditionalExpression[expr1^expr2, cond]",
     }
 
     def apply_generic(self, expr, cond, evaluation):
         "ConditionalExpression[expr_, cond_]"
-        cond = cond.evaluate(evaluation)
+        # What we need here is a way to evaluate
+        # cond as a predicate, using assumptions.
+        # Let's delegate this to the And (and Or) symbols...
+        if not cond.is_atom() and cond._head == SymbolList:
+            cond = Expression("System`And", *(cond._leaves))
+        else:
+            cond = Expression("System`And", cond)
         if cond is None:
             return
         if cond.is_true():
@@ -2380,3 +2433,26 @@ class ConditionalExpression(Builtin):
         if cond == SymbolFalse:
             return SymbolUndefined
         return
+
+    def to_sympy(self, expr, **kwargs):
+        leaves = expr.leaves
+        if len(leaves) != 2:
+            return
+        expr, cond = leaves
+
+        sympy_cond = None
+        if isinstance(cond, Symbol):
+            if cond == SymbolTrue:
+                sympy_cond = True
+            elif cond == SymbolFalse:
+                sympy_cond = False
+        if sympy_cond is None:
+            sympy_cond = cond.to_sympy(**kwargs)
+            if not (sympy_cond.is_Relational or sympy_cond.is_Boolean):
+                return
+
+        sympy_cases = (
+            (expr.to_sympy(**kwargs), sympy_cond),
+            (sympy.Symbol(sympy_symbol_prefix + "System`Undefined"), True),
+        )
+        return sympy.Piecewise(*sympy_cases)

--- a/mathics/builtin/datentime.py
+++ b/mathics/builtin/datentime.py
@@ -147,7 +147,7 @@ if sys.platform != "win32":
          = TimeConstrained[Integrate[Sin[x] ^ 3, x], a]
 
         >> a=1; s
-        = -Cos[x] + Cos[x] ^ 3 / 3
+        =  Cos[x] (-5 + Cos[2 x]) / 6
 
         Possible issues: for certain time-consuming functions (like simplify)
         which are based on sympy or other libraries, it is possible that

--- a/mathics/builtin/inference.py
+++ b/mathics/builtin/inference.py
@@ -1,0 +1,57 @@
+from mathics.version import __version__  # noqa used in loading to check consistency.
+from mathics.core.expression import (
+    Expression,
+    Symbol,
+    SymbolTrue,
+    SymbolFalse,
+)
+
+from mathics.core.rules import Rule
+from mathics.core.parser.util import SystemDefinitions
+
+from mathics.core.parser import parse_builtin_rule
+
+# TODO: Extend these rules?
+
+
+
+def get_assumptions_list(evaluation): 
+    assumptions = None
+    assumptions_def = evaluation.definitions.get_definition(
+        "System`$Assumptions", only_if_exists=True
+    )
+    if assumptions_def:
+        assumptions = assumptions_def.ownvalues
+        if len(assumptions) > 0:
+            assumptions = assumptions[0].replace
+    if assumptions is None:
+        return None
+
+    if assumptions.is_atom() or not assumptions.has_form("List", None):
+        assumptions = (assumptions,)
+    else:
+        assumptions = assumptions._leaves
+
+    return assumptions
+
+
+
+def evaluate_predicate(pred, evaluation):
+    if pred.has_form(("List", "Sequence"), None):
+        return Expression(pred._head,  *[evaluate_predicate(subp, evaluation) for subp in pred._leaves]  )
+    assumptions = get_assumptions_list(evaluation)
+
+    assumption_rules = []
+    for assumption in assumptions:
+        true_state = True
+        while assumption.has_form("Not",1):
+            true_state = False
+            assumption = assumption._leaves[0]
+        if true_state:
+            assumption_rules.append(Rule(assumption, SymbolTrue))
+        else:
+            assumption_rules.append(Rule(assumption, SymbolFalse))
+    
+    pred, changed = pred.apply_rules(assumption_rules, evaluation)
+    pred = pred.evaluate(evaluation)
+    return pred

--- a/mathics/builtin/logic.py
+++ b/mathics/builtin/logic.py
@@ -10,6 +10,7 @@ from mathics.core.expression import (
     SymbolFalse,
 )
 
+
 class Or(BinaryOperator):
     """
     <dl>
@@ -33,6 +34,11 @@ class Or(BinaryOperator):
     precedence = 215
     attributes = ("Flat", "HoldAll", "OneIdentity")
 
+    #    rules = {
+    #        "Or[a_]": "a",
+    #        "Or[a_, a_]": "a",
+    #        "Or[pred1___, a_, pred2___, a_, pred3___]": "Or[pred1, a, pred2, pred3]",
+    #    }
     def apply(self, args, evaluation):
         "Or[args___]"
 
@@ -75,6 +81,12 @@ class And(BinaryOperator):
     operator = "&&"
     precedence = 215
     attributes = ("Flat", "HoldAll", "OneIdentity")
+
+    #    rules = {
+    #        "And[a_]": "a",
+    #        "And[a_, a_]": "a",
+    #        "And[pred1___, a_, pred2___, a_, pred3___]": "And[pred1, a, pred2, pred3]",
+    #    }
 
     def apply(self, args, evaluation):
         "And[args___]"

--- a/mathics/builtin/specialfns/erf.py
+++ b/mathics/builtin/specialfns/erf.py
@@ -82,7 +82,7 @@ class FresnelC(_MPMathFunction):
 
     ## SymPy can't currently simplify this all the way to FresnelC[z].
     >> Integrate[Cos[x^2 Pi/2], {x, 0, z}]
-     = FresnelC[z] Gamma[1 / 4] / (4 Gamma[5 / 4])
+     = FresnelC[z]
     """
 
     rules = {
@@ -102,7 +102,7 @@ class FresnelS(_MPMathFunction):
 
     ## SymPy can't currently simplify this all the way to FresnelS[z].
     >> Integrate[Sin[x^2 Pi/2], {x, 0, z}]
-     = 3 FresnelS[z] Gamma[3 / 4] / (4 Gamma[7 / 4])
+     = FresnelS[z]
     """
 
     rules = {

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -347,6 +347,9 @@ class BaseExpression(KeyComparable):
         # used by NumericQ and expression ordering
         return False
 
+    def has_form(self, heads, *leaf_counts):
+        return False
+
     def flatten(self, head, pattern_only=False, callback=None) -> "BaseExpression":
         return self
 
@@ -559,7 +562,7 @@ class BaseExpression(KeyComparable):
     def get_rules_list(self):
         from mathics.core.rules import Rule
 
-        list_expr = self.flatten(Symbol("List"))
+        list_expr = self.flatten(SymbolList)
         list = []
         if list_expr.has_form("List", None):
             list.extend(list_expr.leaves)
@@ -1514,7 +1517,9 @@ class Expression(BaseExpression):
         elif self.has_form("SuperscriptBox", 2):
             return "^".join([leaf.boxes_to_text(**options) for leaf in self._leaves])
         elif self.has_form("FractionBox", 2):
-            return "/".join([" ( " + leaf.boxes_to_text(**options)+ " ) " for leaf in self._leaves])
+            return "/".join(
+                [" ( " + leaf.boxes_to_text(**options) + " ) " for leaf in self._leaves]
+            )
         else:
             raise BoxError(self, "text")
 


### PR DESCRIPTION
* `Integrate` now uses ConditionalExpression
* `Integrate` simplifies the Sympy output before return.
* Improved `Simplify` using a predicate evaluator,
* `FullSimplify`
* Add Method option Assumption for `Integrate`, and as a second parameter in `Simplify` and `FullSimplify`
* adding `Assuming`
 