### PR TITLE
Unprotect All and Subsets..

### DIFF
--- a/mathics/builtin/combinatorial.py
+++ b/mathics/builtin/combinatorial.py
@@ -454,6 +454,7 @@ class Subsets(Builtin):
      = {}
     """
 
+    attributes = ("Unprotected",)
     rules = {
         "Subsets[list_ , Pattern[n,_?ListQ|All|DirectedInfinity[1]], spec_]": "Take[Subsets[list, n], spec]",
     }

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -379,10 +379,11 @@ class Length(Builtin):
 class All(Predefined):
     """
     <dl>
-    <dt>'All'
-        <dd>is a possible value for 'Span' and 'Quiet'.
+      <dt>'All'
+      <dd>is a possible value for 'Span' and 'Quiet'.
     </dl>
     """
+    attributes = ("Unprotected",)
 
     pass
 


### PR DESCRIPTION
These are prerequisites for having Combinatorica V2.0 to load without
given errors.

Combinatorica v2.0 (the version that is on par with the latest book) is
starting to work, although testing shows it is not as good as v0.9 yet.