### PR TITLE
Fix a number of small bugs

### DIFF
--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -46,6 +46,7 @@ from mathics.core.streams import (
     path_search,
     stream_manager,
 )
+import mathics
 from mathics.builtin.base import Builtin, Predefined, BinaryOperator, PrefixOperator
 from mathics.builtin.strings import to_python_encoding
 from mathics.builtin.base import MessageException
@@ -57,7 +58,7 @@ INPUT_VAR = ""
 INPUTFILE_VAR = ""
 
 TMP_DIR = tempfile.gettempdir()
-
+SymbolPath = Symbol("$Path")
 
 def _channel_to_stream(channel, mode="r"):
     if isinstance(channel, String):
@@ -2024,6 +2025,7 @@ class Get(PrefixOperator):
         result = None
         pypath = path.get_string_value()
         definitions = evaluation.definitions
+        mathics.core.streams.PATH_VAR = SymbolPath.evaluate(evaluation).to_python(string_quotes=False)
         try:
             if trace_fn:
                 trace_fn(pypath)

--- a/mathics/builtin/files_io/filesystem.py
+++ b/mathics/builtin/files_io/filesystem.py
@@ -27,6 +27,7 @@ from mathics.core.expression import (
     valid_context_name,
 )
 
+import mathics.core.streams
 from mathics.core.streams import (
     HOME_DIR,
     PATH_VAR,

--- a/mathics/builtin/files_io/mainloop.py
+++ b/mathics/builtin/files_io/mainloop.py
@@ -5,9 +5,9 @@ The Main Loop
 An interactive session operates a loop, called the "main loop" in this way:
 
 <ul>
-  <li>read input</li>
-  <li>process input</li>
-  <li>format and print results</li>
+  <li>read input
+  <li>process input
+  <li>format and print results
   <li>repeat
 </ul>
 

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -2617,7 +2617,8 @@ class Complex(Number):
         return self.real.to_sympy() + sympy.I * self.imag.to_sympy()
 
     def to_python(self, *args, **kwargs):
-        return complex(self.real.to_python(), self.imag.to_python())
+        return complex(self.real.to_python(*args, **kwargs),
+                       self.imag.to_python(*args, **kwargs))
 
     def to_mpmath(self):
         return mpmath.mpc(self.real.to_mpmath(), self.imag.to_mpmath())

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -2962,7 +2962,11 @@ class String(Atom):
         return None
 
     def to_python(self, *args, **kwargs) -> str:
-        return '"%s"' % self.value  # add quotes to distinguish from Symbols
+        if kwargs.get("string_quotes", True):
+            return '"%s"' % self.value  # add quotes to distinguish from Symbols
+        else:
+            return self.value
+
 
     def __hash__(self):
         return hash(("String", self.value))

--- a/test/data/fortytwo.m
+++ b/test/data/fortytwo.m
@@ -1,0 +1,2 @@
+(* Example for testing issue #1329 *)
+42

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
+import os.path as osp
 import sys
 from .helper import check_evaluation, evaluate
+
 
 def test_compress():
     for text in ("", "abc", " "):
@@ -20,12 +22,20 @@ def test_unprotected():
 
 
 if sys.platform not in ("win32",):
+
     def test_get_and_put():
         temp_filename = evaluate('$TemporaryDirectory<>"/testfile"').to_python()
         temp_filename_strip = temp_filename[1:-1]
         check_evaluation(f"40! >> {temp_filename_strip}", "Null")
         check_evaluation(f"<< {temp_filename_strip}", "40!")
         check_evaluation(f"DeleteFile[{temp_filename}]", "Null")
+
+    def test_get_path_search():
+        # Check that AppendTo[$Path] works in conjunction with Get[]
+        dirname = osp.join(osp.dirname(osp.abspath(__file__)), "data")
+        evaled = evaluate(f"""AppendTo[$Path, "{dirname}"]""")
+        assert evaled.has_form("List", 1, None)
+        check_evaluation('Get["fortytwo.m"]', "42")
 
 
 # I do not know what is it supposed to test with this...


### PR DESCRIPTION
* Synchronize `PATH_VAR` to $Path at least before `mathics_open()` is called.
*  Add to_python option string_quotes: boolean. If `False`don't add extra surrounding quotes.
* Remove extra space in list in Main Loop doc

Partially addresses https://github.com/mathics/Mathics/issues/1329
