### PR TITLE
Fix bug in session.get_settings()..

### DIFF
--- a/mathics/session.py
+++ b/mathics/session.py
@@ -33,8 +33,11 @@ def load_default_settings_files(
 
 
 def get_settings_value(definitions: Definitions, setting_name: str):
-    """Get a Mathics Settings` value with name "setting_name" from definitions."""
-    return definitions.get_ownvalue(setting_name).replace.to_python(string_quotes=False)
+    """Get a Mathics Settings` value with name "setting_name" from definitions. If setting_name is not defined return None"""
+    settings_value = definitions.get_ownvalue(setting_name)
+    if settings_value is None:
+        return None
+    return settings_value.replace.to_python(string_quotes=False)
 
 
 def set_settings_value(definitions: Definitions, setting_name: str, value):

--- a/test/test_settings.py
+++ b/test/test_settings.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 from .helper import session
-from mathics.session import load_default_settings_files
+from mathics.session import load_default_settings_files, get_settings_value
 
 
 def test_settings():
     load_default_settings_files(session.definitions)
 
+    assert get_settings_value(session.definitions, "NoSettingHere") == None
     assert type(session.evaluate("Settings`$TraceGet").to_python()) is bool
 
     assert (


### PR DESCRIPTION
When we don't have a setting defined, session.get_settings should return
None.