### PR TITLE
Add Mathics Core version to PDF title

### DIFF
--- a/mathics/doc/tex/.gitignore
+++ b/mathics/doc/tex/.gitignore
@@ -1,4 +1,4 @@
-/testing.tex
+/core-version.tex
 /doc_tex_data.pcl
 /documentation.tex
 /images/
@@ -39,3 +39,4 @@
 /mathics.pre
 /mathics.toc
 /testing.aux
+/testing.tex

--- a/mathics/doc/tex/Makefile
+++ b/mathics/doc/tex/Makefile
@@ -43,4 +43,4 @@ clean:
 	rm -f mathics_*.* || true
 	rm -f mathics-*.* documentation.tex $(DOC_TEX_DATA_PCL) || true
 	rm -f mathics.pdf mathics.dvi test-mathics.pdf test-mathics.dvi || true
-	rm -f mathics-test.pdf mathics-test.dvi || true
+	rm -f mathics-test.pdf mathics-test.dvi core-version.tex || true

--- a/mathics/doc/tex/doc2latex.py
+++ b/mathics/doc/tex/doc2latex.py
@@ -5,13 +5,14 @@ Reads in Pickle'd file and write LaTeX file containing the entire User Manual
 """
 
 import os
+import os.path as osp
 import pickle
 
 from argparse import ArgumentParser
 
 import mathics
 
-from mathics import version_string
+from mathics import version_string, __version__
 from mathics import settings
 from mathics.doc.common_doc import MathicsMainDocumentation
 
@@ -45,8 +46,8 @@ def open_ensure_dir(f, *args, **kwargs):
     try:
         return open(f, *args, **kwargs)
     except (IOError, OSError):
-        d = os.path.dirname(f)
-        if d and not os.path.exists(d):
+        d = osp.dirname(f)
+        if d and not osp.exists(d):
             os.makedirs(d)
         return open(f, *args, **kwargs)
 
@@ -63,11 +64,20 @@ def print_and_log(*args):
 def write_latex(doc_data, quiet=False):
     documentation = MathicsMainDocumentation()
     if not quiet:
-        print(f"Writing LaTeX {DOC_LATEX_FILE}")
+        print(f"Writing LaTeX document to {DOC_LATEX_FILE}")
     with open_ensure_dir(DOC_LATEX_FILE, "wb") as doc:
         content = documentation.latex(doc_data, quiet=quiet)
         content = content.encode("utf-8")
         doc.write(content)
+    DOC_VERSION_FILE = osp.join(osp.dirname(DOC_LATEX_FILE), "core-version.tex")
+    if not quiet:
+        print(f"Writing Mathics Core Version Information to {DOC_VERSION_FILE}")
+    with open(DOC_VERSION_FILE, "w") as doc:
+        doc.write(
+            r"""%% Mathics core version number created via doc2latex.py
+\newcommand{\version}{%s}"""
+            % __version__
+        )
 
 
 def main():

--- a/mathics/doc/tex/mathics.tex
+++ b/mathics/doc/tex/mathics.tex
@@ -68,7 +68,9 @@
     \includegraphics[height=0.1\linewidth]{logo-heptatom.pdf}
     \includegraphics[height=0.08125\linewidth]{logo-text-nodrop.pdf}
 \\[.5em]
-{\LARGE\color{subtitle}\textit{\textmd{A free, open-source alternative to Mathematica}}}}
+  {\LARGE\color{subtitle}\textit{\textmd{A free, open-source alternative to Mathematica}}}
+  \par\textmd{Mathics Core Version \version}
+}
 \author{The Mathics Team}
 
 
@@ -245,6 +247,7 @@
 \hyphenation{assign-ments}
 
 \begin{document}
+\input{core-version.tex}
 
 \maketitle
 


### PR DESCRIPTION
Include  the Mathics core version number in the title.

The styling may not be perfect, but I'll leave this for someone who feels more strongly about it, and is willing to hack LaTeX to get it done.