### PR TITLE
catch malformed Pattern

### DIFF
--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -721,11 +721,14 @@ class BoxConstruct(InstanceableBuiltin):
 class PatternError(Exception):
     def __init__(self, name, tag, *args):
         super().__init__()
+        self.name = name
+        self.tag = tag
+        self.args = args
 
 
 class PatternArgumentError(PatternError):
     def __init__(self, name, count, expected):
-        super().__init__(None, None)
+        super().__init__(name, "argr", count, expected)
 
 
 class PatternObject(InstanceableBuiltin, Pattern):

--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -45,7 +45,9 @@ from mathics.core.expression import (
     Integer,
     Rational,
     Real,
+    SymbolFalse,
     SymbolList,
+    SymbolTrue,
 )
 from mathics.core.rules import Rule
 from mathics.core.pattern import Pattern, StopGenerator
@@ -451,6 +453,9 @@ class PatternTest(BinaryOperator, PatternObject):
      = True
     >> MatchQ[-3, _Integer?(#>0&)]
      = False
+    >> MatchQ[3, Pattern[3]]
+     : First element in pattern Pattern[3] is not a valid pattern name.
+     = False
     """
 
     operator = "?"
@@ -660,6 +665,9 @@ class MatchQ(Builtin):
      = False
     >> MatchQ[_Integer][123]
      = True
+    >> MatchQ[3, Pattern[3]]
+     : First element in pattern Pattern[3] is not a valid pattern name.
+     = False
     """
 
     rules = {"MatchQ[form_][expr_]": "MatchQ[expr, form]"}
@@ -667,9 +675,13 @@ class MatchQ(Builtin):
     def apply(self, expr, form, evaluation):
         "MatchQ[expr_, form_]"
 
-        if match(expr, form, evaluation):
-            return Symbol("True")
-        return Symbol("False")
+        try:
+            if match(expr, form, evaluation):
+                return SymbolTrue
+            return SymbolFalse
+        except PatternError as e:
+            evaluation.message(e.name, e.tag, *(e.args))
+            return SymbolFalse
 
 
 class Verbatim(PatternObject):
@@ -786,6 +798,7 @@ class Pattern_(PatternObject):
         "nodef": (
             "No default setting found for `1` in " "position `2` when length is `3`."
         ),
+        "argr": "Pattern called with 1 argument; 2 arguments are expected.",
     }
 
     rules = {
@@ -801,10 +814,13 @@ class Pattern_(PatternObject):
     }
 
     def init(self, expr):
-        super(Pattern_, self).init(expr)
-        self.varname = expr.leaves[0].get_name()
-        if self.varname is None:
+        if len(expr.leaves) != 2:
             self.error("patvar", expr)
+        varname = expr.leaves[0].get_name()
+        if varname is None or varname == "":
+            self.error("patvar", expr)
+        super(Pattern_, self).init(expr)
+        self.varname = varname
         self.pattern = Pattern.create(expr.leaves[1])
 
     def __repr__(self):


### PR DESCRIPTION
This PR avoids Mathics crashes as in https://github.com/mathics/Mathics/issues/1174#issuecomment-830236513
due to a malformed `Pattern` expression like `MatchQ[3, Pattern[Pattern[a, Blank[]],Blank[]]]`
