### PR TITLE
Asy exporter

### DIFF
--- a/mathics/autoload/formats/Asy/Export.m
+++ b/mathics/autoload/formats/Asy/Export.m
@@ -1,0 +1,31 @@
+(* Text Exporter *)
+
+Begin["System`Convert`Asy`"]
+
+Options[AsyExport] = {
+		      "CharacterEncoding" :> $CharacterEncoding, (*Not used by now...*)
+};
+
+AsyExport[strm_OutputStream, expr_, OptionsPattern[]]:=
+  Module[{strout, wraplist, encoding=OptionValue["CharacterEncoding"]},
+        If[strm === $Failed, Return[$Failed]];
+	 strout = ToString[(If[Not[MemberQ[{Graphics, Graphics3D},Head[expr]]],Graphics[{Text[expr]}],expr]),TeXForm,
+			  CharacterEncoding->encoding];
+	strout = StringReplace[strout, {"\\begin{asy}"->"", "\\end{asy}"->""}];
+	WriteString[strm, strout];
+    ]
+
+
+ImportExport`RegisterExport[
+    "asy",
+    System`Convert`Asy`AsyExport,
+    FunctionChannels -> {"Streams"},
+    Options -> {"ByteOrderMark"},
+    DefaultElement -> "Plaintext",
+    BinaryFormat -> False,
+    Options -> {
+        "CharacterEncoding"
+    }
+]
+
+End[]

--- a/mathics/builtin/files_io/filesystem.py
+++ b/mathics/builtin/files_io/filesystem.py
@@ -1206,9 +1206,9 @@ class FileNames(Builtin):
     >> FileNames["*.m", "formats"]//Length
      = 0
     >> FileNames["*.m", "formats", 3]//Length
-     = 13
+     = 14
     >> FileNames["*.m", "formats", Infinity]//Length
-     = 13
+     = 14
     """
     # >> FileNames[]//Length
     #  = 2

--- a/mathics/builtin/files_io/importexport.py
+++ b/mathics/builtin/files_io/importexport.py
@@ -1714,6 +1714,9 @@ class Export(Builtin):
         "nffil": "File `1` could not be opened",
     }
 
+    # TODO: This hard-linked dictionary should be
+    # replaced by a definition accesible from inside
+    # WL
     _extdict = {
         "bmp": "BMP",
         "gif": "GIF",
@@ -1728,6 +1731,7 @@ class Export(Builtin):
         "txt": "Text",
         "csv": "CSV",
         "svg": "SVG",
+        "asy": "asy",
     }
 
     rules = {
@@ -1860,6 +1864,8 @@ class Export(Builtin):
     def _infer_form(self, filename, evaluation):
         ext = Expression("FileExtension", filename).evaluate(evaluation)
         ext = ext.get_string_value().lower()
+        # TODO: This dictionary should be accesible from the WL API
+        # to allow defining specific converters
         return self._extdict.get(ext)
 
 


### PR DESCRIPTION
@rocky : This would be a very basic implementation of the exporter. This works both to produce a string (what you want here->https://github.com/Mathics3/mathicsscript/pull/44) and to export to a file.
Examples:

```
In[9]:= ExportString[Graphics,"asy"]
Out[9]:= "
        
        usepackage(\"amsmath\");
        size(6.6667cm, 2.9762cm);
        label(\"$\text{Graphics}$\", (200.0,89.28571428571429), (0,0), rgb(0, 0, 0));
        clip(box((172,76.786), (228,101.79)));
        
        "

In[10]:= ExportString[Graphics[{Disk[]}],"asy"]
Out[10]:= "
         
         usepackage(\"amsmath\");
         size(5.8333cm, 5.8333cm);
         filldraw(ellipse((175,175),175,175), rgb(0, 0, 0), nullpen);
         clip(box((0,0), (350,350)));
         
         "
```