### PR TITLE
Json graphics

### DIFF
--- a/mathics/builtin/drawing/graphics3d.py
+++ b/mathics/builtin/drawing/graphics3d.py
@@ -165,16 +165,16 @@ class Graphics3DBox(GraphicsBox):
         if not leaves:
             raise BoxConstructError
 
-        graphics_options = self.get_option_values(leaves[1:], **options)
+        self.graphics_options = self.get_option_values(leaves[1:], **options)
 
         evaluation = options["evaluation"]
 
         base_width, base_height, size_multiplier, size_aspect = self._get_image_size(
-            options, graphics_options, max_width
+            options, self.graphics_options, max_width
         )
 
         # TODO: Handle ImageScaled[], and Scaled[]
-        lighting_option = graphics_options["System`Lighting"]
+        lighting_option = self.graphics_options["System`Lighting"]
         lighting = lighting_option.to_python()  # can take symbols or strings
         self.lighting = []
 
@@ -294,7 +294,7 @@ class Graphics3DBox(GraphicsBox):
             evaluation.message("Graphics3D", "invlight", lighting_option)
 
         # ViewPoint Option
-        viewpoint_option = graphics_options["System`ViewPoint"]
+        viewpoint_option = self.graphics_options["System`ViewPoint"]
         viewpoint = viewpoint_option.to_python(n_evaluation=evaluation)
 
         if isinstance(viewpoint, list) and len(viewpoint) == 3:
@@ -324,9 +324,9 @@ class Graphics3DBox(GraphicsBox):
         self.viewpoint = viewpoint
 
         # TODO Aspect Ratio
-        # aspect_ratio = graphics_options['AspectRatio'].to_python()
+        # aspect_ratio = self.graphics_options['AspectRatio'].to_python()
 
-        boxratios = graphics_options["System`BoxRatios"].to_python()
+        boxratios = self.graphics_options["System`BoxRatios"].to_python()
         if boxratios == "System`Automatic":
             boxratios = ["System`Automatic"] * 3
         else:
@@ -334,7 +334,7 @@ class Graphics3DBox(GraphicsBox):
         if not isinstance(boxratios, list) or len(boxratios) != 3:
             raise BoxConstructError
 
-        plot_range = graphics_options["System`PlotRange"].to_python()
+        plot_range = self.graphics_options["System`PlotRange"].to_python()
         if plot_range == "System`Automatic":
             plot_range = ["System`Automatic"] * 3
         if not isinstance(plot_range, list) or len(plot_range) != 3:
@@ -431,7 +431,7 @@ class Graphics3DBox(GraphicsBox):
         xmin, xmax, ymin, ymax, zmin, zmax, boxscale = calc_dimensions(final_pass=False)
 
         axes, ticks, ticks_style = self.create_axes(
-            elements, graphics_options, xmin, xmax, ymin, ymax, zmin, zmax, boxscale
+            elements, self.graphics_options, xmin, xmax, ymin, ymax, zmin, zmax, boxscale
         )
 
         return elements, axes, ticks, ticks_style, calc_dimensions, boxscale

--- a/mathics/formatter/asy.py
+++ b/mathics/formatter/asy.py
@@ -215,18 +215,22 @@ add_conversion_fn(Point3DBox)
 
 
 def pointbox(self, **options) -> str:
+
+    # Figure out absolute point size
     point_size, _ = self.style.get_style(PointSize, face_element=False)
     if point_size is None:
         point_size = PointSize(self.graphics, value=0.005)
-    size = point_size.get_absolute_size()
+
+    absolute_point_size = point_size.get_absolute_size()
 
     pen = asy_create_pens(face_color=self.face_color, is_face_element=False)
 
     asy = ""
     for line in self.lines:
         for coords in line:
+            # FIXME: either adjust the pen for the new size or use circle.
             asy += "dot(%s, %s);" % (coords.pos(), pen)
-            # asy += f"Circle(%s, %s, {size}), black;" % (coords.pos())
+            # asy += f"Circle(%s, %s, {absolute_point_size}), black;" % (coords.pos())
 
     # print("### pointbox", asy)
     return asy


### PR DESCRIPTION
This adds `.to_json()` and `.to_js()` methods to Graphics3DBox objects so that the front end use these without being embedded inside MathML tags. (Of course it is still possible using `to_mathml()` to have these embedded in MathML which may is still used when we have a series of 3D Graphics in a list.)

`to_json()` gives a string representation of a JSON structure which represents the 3D Graphics. TODO: we need to write and API description for what can go in there. However for now what is in mathics.js in Mathics Django will have to do as an operational description.

`to_js()` is probably a bit of a misnomer, but I can't think of a better name. This just wraps the JSON inside a tag called `<graphics3d>`.