### PR TITLE
Simplify  Settings.  Move load_settings out of __init__...

### DIFF
--- a/mathics/__init__.py
+++ b/mathics/__init__.py
@@ -51,17 +51,6 @@ if "cython" in version_info:
     version_string += f", cython {version_info['cython']}"
 
 
-def load_default_settings_files(definitions, load_cli_settings: bool = True):
-    import os.path as osp
-    from mathics.core.definitions import autoload_files
-
-    root_dir = osp.realpath(osp.dirname(__file__))
-
-    autoload_files(definitions, root_dir, "autoload", False)
-    if load_cli_settings:
-        autoload_files(definitions, root_dir, "autoload-cli", False)
-
-
 license_string = """\
 Copyright (C) 2011-2021 The Mathics Team.
 This program comes with ABSOLUTELY NO WARRANTY.

--- a/mathics/session.py
+++ b/mathics/session.py
@@ -1,9 +1,55 @@
+# -*- coding: utf-8 -*-
+"""
+This module contains routines to simplify front-end use.
+
+In particular we provide:
+
+* a class to create a Mathics session,
+* load the Mathics core settings files (written in  WL),
+* read and set Mathics Settings.
+"""
+
+import os.path as osp
+from mathics.core.definitions import autoload_files
 from mathics.core.parser import parse, MathicsSingleLineFeeder
 from mathics.core.definitions import Definitions
 from mathics.core.evaluation import Evaluation
 
 
+def load_default_settings_files(
+    definitions: Definitions, load_cli_settings: bool = True
+):
+    """
+    Loads the system default settings for Mathics core.
+
+    Other settings files may get loaded later and override these
+    defaults.
+    """
+    root_dir = osp.realpath(osp.dirname(__file__))
+
+    autoload_files(definitions, root_dir, "autoload", False)
+    if load_cli_settings:
+        autoload_files(definitions, root_dir, "autoload-cli", False)
+
+
+def get_settings_value(definitions: Definitions, setting_name: str):
+    """Get a Mathics Settings` value with name "setting_name" from definitions."""
+    return definitions.get_ownvalue(setting_name).replace.to_python(string_quotes=False)
+
+
+def set_settings_value(definitions: Definitions, setting_name: str, value):
+    """Set a Mathics Settings` with name "setting_name" from definitions to value
+    "value".
+    """
+    return definitions.set_ownvalue(setting_name, value)
+
+
 class MathicsSession:
+    """A session stores definitions or evaluation results.  This class
+    also simplifies the common activity of reading as string, parsing
+    it and evaluating it in the context of the current session.
+    """
+
     def __init__(self, add_builtin=True, catch_interrupt=False, form="InputForm"):
         self.definitions = Definitions(add_builtin)
         self.evaluation = Evaluation(

--- a/mathics/version.py
+++ b/mathics/version.py
@@ -5,4 +5,4 @@
 # well as importing into Python. That's why there is no
 # space around "=" below.
 # fmt: off
-__version__="3.0.1.dev0"  # noqa
+__version__="3.1.0.dev0"  # noqa

--- a/test/test_settings.py
+++ b/test/test_settings.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from .helper import session
-from mathics import load_default_settings_files
+from mathics.session import load_default_settings_files
 
 
 def test_settings():


### PR DESCRIPTION
Add access routines to get and set Settings.

This changes the API so we will have 3.1.0.  It is generally bad practice to put code in `__init__` because everything under `__init_` depends on it. So this increases the chance of circular dependencies when routines use the the functions defined in init.

Add simplified set and get routines for Settings values.