### PR TITLE
Improve Rational performance

### DIFF
--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -876,10 +876,10 @@ class Rational_(Builtin):
     def apply(self, n, m, evaluation):
         "%(name)s[n_Integer, m_Integer]"
 
-        if m.to_sympy() == 1:
-            return Integer(n.to_sympy())
+        if m.value == 1:
+            return n
         else:
-            return Rational(n.to_sympy(), m.to_sympy())
+            return Rational(n.value, m.value)
 
 
 class Complex_(Builtin):


### PR DESCRIPTION
The benchmark:
```
Mathics git repo /workspaces/mathics-benchmark/Mathics at 58dc69
10000 iterations of Rational...
  1.312635 secs for: Rational[10, 1]                         
  1.235519 secs for: Rational[2, 3]                          

Mathics git repo /workspaces/mathics-benchmark/Mathics at b9b11b
10000 iterations of Rational...
  1.199198 secs for: Rational[10, 1]                         
  1.159303 secs for: Rational[2, 3]
```

Way more important than that tenth of second is that there is a lot of places where instead of `.to_sympy()` we could use the faster `.value`.