### PR TITLE
Mostly cosmetic revision of numeric.py

### DIFF
--- a/mathics/builtin/numeric.py
+++ b/mathics/builtin/numeric.py
@@ -26,14 +26,8 @@ from functools import lru_cache
 
 
 from mathics.builtin.base import Builtin, Predefined
-from mathics.core.numbers import (
-    dps,
-    convert_int_to_digit_list,
-    machine_precision,
-    machine_epsilon,
-    get_precision,
-    PrecisionValueError,
-)
+from mathics.core.convert import from_sympy
+
 from mathics.core.expression import (
     Complex,
     Expression,
@@ -51,186 +45,20 @@ from mathics.core.expression import (
     SymbolN,
     from_python,
 )
-from mathics.core.convert import from_sympy
+
+from mathics.core.numbers import (
+    dps,
+    convert_int_to_digit_list,
+    machine_precision,
+    machine_epsilon,
+    get_precision,
+    PrecisionValueError,
+)
 
 
 @lru_cache(maxsize=1024)
 def log_n_b(py_n, py_b) -> int:
     return int(mpmath.ceil(mpmath.log(py_n, py_b))) if py_n != 0 and py_n != 1 else 1
-
-
-class N(Builtin):
-    """
-    <dl>
-    <dt>'N[$expr$, $prec$]'
-        <dd>evaluates $expr$ numerically with a precision of $prec$ digits.
-    </dl>
-    >> N[Pi, 50]
-     = 3.1415926535897932384626433832795028841971693993751
-
-    >> N[1/7]
-     = 0.142857
-
-    >> N[1/7, 5]
-     = 0.14286
-
-    You can manually assign numerical values to symbols.
-    When you do not specify a precision, 'MachinePrecision' is taken.
-    >> N[a] = 10.9
-     = 10.9
-    >> a
-     = a
-
-    'N' automatically threads over expressions, except when a symbol has
-     attributes 'NHoldAll', 'NHoldFirst', or 'NHoldRest'.
-    >> N[a + b]
-     = 10.9 + b
-    >> N[a, 20]
-     = a
-    >> N[a, 20] = 11;
-    >> N[a + b, 20]
-     = 11.000000000000000000 + b
-    >> N[f[a, b]]
-     = f[10.9, b]
-    >> SetAttributes[f, NHoldAll]
-    >> N[f[a, b]]
-     = f[a, b]
-
-    The precision can be a pattern:
-    >> N[c, p_?(#>10&)] := p
-    >> N[c, 3]
-     = c
-    >> N[c, 11]
-     = 11.000000000
-
-    You can also use 'UpSet' or 'TagSet' to specify values for 'N':
-    >> N[d] ^= 5;
-    However, the value will not be stored in 'UpValues', but
-    in 'NValues' (as for 'Set'):
-    >> UpValues[d]
-     = {}
-    >> NValues[d]
-     = {HoldPattern[N[d, MachinePrecision]] :> 5}
-    >> e /: N[e] = 6;
-    >> N[e]
-     = 6.
-
-    Values for 'N[$expr$]' must be associated with the head of $expr$:
-    >> f /: N[e[f]] = 7;
-     : Tag f not found or too deep for an assigned rule.
-
-    You can use 'Condition':
-    >> N[g[x_, y_], p_] := x + y * Pi /; x + y > 3
-    >> SetAttributes[g, NHoldRest]
-    >> N[g[1, 1]]
-     = g[1., 1]
-    >> N[g[2, 2]] // InputForm
-     = 8.283185307179586
-
-    The precision of the result is no higher than the precision of the input
-    >> N[Exp[0.1], 100]
-     = 1.10517
-    >> % // Precision
-     = MachinePrecision
-    >> N[Exp[1/10], 100]
-     = 1.105170918075647624811707826490246668224547194737518718792863289440967966747654302989143318970748654
-    >> % // Precision
-     = 100.
-    >> N[Exp[1.0`20], 100]
-     = 2.7182818284590452354
-    >> % // Precision
-     = 20.
-
-    #> p=N[Pi,100]
-     = 3.141592653589793238462643383279502884197169399375105820974944592307816406286208998628034825342117068
-    #> ToString[p]
-     = 3.141592653589793238462643383279502884197169399375105820974944592307816406286208998628034825342117068
-
-    #> N[1.012345678901234567890123, 20]
-     = 1.0123456789012345679
-
-    #> N[I, 30]
-     = 1.00000000000000000000000000000 I
-
-    #> N[1.012345678901234567890123, 50]
-     = 1.01234567890123456789012
-    #> % // Precision
-     = 24.
-    """
-
-    messages = {
-        "precbd": ("Requested precision `1` is not a " + "machine-sized real number."),
-        "preclg": (
-            "Requested precision `1` is larger than $MaxPrecision. "
-            + "Using current $MaxPrecision of `2` instead. "
-            + "$MaxPrecision = Infinity specifies that any precision "
-            + "should be allowed."
-        ),
-        "precsm": (
-            "Requested precision `1` is smaller than "
-            + "$MinPrecision. Using current $MinPrecision of "
-            + "`2` instead."
-        ),
-    }
-
-    rules = {
-        "N[expr_]": "N[expr, MachinePrecision]",
-    }
-
-    def apply_with_prec(self, expr, prec, evaluation):
-        "N[expr_, prec_]"
-
-        try:
-            d = get_precision(prec, evaluation)
-        except PrecisionValueError:
-            return
-
-        if expr.get_head_name() in ("System`List", "System`Rule"):
-            return Expression(
-                expr.head,
-                *[self.apply_with_prec(leaf, prec, evaluation) for leaf in expr.leaves],
-            )
-
-        # Special case for the Root builtin
-        if expr.has_form("Root", 2):
-            return from_sympy(sympy.N(expr.to_sympy(), d))
-
-        if isinstance(expr, Number):
-            return expr.round(d)
-
-        name = expr.get_lookup_name()
-        if name != "":
-            nexpr = Expression(SymbolN, expr, prec)
-            result = evaluation.definitions.get_value(
-                name, "System`NValues", nexpr, evaluation
-            )
-            if result is not None:
-                if not result.sameQ(nexpr):
-                    result = Expression(SymbolN, result, prec).evaluate(evaluation)
-                return result
-
-        if expr.is_atom():
-            return expr
-        else:
-            attributes = expr.head.get_attributes(evaluation.definitions)
-            if "System`NHoldAll" in attributes:
-                eval_range = ()
-            elif "System`NHoldFirst" in attributes:
-                eval_range = range(1, len(expr.leaves))
-            elif "System`NHoldRest" in attributes:
-                if len(expr.leaves) > 0:
-                    eval_range = (0,)
-                else:
-                    eval_range = ()
-            else:
-                eval_range = range(len(expr.leaves))
-            head = Expression(SymbolN, expr.head, prec).evaluate(evaluation)
-            leaves = expr.get_mutable_leaves()
-            for index in eval_range:
-                leaves[index] = Expression(SymbolN, leaves[index], prec).evaluate(
-                    evaluation
-                )
-            return Expression(head, *leaves)
 
 
 def _scipy_interface(integrator, options_map, mandatory=None, adapt_func=None):
@@ -377,6 +205,704 @@ def _fubini(func, ranges, **opts):
     else:
         val = integrator(func, a, b, **opts)
         return val
+
+
+def check_finite_decimal(denominator):
+    # The rational number is finite decimal if the denominator has form 2^a * 5^b
+    while denominator % 5 == 0:
+        denominator = denominator / 5
+
+    while denominator % 2 == 0:
+        denominator = denominator / 2
+
+    return True if denominator == 1 else False
+
+
+def chop(expr, delta=10.0 ** (-10.0)):
+    if isinstance(expr, Real):
+        if expr.is_nan(expr):
+            return expr
+        if -delta < expr.get_float_value() < delta:
+            return Integer0
+    elif isinstance(expr, Complex) and expr.is_inexact():
+        real, imag = expr.real, expr.imag
+        if -delta < real.get_float_value() < delta:
+            real = Integer0
+        if -delta < imag.get_float_value() < delta:
+            imag = Integer0
+        return Complex(real, imag)
+    elif isinstance(expr, Expression):
+        return Expression(chop(expr.head), *[chop(leaf) for leaf in expr.leaves])
+    return expr
+
+
+def convert_repeating_decimal(numerator, denominator, base):
+    head = [x for x in str(numerator // denominator)]
+    tails = []
+    subresults = [numerator % denominator]
+    numerator %= denominator
+
+    while numerator != 0:  # only rational input can go to this case
+        numerator *= base
+        result_digit, numerator = divmod(numerator, denominator)
+        tails.append(str(result_digit))
+        if numerator not in subresults:
+            subresults.append(numerator)
+        else:
+            break
+
+    for i in range(len(head) - 1, -1, -1):
+        j = len(tails) - 1
+        if head[i] != tails[j]:
+            break
+        else:
+            del tails[j]
+            tails.insert(0, head[i])
+            del head[i]
+            j = j - 1
+
+    # truncate all leading 0's
+    if all(elem == "0" for elem in head):
+        for i in range(0, len(tails)):
+            if tails[0] == "0":
+                tails = tails[1:] + [str(0)]
+            else:
+                break
+    return (head, tails)
+
+
+def convert_float_base(x, base, precision=10):
+
+    length_of_int = 0 if x == 0 else int(mpmath.log(x, base))
+    # iexps = list(range(length_of_int, -1, -1))
+
+    def convert_int(x, base, exponents):
+        out = []
+        for e in range(0, exponents + 1):
+            d = x % base
+            out.append(d)
+            x = x / base
+            if x == 0:
+                break
+        out.reverse()
+        return out
+
+    def convert_float(x, base, exponents):
+        out = []
+        for e in range(0, exponents):
+            d = int(x * base)
+            out.append(d)
+            x = (x * base) - d
+            if x == 0:
+                break
+        return out
+
+    int_part = convert_int(int(x), base, length_of_int)
+    if isinstance(x, (float, sympy.Float)):
+        # fexps = list(range(-1, -int(precision + 1), -1))
+        real_part = convert_float(x - int(x), base, precision + 1)
+        return int_part + real_part
+    elif isinstance(x, int):
+        return int_part
+    else:
+        raise TypeError(x)
+
+
+class Chop(Builtin):
+    """
+    <dl>
+      <dt>'Chop[$expr$]'
+      <dd>replaces floating point numbers close to 0 by 0.
+
+      <dt>'Chop[$expr$, $delta$]'
+      <dd>uses a tolerance of $delta$. The default tolerance is '10^-10'.
+    </dl>
+
+    >> Chop[10.0 ^ -16]
+     = 0
+    >> Chop[10.0 ^ -9]
+     = 1.*^-9
+    >> Chop[10 ^ -11 I]
+     = I / 100000000000
+    >> Chop[0. + 10 ^ -11 I]
+     = 0
+    """
+
+    messages = {
+        "tolnn": "Tolerance specification a must be a non-negative number.",
+    }
+
+    rules = {
+        "Chop[expr_]": "Chop[expr, 10^-10]",
+    }
+
+    summary_text = "set sufficiently small numbers or imaginary parts to zero"
+
+    def apply(self, expr, delta, evaluation):
+        "Chop[expr_, delta_:(10^-10)]"
+
+        delta = delta.round_to_float(evaluation)
+        if delta is None or delta < 0:
+            return evaluation.message("Chop", "tolnn")
+
+        return chop(expr, delta=delta)
+
+
+class Fold(object):
+    # allows inherited classes to specify a single algorithm implementation that
+    # can be called with machine precision, arbitrary precision or symbolically.
+
+    ComputationFunctions = namedtuple("ComputationFunctions", ("sin", "cos"))
+
+    FLOAT = 0
+    MPMATH = 1
+    SYMBOLIC = 2
+
+    math = {
+        FLOAT: ComputationFunctions(
+            cos=math.cos,
+            sin=math.sin,
+        ),
+        MPMATH: ComputationFunctions(
+            cos=mpmath.cos,
+            sin=mpmath.sin,
+        ),
+        SYMBOLIC: ComputationFunctions(
+            cos=lambda x: Expression("Cos", x),
+            sin=lambda x: Expression("Sin", x),
+        ),
+    }
+
+    operands = {
+        FLOAT: lambda x: None if x is None else x.round_to_float(),
+        MPMATH: lambda x: None if x is None else x.to_mpmath(),
+        SYMBOLIC: lambda x: x,
+    }
+
+    def _operands(self, state, steps):
+        raise NotImplementedError
+
+    def _fold(self, state, steps, math):
+        raise NotImplementedError
+
+    def _spans(self, operands):
+        spans = {}
+        k = 0
+        j = 0
+
+        for mode in (self.FLOAT, self.MPMATH):
+            for i, operand in enumerate(operands[k:]):
+                if operand[0] > mode:
+                    break
+                j = i + k + 1
+
+            if k == 0 and j == 1:  # only init state? then ignore.
+                j = 0
+
+            spans[mode] = slice(k, j)
+            k = j
+
+        spans[self.SYMBOLIC] = slice(k, len(operands))
+
+        return spans
+
+    def fold(self, x, ll):
+        # computes fold(x, ll) with the internal _fold function. will start
+        # its evaluation machine precision, and will escalate to arbitrary
+        # precision if or symbolical evaluation only if necessary. folded
+        # items already computed are carried over to new evaluation modes.
+
+        yield x  # initial state
+
+        init = None
+        operands = list(self._operands(x, ll))
+        spans = self._spans(operands)
+
+        for mode in (self.FLOAT, self.MPMATH, self.SYMBOLIC):
+            s_operands = [y[1:] for y in operands[spans[mode]]]
+
+            if not s_operands:
+                continue
+
+            if mode == self.MPMATH:
+                from mathics.core.numbers import min_prec
+
+                precision = min_prec(*[t for t in chain(*s_operands) if t is not None])
+                working_precision = mpmath.workprec
+            else:
+
+                @contextmanager
+                def working_precision(_):
+                    yield
+
+                precision = None
+
+            if mode == self.FLOAT:
+
+                def out(z):
+                    return Real(z)
+
+            elif mode == self.MPMATH:
+
+                def out(z):
+                    return Real(z, precision)
+
+            else:
+
+                def out(z):
+                    return z
+
+            as_operand = self.operands.get(mode)
+
+            def converted_operands():
+                for y in s_operands:
+                    yield tuple(as_operand(t) for t in y)
+
+            with working_precision(precision):
+                c_operands = converted_operands()
+
+                if init is not None:
+                    c_init = tuple(
+                        (None if t is None else as_operand(from_python(t)))
+                        for t in init
+                    )
+                else:
+                    c_init = next(c_operands)
+                    init = tuple((None if t is None else out(t)) for t in c_init)
+
+                generator = self._fold(c_init, c_operands, self.math.get(mode))
+
+                for y in generator:
+                    y = tuple(out(t) for t in y)
+                    yield y
+                    init = y
+
+
+class IntegerDigits(Builtin):
+    """
+    <dl>
+    <dt>'IntegerDigits[$n$]'
+        <dd>returns a list of the base-10 digits in the integer $n$.
+    <dt>'IntegerDigits[$n$, $base$]'
+        <dd>returns a list of the base-$base$ digits in $n$.
+    <dt>'IntegerDigits[$n$, $base$, $length$]'
+        <dd>returns a list of length $length$, truncating or padding
+        with zeroes on the left as necessary.
+    </dl>
+
+    >> IntegerDigits[76543]
+     = {7, 6, 5, 4, 3}
+
+    The sign of $n$ is discarded:
+    >> IntegerDigits[-76543]
+     = {7, 6, 5, 4, 3}
+
+    >> IntegerDigits[15, 16]
+     = {15}
+    >> IntegerDigits[1234, 16]
+     = {4, 13, 2}
+    >> IntegerDigits[1234, 10, 5]
+     = {0, 1, 2, 3, 4}
+
+    #> IntegerDigits[1000, 10]
+     = {1, 0, 0, 0}
+
+    #> IntegerDigits[0]
+     = {0}
+    """
+
+    attributes = ("Listable",)
+
+    messages = {
+        "int": "Integer expected at position 1 in `1`",
+        "ibase": "Base `1` is not an integer greater than 1.",
+    }
+
+    rules = {
+        "IntegerDigits[n_]": "IntegerDigits[n, 10]",
+    }
+
+    def apply_len(self, n, base, length, evaluation):
+        "IntegerDigits[n_, base_, length_]"
+
+        if not (isinstance(length, Integer) and length.get_int_value() >= 0):
+            return evaluation.message("IntegerDigits", "intnn")
+
+        return self.apply(n, base, evaluation, nr_elements=length.get_int_value())
+
+    def apply(self, n, base, evaluation, nr_elements=None):
+        "IntegerDigits[n_, base_]"
+
+        if not (isinstance(n, Integer)):
+            return evaluation.message(
+                "IntegerDigits", "int", Expression("IntegerDigits", n, base)
+            )
+
+        if not (isinstance(base, Integer) and base.get_int_value() > 1):
+            return evaluation.message("IntegerDigits", "ibase", base)
+
+        if nr_elements == 0:
+            # trivial case: we don't want any digits
+            return Expression(SymbolList)
+
+        digits = convert_int_to_digit_list(n.get_int_value(), base.get_int_value())
+
+        if nr_elements is not None:
+            if len(digits) >= nr_elements:
+                # Truncate, preserving the digits on the right
+                digits = digits[-nr_elements:]
+            else:
+                # Pad with zeroes
+                digits = [0] * (nr_elements - len(digits)) + digits
+
+        return Expression(SymbolList, *digits)
+
+
+class MaxPrecision(Predefined):
+    """
+    <dl>
+      <dt>'$MaxPrecision'
+      <dd>represents the maximum number of digits of precision permitted in abitrary-precision numbers.
+    </dl>
+
+    >> $MaxPrecision
+     = Infinity
+
+    >> $MaxPrecision = 10;
+
+    >> N[Pi, 11]
+     : Requested precision 11 is larger than $MaxPrecision. Using current $MaxPrecision of 10. instead. $MaxPrecision = Infinity specifies that any precision should be allowed.
+     = 3.141592654
+
+    #> N[Pi, 10]
+     = 3.141592654
+
+    #> $MaxPrecision = x
+     : Cannot set $MaxPrecision to x; value must be a positive number or Infinity.
+     = x
+    #> $MaxPrecision = -Infinity
+     : Cannot set $MaxPrecision to -Infinity; value must be a positive number or Infinity.
+     = -Infinity
+    #> $MaxPrecision = 0
+     : Cannot set $MaxPrecision to 0; value must be a positive number or Infinity.
+     = 0
+    #> $MaxPrecision = Infinity;
+
+    #> $MinPrecision = 15;
+    #> $MaxPrecision = 10
+     : Cannot set $MaxPrecision such that $MaxPrecision < $MinPrecision.
+     = 10
+    #> $MaxPrecision
+     = Infinity
+    #> $MinPrecision = 0;
+    """
+
+    messages = {
+        "precset": "Cannot set `1` to `2`; value must be a positive number or Infinity.",
+        "preccon": "Cannot set `1` such that $MaxPrecision < $MinPrecision.",
+    }
+
+    name = "$MaxPrecision"
+
+    rules = {
+        "$MaxPrecision": "Infinity",
+    }
+
+    summary_text = "settable global maximum precision bound"
+
+
+class MachineEpsilon_(Predefined):
+    """
+    <dl>
+    <dt>'$MachineEpsilon'
+        <dd>is the distance between '1.0' and the next
+            nearest representable machine-precision number.
+    </dl>
+
+    >> $MachineEpsilon
+     = 2.22045*^-16
+
+    >> x = 1.0 + {0.4, 0.5, 0.6} $MachineEpsilon;
+    >> x - 1
+     = {0., 0., 2.22045*^-16}
+    """
+
+    name = "$MachineEpsilon"
+
+    def evaluate(self, evaluation):
+        return MachineReal(machine_epsilon)
+
+
+class MachinePrecision_(Predefined):
+    """
+    <dl>
+    <dt>'$MachinePrecision'
+        <dd>is the number of decimal digits of precision for
+            machine-precision numbers.
+    </dl>
+
+    >> $MachinePrecision
+     = 15.9546
+    """
+
+    name = "$MachinePrecision"
+
+    rules = {
+        "$MachinePrecision": "N[MachinePrecision]",
+    }
+
+
+class MachinePrecision(Predefined):
+    """
+    <dl>
+    <dt>'MachinePrecision'
+        <dd>represents the precision of machine precision numbers.
+    </dl>
+
+    >> N[MachinePrecision]
+     = 15.9546
+    >> N[MachinePrecision, 30]
+     = 15.9545897701910033463281614204
+
+    #> N[E, MachinePrecision]
+     = 2.71828
+
+    #> Round[MachinePrecision]
+     = 16
+    """
+
+    rules = {
+        "N[MachinePrecision, prec_]": ("N[Log[10, 2] * %i, prec]" % machine_precision),
+    }
+
+
+class MinPrecision(Builtin):
+    """
+    <dl>
+      <dt>'$MinPrecision'
+      <dd>represents the minimum number of digits of precision permitted in abitrary-precision numbers.
+    </dl>
+
+    >> $MinPrecision
+     = 0
+
+    >> $MinPrecision = 10;
+
+    >> N[Pi, 9]
+     : Requested precision 9 is smaller than $MinPrecision. Using current $MinPrecision of 10. instead.
+     = 3.141592654
+
+    #> N[Pi, 10]
+     = 3.141592654
+
+    #> $MinPrecision = x
+     : Cannot set $MinPrecision to x; value must be a non-negative number.
+     = x
+    #> $MinPrecision = -Infinity
+     : Cannot set $MinPrecision to -Infinity; value must be a non-negative number.
+     = -Infinity
+    #> $MinPrecision = -1
+     : Cannot set $MinPrecision to -1; value must be a non-negative number.
+     = -1
+    #> $MinPrecision = 0;
+
+    #> $MaxPrecision = 10;
+    #> $MinPrecision = 15
+     : Cannot set $MinPrecision such that $MaxPrecision < $MinPrecision.
+     = 15
+    #> $MinPrecision
+     = 0
+    #> $MaxPrecision = Infinity;
+    """
+
+    messages = {
+        "precset": "Cannot set `1` to `2`; value must be a non-negative number.",
+        "preccon": "Cannot set `1` such that $MaxPrecision < $MinPrecision.",
+    }
+
+    name = "$MinPrecision"
+
+    rules = {
+        "$MinPrecision": "0",
+    }
+
+    summary_text = "settable global minimum precision bound"
+
+
+class N(Builtin):
+    """
+    <dl>
+    <dt>'N[$expr$, $prec$]'
+        <dd>evaluates $expr$ numerically with a precision of $prec$ digits.
+    </dl>
+    >> N[Pi, 50]
+     = 3.1415926535897932384626433832795028841971693993751
+
+    >> N[1/7]
+     = 0.142857
+
+    >> N[1/7, 5]
+     = 0.14286
+
+    You can manually assign numerical values to symbols.
+    When you do not specify a precision, 'MachinePrecision' is taken.
+    >> N[a] = 10.9
+     = 10.9
+    >> a
+     = a
+
+    'N' automatically threads over expressions, except when a symbol has
+     attributes 'NHoldAll', 'NHoldFirst', or 'NHoldRest'.
+    >> N[a + b]
+     = 10.9 + b
+    >> N[a, 20]
+     = a
+    >> N[a, 20] = 11;
+    >> N[a + b, 20]
+     = 11.000000000000000000 + b
+    >> N[f[a, b]]
+     = f[10.9, b]
+    >> SetAttributes[f, NHoldAll]
+    >> N[f[a, b]]
+     = f[a, b]
+
+    The precision can be a pattern:
+    >> N[c, p_?(#>10&)] := p
+    >> N[c, 3]
+     = c
+    >> N[c, 11]
+     = 11.000000000
+
+    You can also use 'UpSet' or 'TagSet' to specify values for 'N':
+    >> N[d] ^= 5;
+    However, the value will not be stored in 'UpValues', but
+    in 'NValues' (as for 'Set'):
+    >> UpValues[d]
+     = {}
+    >> NValues[d]
+     = {HoldPattern[N[d, MachinePrecision]] :> 5}
+    >> e /: N[e] = 6;
+    >> N[e]
+     = 6.
+
+    Values for 'N[$expr$]' must be associated with the head of $expr$:
+    >> f /: N[e[f]] = 7;
+     : Tag f not found or too deep for an assigned rule.
+
+    You can use 'Condition':
+    >> N[g[x_, y_], p_] := x + y * Pi /; x + y > 3
+    >> SetAttributes[g, NHoldRest]
+    >> N[g[1, 1]]
+     = g[1., 1]
+    >> N[g[2, 2]] // InputForm
+     = 8.283185307179586
+
+    The precision of the result is no higher than the precision of the input
+    >> N[Exp[0.1], 100]
+     = 1.10517
+    >> % // Precision
+     = MachinePrecision
+    >> N[Exp[1/10], 100]
+     = 1.105170918075647624811707826490246668224547194737518718792863289440967966747654302989143318970748654
+    >> % // Precision
+     = 100.
+    >> N[Exp[1.0`20], 100]
+     = 2.7182818284590452354
+    >> % // Precision
+     = 20.
+
+    #> p=N[Pi,100]
+     = 3.141592653589793238462643383279502884197169399375105820974944592307816406286208998628034825342117068
+    #> ToString[p]
+     = 3.141592653589793238462643383279502884197169399375105820974944592307816406286208998628034825342117068
+
+    #> N[1.012345678901234567890123, 20]
+     = 1.0123456789012345679
+
+    #> N[I, 30]
+     = 1.00000000000000000000000000000 I
+
+    #> N[1.012345678901234567890123, 50]
+     = 1.01234567890123456789012
+    #> % // Precision
+     = 24.
+    """
+
+    messages = {
+        "precbd": ("Requested precision `1` is not a " + "machine-sized real number."),
+        "preclg": (
+            "Requested precision `1` is larger than $MaxPrecision. "
+            + "Using current $MaxPrecision of `2` instead. "
+            + "$MaxPrecision = Infinity specifies that any precision "
+            + "should be allowed."
+        ),
+        "precsm": (
+            "Requested precision `1` is smaller than "
+            + "$MinPrecision. Using current $MinPrecision of "
+            + "`2` instead."
+        ),
+    }
+
+    rules = {
+        "N[expr_]": "N[expr, MachinePrecision]",
+    }
+
+    summary_text = "numerical evaluation to specified precision and accuracy"
+
+    def apply_with_prec(self, expr, prec, evaluation):
+        "N[expr_, prec_]"
+
+        try:
+            d = get_precision(prec, evaluation)
+        except PrecisionValueError:
+            return
+
+        if expr.get_head_name() in ("System`List", "System`Rule"):
+            return Expression(
+                expr.head,
+                *[self.apply_with_prec(leaf, prec, evaluation) for leaf in expr.leaves],
+            )
+
+        # Special case for the Root builtin
+        if expr.has_form("Root", 2):
+            return from_sympy(sympy.N(expr.to_sympy(), d))
+
+        if isinstance(expr, Number):
+            return expr.round(d)
+
+        name = expr.get_lookup_name()
+        if name != "":
+            nexpr = Expression(SymbolN, expr, prec)
+            result = evaluation.definitions.get_value(
+                name, "System`NValues", nexpr, evaluation
+            )
+            if result is not None:
+                if not result.sameQ(nexpr):
+                    result = Expression(SymbolN, result, prec).evaluate(evaluation)
+                return result
+
+        if expr.is_atom():
+            return expr
+        else:
+            attributes = expr.head.get_attributes(evaluation.definitions)
+            if "System`NHoldAll" in attributes:
+                eval_range = ()
+            elif "System`NHoldFirst" in attributes:
+                eval_range = range(1, len(expr.leaves))
+            elif "System`NHoldRest" in attributes:
+                if len(expr.leaves) > 0:
+                    eval_range = (0,)
+                else:
+                    eval_range = ()
+            else:
+                eval_range = range(len(expr.leaves))
+            head = Expression(SymbolN, expr.head, prec).evaluate(evaluation)
+            leaves = expr.get_mutable_leaves()
+            for index in eval_range:
+                leaves[index] = Expression(SymbolN, leaves[index], prec).evaluate(
+                    evaluation
+                )
+            return Expression(head, *leaves)
 
 
 class NIntegrate(Builtin):
@@ -685,69 +1211,34 @@ class NIntegrate(Builtin):
         return from_python(result)
 
 
-class MachinePrecision(Predefined):
+class NumericQ(Builtin):
     """
     <dl>
-    <dt>'MachinePrecision'
-        <dd>represents the precision of machine precision numbers.
+    <dt>'NumericQ[$expr$]'
+        <dd>tests whether $expr$ represents a numeric quantity.
     </dl>
 
-    >> N[MachinePrecision]
-     = 15.9546
-    >> N[MachinePrecision, 30]
-     = 15.9545897701910033463281614204
-
-    #> N[E, MachinePrecision]
-     = 2.71828
-
-    #> Round[MachinePrecision]
-     = 16
+    >> NumericQ[2]
+     = True
+    >> NumericQ[Sqrt[Pi]]
+     = True
+    >> NumberQ[Sqrt[Pi]]
+     = False
     """
 
-    rules = {
-        "N[MachinePrecision, prec_]": ("N[Log[10, 2] * %i, prec]" % machine_precision),
-    }
+    def apply(self, expr, evaluation):
+        "NumericQ[expr_]"
 
+        def test(expr):
+            if isinstance(expr, Expression):
+                attr = evaluation.definitions.get_attributes(expr.head.get_name())
+                return "System`NumericFunction" in attr and all(
+                    test(leaf) for leaf in expr.leaves
+                )
+            else:
+                return expr.is_numeric()
 
-class MachineEpsilon_(Predefined):
-    """
-    <dl>
-    <dt>'$MachineEpsilon'
-        <dd>is the distance between '1.0' and the next
-            nearest representable machine-precision number.
-    </dl>
-
-    >> $MachineEpsilon
-     = 2.22045*^-16
-
-    >> x = 1.0 + {0.4, 0.5, 0.6} $MachineEpsilon;
-    >> x - 1
-     = {0., 0., 2.22045*^-16}
-    """
-
-    name = "$MachineEpsilon"
-
-    def evaluate(self, evaluation):
-        return MachineReal(machine_epsilon)
-
-
-class MachinePrecision_(Predefined):
-    """
-    <dl>
-    <dt>'$MachinePrecision'
-        <dd>is the number of decimal digits of precision for
-            machine-precision numbers.
-    </dl>
-
-    >> $MachinePrecision
-     = 15.9546
-    """
-
-    name = "$MachinePrecision"
-
-    rules = {
-        "$MachinePrecision": "N[MachinePrecision]",
-    }
+        return SymbolTrue if test(expr) else SymbolFalse
 
 
 class Precision(Builtin):
@@ -792,6 +1283,8 @@ class Precision(Builtin):
         "Precision[z_?MachineNumberQ]": "MachinePrecision",
     }
 
+    summary_text = "find the precision of a number"
+
     def apply(self, z, evaluation):
         "Precision[z_]"
 
@@ -803,106 +1296,141 @@ class Precision(Builtin):
             return Real(dps(z.get_precision()))
 
 
-class MinPrecision(Builtin):
+class Rationalize(Builtin):
     """
     <dl>
-    <dt>'$MinPrecision'
-      <dd>represents the minimum number of digits of precision
-          permitted in abitrary-precision numbers.
+      <dt>'Rationalize[$x$]'
+      <dd>converts a real number $x$ to a nearby rational number with small denominator.
+
+      <dt>'Rationalize[$x$, $dx$]'
+      <dd>finds the rational number lies within $dx$ of $x$.
     </dl>
 
-    >> $MinPrecision
-     = 0
+    >> Rationalize[2.2]
+    = 11 / 5
 
-    >> $MinPrecision = 10;
+    Not all numbers can be well approximated.
+    >> Rationalize[N[Pi]]
+     = 3.14159
 
-    >> N[Pi, 9]
-     : Requested precision 9 is smaller than $MinPrecision. Using current $MinPrecision of 10. instead.
-     = 3.141592654
+    Find the exact rational representation of 'N[Pi]'
+    >> Rationalize[N[Pi], 0]
+     = 245850922 / 78256779
 
-    #> N[Pi, 10]
-     = 3.141592654
+    #> Rationalize[N[Pi] + 0.8 I, x]
+     : Tolerance specification x must be a non-negative number.
+     = Rationalize[3.14159 + 0.8 I, x]
 
-    #> $MinPrecision = x
-     : Cannot set $MinPrecision to x; value must be a non-negative number.
-     = x
-    #> $MinPrecision = -Infinity
-     : Cannot set $MinPrecision to -Infinity; value must be a non-negative number.
-     = -Infinity
-    #> $MinPrecision = -1
-     : Cannot set $MinPrecision to -1; value must be a non-negative number.
-     = -1
-    #> $MinPrecision = 0;
+    #> Rationalize[N[Pi] + 0.8 I, -1]
+     : Tolerance specification -1 must be a non-negative number.
+     = Rationalize[3.14159 + 0.8 I, -1]
 
-    #> $MaxPrecision = 10;
-    #> $MinPrecision = 15
-     : Cannot set $MinPrecision such that $MaxPrecision < $MinPrecision.
-     = 15
-    #> $MinPrecision
-     = 0
-    #> $MaxPrecision = Infinity;
+    #> Rationalize[x, y]
+     : Tolerance specification y must be a non-negative number.
+     = Rationalize[x, y]
     """
-
-    name = "$MinPrecision"
-    rules = {
-        "$MinPrecision": "0",
-    }
 
     messages = {
-        "precset": "Cannot set `1` to `2`; value must be a non-negative number.",
-        "preccon": "Cannot set `1` such that $MaxPrecision < $MinPrecision.",
+        "tolnn": "Tolerance specification `1` must be a non-negative number.",
     }
-
-
-class MaxPrecision(Predefined):
-    """
-    <dl>
-    <dt>'$MaxPrecision'
-      <dd>represents the maximum number of digits of precision
-          permitted in abitrary-precision numbers.
-    </dl>
-
-    >> $MaxPrecision
-     = Infinity
-
-    >> $MaxPrecision = 10;
-
-    >> N[Pi, 11]
-     : Requested precision 11 is larger than $MaxPrecision. Using current $MaxPrecision of 10. instead. $MaxPrecision = Infinity specifies that any precision should be allowed.
-     = 3.141592654
-
-    #> N[Pi, 10]
-     = 3.141592654
-
-    #> $MaxPrecision = x
-     : Cannot set $MaxPrecision to x; value must be a positive number or Infinity.
-     = x
-    #> $MaxPrecision = -Infinity
-     : Cannot set $MaxPrecision to -Infinity; value must be a positive number or Infinity.
-     = -Infinity
-    #> $MaxPrecision = 0
-     : Cannot set $MaxPrecision to 0; value must be a positive number or Infinity.
-     = 0
-    #> $MaxPrecision = Infinity;
-
-    #> $MinPrecision = 15;
-    #> $MaxPrecision = 10
-     : Cannot set $MaxPrecision such that $MaxPrecision < $MinPrecision.
-     = 10
-    #> $MaxPrecision
-     = Infinity
-    #> $MinPrecision = 0;
-    """
-
-    name = "$MaxPrecision"
 
     rules = {
-        "$MaxPrecision": "Infinity",
+        "Rationalize[z_Complex]": "Rationalize[Re[z]] + I Rationalize[Im[z]]",
+        "Rationalize[z_Complex, dx_?Internal`RealValuedNumberQ]/;dx >= 0": "Rationalize[Re[z], dx] + I Rationalize[Im[z], dx]",
     }
 
-    messages = {
-        "precset": "Cannot set `1` to `2`; value must be a positive number or Infinity.",
-        "preccon": "Cannot set `1` such that $MaxPrecision < $MinPrecision.",
+    summary_text = "find a rational approximation"
+
+    def apply(self, x, evaluation):
+        "Rationalize[x_]"
+
+        py_x = x.to_sympy()
+        if py_x is None or (not py_x.is_number) or (not py_x.is_real):
+            return x
+        return from_sympy(self.find_approximant(py_x))
+
+    @staticmethod
+    def find_approximant(x):
+        c = 1e-4
+        it = sympy.ntheory.continued_fraction_convergents(
+            sympy.ntheory.continued_fraction_iterator(x)
+        )
+        for i in it:
+            p, q = i.as_numer_denom()
+            tol = c / q ** 2
+            if abs(i - x) <= tol:
+                return i
+            if tol < machine_epsilon:
+                break
+        return x
+
+    @staticmethod
+    def find_exact(x):
+        p, q = x.as_numer_denom()
+        it = sympy.ntheory.continued_fraction_convergents(
+            sympy.ntheory.continued_fraction_iterator(x)
+        )
+        for i in it:
+            p, q = i.as_numer_denom()
+            if abs(x - i) < machine_epsilon:
+                return i
+
+    def apply_dx(self, x, dx, evaluation):
+        "Rationalize[x_, dx_]"
+        py_x = x.to_sympy()
+        if py_x is None:
+            return x
+        py_dx = dx.to_sympy()
+        if (
+            py_dx is None
+            or (not py_dx.is_number)
+            or (not py_dx.is_real)
+            or py_dx.is_negative
+        ):
+            return evaluation.message("Rationalize", "tolnn", dx)
+        elif py_dx == 0:
+            return from_sympy(self.find_exact(py_x))
+        a = self.approx_interval_continued_fraction(py_x - py_dx, py_x + py_dx)
+        sym_x = sympy.ntheory.continued_fraction_reduce(a)
+        return Rational(sym_x)
+
+    @staticmethod
+    def approx_interval_continued_fraction(xmin, xmax):
+        result = []
+        a_gen = sympy.ntheory.continued_fraction_iterator(xmin)
+        b_gen = sympy.ntheory.continued_fraction_iterator(xmax)
+        while True:
+            a, b = next(a_gen), next(b_gen)
+            if a == b:
+                result.append(a)
+            else:
+                result.append(min(a, b) + 1)
+                break
+        return result
+
+
+class RealValuedNumericQ(Builtin):
+    # No docstring since this is internal and it will mess up documentation.
+    # FIXME: Perhaps in future we will have a more explicite way to indicate not
+    # to add something to the docs.
+    context = "Internal`"
+
+    rules = {
+        "Internal`RealValuedNumericQ[x_]": "Head[N[x]] === Real",
+    }
+
+
+class RealValuedNumberQ(Builtin):
+    # No docstring since this is internal and it will mess up documentation.
+    # FIXME: Perhaps in future we will have a more explicite way to indicate not
+    # to add something to the docs.
+    context = "Internal`"
+
+    rules = {
+        "Internal`RealValuedNumberQ[x_Real]": "True",
+        "Internal`RealValuedNumberQ[x_Integer]": "True",
+        "Internal`RealValuedNumberQ[x_Rational]": "True",
+        "Internal`RealValuedNumberQ[x_]": "False",
     }
 
 
@@ -976,421 +1504,20 @@ class Round(Builtin):
         return Expression("Times", Integer(n), k)
 
 
-class Rationalize(Builtin):
-    """
-    <dl>
-    <dt>'Rationalize[$x$]'
-        <dd>converts a real number $x$ to a nearby rational number.
-    <dt>'Rationalize[$x$, $dx$]'
-        <dd>finds the rational number within $dx$ of $x$ with the smallest denominator.
-    </dl>
-
-    >> Rationalize[2.2]
-    = 11 / 5
-
-    Not all numbers can be well approximated.
-    >> Rationalize[N[Pi]]
-     = 3.14159
-
-    Find the exact rational representation of 'N[Pi]'
-    >> Rationalize[N[Pi], 0]
-     = 245850922 / 78256779
-
-    #> Rationalize[1.6 + 0.8 I]
-     = 8 / 5 + 4 I / 5
-
-    #> Rationalize[N[Pi] + 0.8 I, 1*^-6]
-     = 355 / 113 + 4 I / 5
-
-    #> Rationalize[N[Pi] + 0.8 I, x]
-     : Tolerance specification x must be a non-negative number.
-     = Rationalize[3.14159 + 0.8 I, x]
-
-    #> Rationalize[N[Pi] + 0.8 I, -1]
-     : Tolerance specification -1 must be a non-negative number.
-     = Rationalize[3.14159 + 0.8 I, -1]
-
-    #> Rationalize[N[Pi] + 0.8 I, 0]
-     = 245850922 / 78256779 + 4 I / 5
-
-    #> Rationalize[17 / 7]
-     = 17 / 7
-
-    #> Rationalize[x]
-     = x
-
-    #> Table[Rationalize[E, 0.1^n], {n, 1, 10}]
-     = {8 / 3, 19 / 7, 87 / 32, 193 / 71, 1071 / 394, 2721 / 1001, 15062 / 5541, 23225 / 8544, 49171 / 18089, 419314 / 154257}
-
-    #> Rationalize[x, y]
-     : Tolerance specification y must be a non-negative number.
-     = Rationalize[x, y]
-    """
-
-    messages = {
-        "tolnn": "Tolerance specification `1` must be a non-negative number.",
-    }
-
-    rules = {
-        "Rationalize[z_Complex]": "Rationalize[Re[z]] + I Rationalize[Im[z]]",
-        "Rationalize[z_Complex, dx_?Internal`RealValuedNumberQ]/;dx >= 0": "Rationalize[Re[z], dx] + I Rationalize[Im[z], dx]",
-    }
-
-    def apply(self, x, evaluation):
-        "Rationalize[x_]"
-
-        py_x = x.to_sympy()
-        if py_x is None or (not py_x.is_number) or (not py_x.is_real):
-            return x
-        return from_sympy(self.find_approximant(py_x))
-
-    @staticmethod
-    def find_approximant(x):
-        c = 1e-4
-        it = sympy.ntheory.continued_fraction_convergents(
-            sympy.ntheory.continued_fraction_iterator(x)
-        )
-        for i in it:
-            p, q = i.as_numer_denom()
-            tol = c / q ** 2
-            if abs(i - x) <= tol:
-                return i
-            if tol < machine_epsilon:
-                break
-        return x
-
-    @staticmethod
-    def find_exact(x):
-        p, q = x.as_numer_denom()
-        it = sympy.ntheory.continued_fraction_convergents(
-            sympy.ntheory.continued_fraction_iterator(x)
-        )
-        for i in it:
-            p, q = i.as_numer_denom()
-            if abs(x - i) < machine_epsilon:
-                return i
-
-    def apply_dx(self, x, dx, evaluation):
-        "Rationalize[x_, dx_]"
-        py_x = x.to_sympy()
-        if py_x is None:
-            return x
-        py_dx = dx.to_sympy()
-        if (
-            py_dx is None
-            or (not py_dx.is_number)
-            or (not py_dx.is_real)
-            or py_dx.is_negative
-        ):
-            return evaluation.message("Rationalize", "tolnn", dx)
-        elif py_dx == 0:
-            return from_sympy(self.find_exact(py_x))
-        a = self.approx_interval_continued_fraction(py_x - py_dx, py_x + py_dx)
-        sym_x = sympy.ntheory.continued_fraction_reduce(a)
-        return Rational(sym_x)
-
-    @staticmethod
-    def approx_interval_continued_fraction(xmin, xmax):
-        result = []
-        a_gen = sympy.ntheory.continued_fraction_iterator(xmin)
-        b_gen = sympy.ntheory.continued_fraction_iterator(xmax)
-        while True:
-            a, b = next(a_gen), next(b_gen)
-            if a == b:
-                result.append(a)
-            else:
-                result.append(min(a, b) + 1)
-                break
-        return result
-
-
-def chop(expr, delta=10.0 ** (-10.0)):
-    if isinstance(expr, Real):
-        if expr.is_nan(expr):
-            return expr
-        if -delta < expr.get_float_value() < delta:
-            return Integer0
-    elif isinstance(expr, Complex) and expr.is_inexact():
-        real, imag = expr.real, expr.imag
-        if -delta < real.get_float_value() < delta:
-            real = Integer0
-        if -delta < imag.get_float_value() < delta:
-            imag = Integer0
-        return Complex(real, imag)
-    elif isinstance(expr, Expression):
-        return Expression(chop(expr.head), *[chop(leaf) for leaf in expr.leaves])
-    return expr
-
-
-class Chop(Builtin):
-    """
-    <dl>
-    <dt>'Chop[$expr$]'
-        <dd>replaces floating point numbers close to 0 by 0.
-    <dt>'Chop[$expr$, $delta$]'
-        <dd>uses a tolerance of $delta$. The default tolerance is '10^-10'.
-    </dl>
-
-    >> Chop[10.0 ^ -16]
-     = 0
-    >> Chop[10.0 ^ -9]
-     = 1.*^-9
-    >> Chop[10 ^ -11 I]
-     = I / 100000000000
-    >> Chop[0. + 10 ^ -11 I]
-     = 0
-    """
-
-    messages = {
-        "tolnn": "Tolerance specification a must be a non-negative number.",
-    }
-
-    rules = {
-        "Chop[expr_]": "Chop[expr, 10^-10]",
-    }
-
-    def apply(self, expr, delta, evaluation):
-        "Chop[expr_, delta_:(10^-10)]"
-
-        delta = delta.round_to_float(evaluation)
-        if delta is None or delta < 0:
-            return evaluation.message("Chop", "tolnn")
-
-        return chop(expr, delta=delta)
-
-
-class NumericQ(Builtin):
-    """
-    <dl>
-    <dt>'NumericQ[$expr$]'
-        <dd>tests whether $expr$ represents a numeric quantity.
-    </dl>
-
-    >> NumericQ[2]
-     = True
-    >> NumericQ[Sqrt[Pi]]
-     = True
-    >> NumberQ[Sqrt[Pi]]
-     = False
-    """
-
-    def apply(self, expr, evaluation):
-        "NumericQ[expr_]"
-
-        def test(expr):
-            if isinstance(expr, Expression):
-                attr = evaluation.definitions.get_attributes(expr.head.get_name())
-                return "System`NumericFunction" in attr and all(
-                    test(leaf) for leaf in expr.leaves
-                )
-            else:
-                return expr.is_numeric()
-
-        return SymbolTrue if test(expr) else SymbolFalse
-
-
-class RealValuedNumericQ(Builtin):
-    # No docstring since this is internal and it will mess up documentation.
-    # FIXME: Perhaps in future we will have a more explicite way to indicate not
-    # to add something to the docs.
-    context = "Internal`"
-
-    rules = {
-        "Internal`RealValuedNumericQ[x_]": "Head[N[x]] === Real",
-    }
-
-
-class RealValuedNumberQ(Builtin):
-    # No docstring since this is internal and it will mess up documentation.
-    # FIXME: Perhaps in future we will have a more explicite way to indicate not
-    # to add something to the docs.
-    context = "Internal`"
-
-    rules = {
-        "Internal`RealValuedNumberQ[x_Real]": "True",
-        "Internal`RealValuedNumberQ[x_Integer]": "True",
-        "Internal`RealValuedNumberQ[x_Rational]": "True",
-        "Internal`RealValuedNumberQ[x_]": "False",
-    }
-
-
-class IntegerDigits(Builtin):
-    """
-    <dl>
-    <dt>'IntegerDigits[$n$]'
-        <dd>returns a list of the base-10 digits in the integer $n$.
-    <dt>'IntegerDigits[$n$, $base$]'
-        <dd>returns a list of the base-$base$ digits in $n$.
-    <dt>'IntegerDigits[$n$, $base$, $length$]'
-        <dd>returns a list of length $length$, truncating or padding
-        with zeroes on the left as necessary.
-    </dl>
-
-    >> IntegerDigits[76543]
-     = {7, 6, 5, 4, 3}
-
-    The sign of $n$ is discarded:
-    >> IntegerDigits[-76543]
-     = {7, 6, 5, 4, 3}
-
-    >> IntegerDigits[15, 16]
-     = {15}
-    >> IntegerDigits[1234, 16]
-     = {4, 13, 2}
-    >> IntegerDigits[1234, 10, 5]
-     = {0, 1, 2, 3, 4}
-
-    #> IntegerDigits[1000, 10]
-     = {1, 0, 0, 0}
-
-    #> IntegerDigits[0]
-     = {0}
-    """
-
-    attributes = ("Listable",)
-
-    messages = {
-        "int": "Integer expected at position 1 in `1`",
-        "ibase": "Base `1` is not an integer greater than 1.",
-    }
-
-    rules = {
-        "IntegerDigits[n_]": "IntegerDigits[n, 10]",
-    }
-
-    def apply_len(self, n, base, length, evaluation):
-        "IntegerDigits[n_, base_, length_]"
-
-        if not (isinstance(length, Integer) and length.get_int_value() >= 0):
-            return evaluation.message("IntegerDigits", "intnn")
-
-        return self.apply(n, base, evaluation, nr_elements=length.get_int_value())
-
-    def apply(self, n, base, evaluation, nr_elements=None):
-        "IntegerDigits[n_, base_]"
-
-        if not (isinstance(n, Integer)):
-            return evaluation.message(
-                "IntegerDigits", "int", Expression("IntegerDigits", n, base)
-            )
-
-        if not (isinstance(base, Integer) and base.get_int_value() > 1):
-            return evaluation.message("IntegerDigits", "ibase", base)
-
-        if nr_elements == 0:
-            # trivial case: we don't want any digits
-            return Expression(SymbolList)
-
-        digits = convert_int_to_digit_list(n.get_int_value(), base.get_int_value())
-
-        if nr_elements is not None:
-            if len(digits) >= nr_elements:
-                # Truncate, preserving the digits on the right
-                digits = digits[-nr_elements:]
-            else:
-                # Pad with zeroes
-                digits = [0] * (nr_elements - len(digits)) + digits
-
-        return Expression(SymbolList, *digits)
-
-
-def check_finite_decimal(denominator):
-    # The rational number is finite decimal if the denominator has form 2^a * 5^b
-    while denominator % 5 == 0:
-        denominator = denominator / 5
-
-    while denominator % 2 == 0:
-        denominator = denominator / 2
-
-    return True if denominator == 1 else False
-
-
-def convert_repeating_decimal(numerator, denominator, base):
-    head = [x for x in str(numerator // denominator)]
-    tails = []
-    subresults = [numerator % denominator]
-    numerator %= denominator
-
-    while numerator != 0:  # only rational input can go to this case
-        numerator *= base
-        result_digit, numerator = divmod(numerator, denominator)
-        tails.append(str(result_digit))
-        if numerator not in subresults:
-            subresults.append(numerator)
-        else:
-            break
-
-    for i in range(len(head) - 1, -1, -1):
-        j = len(tails) - 1
-        if head[i] != tails[j]:
-            break
-        else:
-            del tails[j]
-            tails.insert(0, head[i])
-            del head[i]
-            j = j - 1
-
-    # truncate all leading 0's
-    if all(elem == "0" for elem in head):
-        for i in range(0, len(tails)):
-            if tails[0] == "0":
-                tails = tails[1:] + [str(0)]
-            else:
-                break
-    return (head, tails)
-
-
-def convert_float_base(x, base, precision=10):
-
-    length_of_int = 0 if x == 0 else int(mpmath.log(x, base))
-    # iexps = list(range(length_of_int, -1, -1))
-
-    def convert_int(x, base, exponents):
-        out = []
-        for e in range(0, exponents + 1):
-            d = x % base
-            out.append(d)
-            x = x / base
-            if x == 0:
-                break
-        out.reverse()
-        return out
-
-    def convert_float(x, base, exponents):
-        out = []
-        for e in range(0, exponents):
-            d = int(x * base)
-            out.append(d)
-            x = (x * base) - d
-            if x == 0:
-                break
-        return out
-
-    int_part = convert_int(int(x), base, length_of_int)
-    if isinstance(x, (float, sympy.Float)):
-        # fexps = list(range(-1, -int(precision + 1), -1))
-        real_part = convert_float(x - int(x), base, precision + 1)
-        return int_part + real_part
-    elif isinstance(x, int):
-        return int_part
-    else:
-        raise TypeError(x)
-
-
 class RealDigits(Builtin):
     """
     <dl>
-    <dt>'RealDigits[$n$]'
-        <dd>returns the decimal representation of the real number $n$ as list of digits, together with the number of digits that are to the left of the decimal point.
+      <dt>'RealDigits[$n$]'
+      <dd>returns the decimal representation of the real number $n$ as list of digits, together with the number of digits that are to the left of the decimal point.
 
-    <dt>'RealDigits[$n$, $b$]'
-        <dd>returns a list of base_$b$ representation of the real number $n$.
+      <dt>'RealDigits[$n$, $b$]'
+      <dd>returns a list of base_$b$ representation of the real number $n$.
 
-    <dt>'RealDigits[$n$, $b$, $len$]'
-        <dd>returns a list of $len$ digits.
+      <dt>'RealDigits[$n$, $b$, $len$]'
+      <dd>returns a list of $len$ digits.
 
-    <dt>'RealDigits[$n$, $b$, $len$, $p$]'
-        <dd>return $len$ digits starting with the coefficient of $b$^$p$
+      <dt>'RealDigits[$n$, $b$, $len$, $p$]'
+      <dd>return $len$ digits starting with the coefficient of $b$^$p$
     </dl>
 
     Return the list of digits and exponent:
@@ -1457,6 +1584,8 @@ class RealDigits(Builtin):
         "intnm": "Non-negative machine-sized integer expected at position 3 in `1`.",
         "intm": "Machine-sized integer expected at position 4 in `1`.",
     }
+
+    summary_text = "digits of a real number"
 
     def apply_complex(self, n, var, evaluation):
         "%(name)s[n_Complex, var___]"
@@ -1722,133 +1851,3 @@ class Hash(Builtin):
 class TypeEscalation(Exception):
     def __init__(self, mode):
         self.mode = mode
-
-
-class Fold(object):
-    # allows inherited classes to specify a single algorithm implementation that
-    # can be called with machine precision, arbitrary precision or symbolically.
-
-    ComputationFunctions = namedtuple("ComputationFunctions", ("sin", "cos"))
-
-    FLOAT = 0
-    MPMATH = 1
-    SYMBOLIC = 2
-
-    math = {
-        FLOAT: ComputationFunctions(
-            cos=math.cos,
-            sin=math.sin,
-        ),
-        MPMATH: ComputationFunctions(
-            cos=mpmath.cos,
-            sin=mpmath.sin,
-        ),
-        SYMBOLIC: ComputationFunctions(
-            cos=lambda x: Expression("Cos", x),
-            sin=lambda x: Expression("Sin", x),
-        ),
-    }
-
-    operands = {
-        FLOAT: lambda x: None if x is None else x.round_to_float(),
-        MPMATH: lambda x: None if x is None else x.to_mpmath(),
-        SYMBOLIC: lambda x: x,
-    }
-
-    def _operands(self, state, steps):
-        raise NotImplementedError
-
-    def _fold(self, state, steps, math):
-        raise NotImplementedError
-
-    def _spans(self, operands):
-        spans = {}
-        k = 0
-        j = 0
-
-        for mode in (self.FLOAT, self.MPMATH):
-            for i, operand in enumerate(operands[k:]):
-                if operand[0] > mode:
-                    break
-                j = i + k + 1
-
-            if k == 0 and j == 1:  # only init state? then ignore.
-                j = 0
-
-            spans[mode] = slice(k, j)
-            k = j
-
-        spans[self.SYMBOLIC] = slice(k, len(operands))
-
-        return spans
-
-    def fold(self, x, ll):
-        # computes fold(x, ll) with the internal _fold function. will start
-        # its evaluation machine precision, and will escalate to arbitrary
-        # precision if or symbolical evaluation only if necessary. folded
-        # items already computed are carried over to new evaluation modes.
-
-        yield x  # initial state
-
-        init = None
-        operands = list(self._operands(x, ll))
-        spans = self._spans(operands)
-
-        for mode in (self.FLOAT, self.MPMATH, self.SYMBOLIC):
-            s_operands = [y[1:] for y in operands[spans[mode]]]
-
-            if not s_operands:
-                continue
-
-            if mode == self.MPMATH:
-                from mathics.core.numbers import min_prec
-
-                precision = min_prec(*[t for t in chain(*s_operands) if t is not None])
-                working_precision = mpmath.workprec
-            else:
-
-                @contextmanager
-                def working_precision(_):
-                    yield
-
-                precision = None
-
-            if mode == self.FLOAT:
-
-                def out(z):
-                    return Real(z)
-
-            elif mode == self.MPMATH:
-
-                def out(z):
-                    return Real(z, precision)
-
-            else:
-
-                def out(z):
-                    return z
-
-            as_operand = self.operands.get(mode)
-
-            def converted_operands():
-                for y in s_operands:
-                    yield tuple(as_operand(t) for t in y)
-
-            with working_precision(precision):
-                c_operands = converted_operands()
-
-                if init is not None:
-                    c_init = tuple(
-                        (None if t is None else as_operand(from_python(t)))
-                        for t in init
-                    )
-                else:
-                    c_init = next(c_operands)
-                    init = tuple((None if t is None else out(t)) for t in c_init)
-
-                generator = self._fold(c_init, c_operands, self.math.get(mode))
-
-                for y in generator:
-                    y = tuple(out(t) for t in y)
-                    yield y
-                    init = y

--- a/test/test_numeric.py
+++ b/test/test_numeric.py
@@ -2,6 +2,54 @@
 from .helper import check_evaluation
 
 
+def test_rationalize():
+    # Some of the Rationalize tests were taken from Symja's tests and docs
+    for str_expr, str_expected in (
+        (
+            "Rationalize[42]",
+            "42",
+        ),
+        # We get 3 / 1 instead of 3
+        # (
+        #     "Rationalize[3, 1]",
+        #     "3",
+        # ),
+        (
+            "Rationalize[N[Pi] + 0.8 I, 0]",
+            "245850922 / 78256779 + 4 I / 5",
+        ),
+        (
+            "Rationalize[1.6 + 0.8 I]",
+            "8 / 5 + 4 I / 5",
+        ),
+        (
+            "Rationalize[17 / 7]",
+            "17 / 7",
+        ),
+        (
+            "Rationalize[6.75]",
+            "27 / 4",
+        ),
+        (
+            "Rationalize[0.25+I*0.33333]",
+            "1 / 4 + I / 3",
+        ),
+        (
+            "Rationalize[N[Pi] + 0.8 I, 1*^-6]",
+            "355 / 113 + 4 I / 5",
+        ),
+        (
+            "Rationalize[x]",
+            "x",
+        ),
+        (
+            "Table[Rationalize[E, 0.1^n], {n, 1, 10}]",
+            "{8 / 3, 19 / 7, 87 / 32, 193 / 71, 1071 / 394, 2721 / 1001, 15062 / 5541, 23225 / 8544, 49171 / 18089, 419314 / 154257}",
+        ),
+    ):
+        check_evaluation(str_expr, str_expected)
+
+
 def test_realvalued():
     for str_expr, str_expected in (
         (


### PR DESCRIPTION
* Put builtins in alphabetic order
* Add summary text for some built ins
* No hard line breaks on doc text
* Move non-showing test code in Rationalize out to a pytest