### PR TITLE
Handle PointSize in PointBox  (roughly)

### DIFF
--- a/mathics/doc/tex/Makefile
+++ b/mathics/doc/tex/Makefile
@@ -16,6 +16,11 @@ doc_tex_data.pcl:
 mathics.pdf: mathics.tex documentation.tex logo-text-nodrop.pdf logo-heptatom.pdf doc_tex_data.pcl
 	$(LATEXMK) -f -pdf -pdflatex="$(XETEX) -halt-on-error" mathics
 
+#: Build test PDF
+mathics-test.pdf: mathics-test.tex
+	$(LATEXMK) -f -pdf -pdflatex="$(XETEX) -halt-on-error" mathics-test
+
+
 #: Generate logos used in the titlepage
 logo-heptatom.pdf logo-text-nodrop.pdf:
 	(cd .. && $(BASH) ./images.sh)
@@ -34,3 +39,4 @@ clean:
 	rm -f mathics_*.* || true
 	rm -f mathics-*.* documentation.tex || true
 	rm -f mathics.pdf mathics.dvi data_tex_data.pcl || true
+	rm -f mathics-test.pdf mathics-test.dvi || true

--- a/mathics/formatter/svg.py
+++ b/mathics/formatter/svg.py
@@ -133,6 +133,7 @@ def filled_curve_box(self, **options):
 add_conversion_fn(FilledCurveBox, filled_curve_box)
 
 def graphics_box(self, leaves=None, **options) -> str:
+
         if not leaves:
             leaves = self._leaves
 
@@ -163,17 +164,6 @@ def graphics_box(self, leaves=None, **options) -> str:
                 self.background_color.to_css()[0],
                 svg_body,
             )
-
-
-        # FIXME:
-        # Length calculation with PointBox is off by PointSize
-        # point_size, _ = self.style.get_style(PointSize, face_element=False)
-        # For others, I guess we just have this extra margin around the edge.
-        point_size = 14.06 # Really 14.05333..5
-        xmin -= point_size
-        ymin -= point_size
-        w += 2 * point_size
-        h += 2 * point_size
 
         if options.get("noheader", False):
             return svg_body

--- a/test/test_formatter/test_svg.py
+++ b/test/test_formatter/test_svg.py
@@ -76,7 +76,7 @@ def test_svg_point():
     # Circles are implemented as ellipses with equal major and minor axes.
     # Check for that.
     print(inner_svg)
-    matches = re.match(r'^<circle cx="(\S+)" cy="(\S+)" r="(\S+)" .*/>', inner_svg)
+    matches = re.match(r'^<circle cx="(\S+)" cy="(\S+)"', inner_svg)
     assert matches
     assert matches.group(1) == matches.group(2)
 


### PR DESCRIPTION
Originally I had this as a hack on svg formatting. Then I saw that asymptote formatting was broken too. 

The basic problem is that PointBox doesn't handle PointSize as 0-width points. But the formatters, naturally fill in a nonzero point width. This causes points to extend outside of the viewport for SVG.

PointSize is specified as a fraction of the image width and we might not always have that. And for PointBox we don't have access to the top-level graphics options.

A lot of this should be (re)thought out or documented if it already is. 

Either way once you start to disentangle the code, a lot of the weaknesses become apparent.

Fixes #1091 