### PR TITLE
Make Python package lxml optional

### DIFF
--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -23,8 +23,8 @@ from mathics.core.expression import (
     PrecisionReal,
     String,
     Symbol,
-    SymbolTrue,
     SymbolFalse,
+    SymbolTrue,
     ensure_context,
     strip_context,
 )

--- a/mathics/builtin/fileformats/htmlformat.py
+++ b/mathics/builtin/fileformats/htmlformat.py
@@ -20,11 +20,15 @@ from io import BytesIO
 import re
 import sys
 
+
 try:
     import lxml.html as lhtml
+
+    lhtml_available = True
 except ImportError:
-    print("lxml.html is not available...")
-    pass
+    from mathics.builtin.fileformats.xmlformat import  parse_xml_stream
+
+    lhtml_available = False
 
 
 def node_to_xml_element(node, strip_whitespace=True):
@@ -89,14 +93,19 @@ class ParseError(Exception):
 if "__pypy__" in sys.builtin_module_names:
 
     def parse_html_stream(f):
-        parser = lhtml.HTMLParser(encoding="utf8")
-        return lhtml.parse(f, parser)
-
+        if lhtml_available:
+            parser = lhtml.HTMLParser(encoding="utf8")
+            return lhtml.parse(f, parser)
+        else:
+            return parse_xml_stream(f)
 
 else:
 
     def parse_html_stream(f):
-        return lhtml.parse(f)
+        if lhtml_available:
+            return lhtml.parse(f)
+        else:
+            return parse_xml_stream(f)
 
 
 def parse_html_file(filename):

--- a/mathics/builtin/fileformats/htmlformat.py
+++ b/mathics/builtin/fileformats/htmlformat.py
@@ -17,8 +17,8 @@ from mathics.core.expression import Expression, String, Symbol, from_python
 from mathics.builtin.base import MessageException
 
 from io import BytesIO
+import platform
 import re
-import sys
 
 
 try:
@@ -26,8 +26,6 @@ try:
 
     lhtml_available = True
 except ImportError:
-    from mathics.builtin.fileformats.xmlformat import  parse_xml_stream
-
     lhtml_available = False
 
 
@@ -90,22 +88,16 @@ class ParseError(Exception):
     pass
 
 
-if "__pypy__" in sys.builtin_module_names:
+if platform.python_implementation() == "PyPy":
 
     def parse_html_stream(f):
-        if lhtml_available:
-            parser = lhtml.HTMLParser(encoding="utf8")
-            return lhtml.parse(f, parser)
-        else:
-            return parse_xml_stream(f)
+        parser = lhtml.HTMLParser(encoding="utf8")
+        return lhtml.parse(f, parser)
 
 else:
 
     def parse_html_stream(f):
-        if lhtml_available:
-            return lhtml.parse(f)
-        else:
-            return parse_xml_stream(f)
+        return lhtml.parse(f)
 
 
 def parse_html_file(filename):

--- a/mathics/builtin/fileformats/htmlformat.py
+++ b/mathics/builtin/fileformats/htmlformat.py
@@ -23,10 +23,8 @@ import re
 
 try:
     import lxml.html as lhtml
-
-    lhtml_available = True
 except ImportError:
-    lhtml_available = False
+    pass
 
 
 def node_to_xml_element(node, strip_whitespace=True):
@@ -250,7 +248,7 @@ class _DataImport(_TagImport):
 class DataImport(_DataImport):
     """
     >> Import["ExampleData/PrimeMeridian.html", "Data"][[1, 1, 2, 3]]
-     = {Washington, D.C., 77°03′56.07″ W (1897) or 77°04′02.24″ W (NAD 27) or 77°04′01.16″ W (NAD 83), New Naval Observatory meridian}
+     = {Washington, D.C., 77...03′56.07″ W (1897) or 77...04′02.24″ W (NAD 27) or 77...04′01.16″ W (NAD 83), New Naval Observatory meridian}
 
     #> Length[Import["ExampleData/PrimeMeridian.html", "Data"]]
      = 3

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -1930,7 +1930,7 @@ class General(Builtin):
         "syntax": "`1`",
         "invalidargs": "Invalid arguments.",
         "notboxes": "`1` is not a valid box structure.",
-        "pyimport": '`1`[] is not available. Your Python installation misses the "`2`" module.',
+        "pyimport": '`1`[] is not available. Python module "`2`" is not installed.',
     }
 
 

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -1117,6 +1117,8 @@ class Part(Builtin):
     def apply(self, list, i, evaluation):
         "Part[list_, i___]"
 
+        if list == SymbolFailed:
+            return
         indices = i.get_sequence()
         # How to deal with ByteArrays
         if list.get_head_name() == "System`ByteArray":

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,9 @@ INSTALL_REQUIRES += [
     "requests",
     "scikit-image",
     "wordcloud",  # Used in builtin/image.py by WordCloud()
-    "lxml", # Used in builtin/fileformats/html
+
+    # lxml is an optional dependency for HTML parsing
+    # "lxml", # Used in builtin/fileformats/html
 ]
 
 


### PR DESCRIPTION
I tried using the html module but the existing code is too tied in with ElementTree. A separate issue #1382 has been filed to track this aspect.

This is the merge of PRs #1379 and #1380. It fixes #1378.

Changes:

Change setup.py so that lxml is not required
Adjust pyimport error message
Avoid cascading failures in Import
parse_xml_stream(f) is not a usable replacement for HTML, so skip HTML if lxml isn't available