### PR TITLE
Go over $SystemMemory and MemoryAvailable[]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,16 +5,19 @@ CHANGES
 2.1.1
 -----
 
-New builtins
-++++++++++++
+New variables and builtins
+++++++++++++++++++++++++++
 
 * ``Arg``
 * ``Dispatch``
 * ``FullSimplify``
 * ``LetterNumber`` #1298. The ``alphabet`` parameter supports only a minimal number of languages.
+* ``MemoryAvailable``
+* ``MemoryInUse``
 * ``Nand`` and ``Nor`` logical functions.
 * ``Series``,  ``O`` and ``SeriesData``
 * ``StringReverse``
+* ``$SystemMemory``
 * Add all of the named colors, e.g. ``Brown`` or ``LighterMagenta``.
 
 
@@ -28,7 +31,7 @@ Enhancements
 * ``D`` and ``Derivative`` improvements.
 * ``FileNames`` returns a sorted list (#1250).
 * ``FindRoot`` now receives several optional parameters like ``Method`` and ``MaxIterations``.
-* ``FixedPoint`` now supports the ``SameTest`` option.  
+* ``FixedPoint`` now supports the ``SameTest`` option.
 * ``Prime`` and ``PrimePi`` now accept a list parameter and have the ``NumericFunction`` attribute.
 * ``ReplaceRepeated`` and ``FixedPoint`` now supports the ``MaxIteration`` option (#1260).
 * ``Simplify`` performs a more sophisticated set of simplifications.
@@ -38,7 +41,7 @@ Enhancements
 * ``ToString`` accepts an optional *form* parameter.
 * ``ToExpression`` handles multi-line string input
 * The implementation of Streams was redone.
-  
+
 
 
 Bug fixes
@@ -54,7 +57,7 @@ Internal changes
 ----------------
 
 * doctest  accepts the option `-d` to show how long it takes to parse, evaluate and compare each individual test.
-  
+
 
 2.1.0
 -----

--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -8,6 +8,7 @@ Global System Information
 
 import os
 import platform
+import psutil
 import sys
 import re
 import subprocess
@@ -472,13 +473,8 @@ class SystemMemory(Predefined):
     name = "$SystemMemory"
 
     def evaluate(self, evaluation) -> Integer:
-        try:
-            import psutil
-            totalmem = psutil.virtual_memory().total
-            return Integer(total)
-        except:
-            return String(SymbolFailed)
-
+        totalmem = psutil.virtual_memory().total
+        return Integer(totalmem)
 
 class MemoryAvailable(Builtin):
     """
@@ -491,14 +487,10 @@ class MemoryAvailable(Builtin):
      = ...
     """
 
-    def apply_0(self, evaluation) -> Integer:
+    def apply(self, evaluation) -> Integer:
         """MemoryAvailable[]"""
-        try:
-            import psutil
-            totalmem = psutil.virtual_memory().available
-            return Integer(total)
-        except:
-            return String(SymbolFailed)
+        totalmem = psutil.virtual_memory().available
+        return Integer(totalmem)
 
 
 class MemoryInUse(Builtin):

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,7 @@ INSTALL_REQUIRES += [
     "palettable",
     "pint",
     "python-dateutil",
+    "psutil",  # for $SystemMemory
     "llvmlite",
     "requests",
     "scikit-image",


### PR DESCRIPTION
* we were not using the psutil return values in reporting values
* make psutil mandatory rather than optional: it appears to work on all
  the platforms we support.
* Add new variables/functions to `CHANGES.rst`

Fixes #1256