### PR TITLE
adding some quick pattern tests for PatternTest

### DIFF
--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -480,7 +480,7 @@ class PatternTest(BinaryOperator, PatternObject):
             if isinstance(candidate, (Integer, Rational, Real)):
                 return True
             return False
-            # pass        
+            # pass
         elif test == "System`Positive":
             if isinstance(candidate, (Integer, Rational, Real)):
                 return candidate.value > 0

--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -476,6 +476,16 @@ class PatternTest(BinaryOperator, PatternObject):
     def quick_pattern_test(self, candidate, test, evaluation):
         if test == "System`NumberQ":
             return isinstance(candidate, Number)
+        elif test == "System`RealNumberQ":
+            if isinstance(candidate, (Integer, Rational, Real)):
+                return True
+            return False
+            # pass        
+        elif test == "System`Positive":
+            if isinstance(candidate, (Integer, Rational, Real)):
+                return candidate.value > 0
+            return False
+            # pass
         elif test == "System`Negative":
             if isinstance(candidate, (Integer, Rational, Real)):
                 return candidate.value < 0


### PR DESCRIPTION
Related to #1560, the processing of some typical `PatternTests` that appear in the definitions can be accelerated by evaluating them inside the method `quick_pattern_test`. Here I added a couple.