### PR TITLE
use ToString for formatting in Evaluation

### DIFF
--- a/mathics/builtin/fileformats/htmlformat.py
+++ b/mathics/builtin/fileformats/htmlformat.py
@@ -23,7 +23,6 @@ import sys
 try:
     import lxml.html as lhtml
 except ImportError:
-    print("lxml.html is not available...")
     pass
 
 

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -2784,7 +2784,8 @@ class BaseForm(Builtin):
         try:
             val = convert_base(x, base, p)
         except ValueError:
-            return evaluation.message("BaseForm", "basf", n)
+            evaluation.message("BaseForm", "basf", n)
+            return None
 
         if f.get_name() == "System`OutputForm":
             return from_python("%s_%d" % (val, base))


### PR DESCRIPTION
In the same direction as PR #1376, this PR starts to decouple formatting routines from the mathics core. 
* `evaluation.format` implements formatting by applying `ToString[HoldForm[], format]` to the result.
* doctest now parses strings in a way that we can use "\[charname]" inside the expected results.

The idea is that, at the end, every conversion be consistent with the output of ToString. 