### PR TITLE
Faster numericq

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Internals
 
 * now `Expression.is_numeric()` accepts an `Evaluation` object as a parameter,
   to use the definitions.
-* To numerify expressions, the function `_numeric_evaluation_with_prec` was introduced in the module `mathics.builtin.numeric` to avoid the idiom
+* To numerify expressions, the function `apply_N` was introduced in the module `mathics.builtin.numeric` to avoid the idiom
   `Expression("N", expr, prec).evaluate(evaluation)`. The idea is to avoid when it is possible to call the Pattern matching routines to obtain the numeric value of an expression.
 * A bug comming from a failure in the order in which `mathics.core.definitions` stores the rules was fixed.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,18 @@
 CHANGES
 =======
 
+Internals
+=========
+
+* now `Expression.is_numeric()` accepts an `Evaluation` object as a parameter,
+  to use the definitions.
+* To numerify expressions, the function `_numeric_evaluation_with_prec` was introduced in the module `mathics.builtin.numeric` to avoid the idiom
+  `Expression("N", expr, prec).evaluate(evaluation)`. The idea is to avoid when it is possible to call the Pattern matching routines to obtain the numeric value of an expression.
+* `Positive`,  `Negative`, `NonPositive` and `NonNegative` do not check their arguments using the Pattern matching mechanism, but inside the Python code.
+* special cases for `quick_pattern_test` were reduced as much as possible.
+* A bug comming from a failure in the order in which `mathics.core.definitions` stores the rules was fixed.
+
+
 4.0.1
 -----
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,8 +8,6 @@ Internals
   to use the definitions.
 * To numerify expressions, the function `_numeric_evaluation_with_prec` was introduced in the module `mathics.builtin.numeric` to avoid the idiom
   `Expression("N", expr, prec).evaluate(evaluation)`. The idea is to avoid when it is possible to call the Pattern matching routines to obtain the numeric value of an expression.
-* `Positive`,  `Negative`, `NonPositive` and `NonNegative` do not check their arguments using the Pattern matching mechanism, but inside the Python code.
-* special cases for `quick_pattern_test` were reduced as much as possible.
 * A bug comming from a failure in the order in which `mathics.core.definitions` stores the rules was fixed.
 
 

--- a/mathics/benchmark.py
+++ b/mathics/benchmark.py
@@ -26,6 +26,41 @@ TESTS_PER_BENCHMARK = None
 
 # Mathics expressions to benchmark
 BENCHMARKS = {
+    "NumericQ": [
+        "NumericQ[Sqrt[2]]",
+        "NumericQ[Sqrt[-2]]",
+        "NumericQ[Sqrt[2.]]",
+        "NumericQ[Sqrt[-2.]]",
+        "NumericQ[q]",
+        'NumericQ["q"]',
+    ],
+    # This function checks for numericQ in ints argument before calling
+    "Positive": [
+        "Positive[Sqrt[2]]",
+        "Positive[Sqrt[-2]]",
+        "Positive[Sqrt[2.]]",
+        "Positive[Sqrt[-2.]]",
+        "Positive[q]",
+        'Positive["q"]',
+    ],
+    # This function uses the WL rules definition, like in master
+    "NonNegative": [
+        "NonNegative[Sqrt[2]]",
+        "NonNegative[Sqrt[-2]]",
+        "NonNegative[Sqrt[2.]]",
+        "NonNegative[Sqrt[-2.]]",
+        "NonNegative[q]",
+        'NonNegative["q"]',
+    ],
+    # This function does the check inside the method.
+    "Negative": [
+        "Negative[Sqrt[2]]",
+        "Negative[Sqrt[-2]]",
+        "Negative[Sqrt[2.]]",
+        "Negative[Sqrt[-2.]]",
+        "Negative[q]",
+        'Negative["q"]',
+    ],
     "Arithmetic": ["1 + 2", "5 * 3"],
     "Plot": [
         "Plot[0, {x, -3, 3}]",

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -47,6 +47,7 @@ from mathics.builtin.lists import _IterationFunction
 from mathics.core.convert import from_sympy, SympyExpression, sympy_symbol_prefix
 from mathics.builtin.scoping import dynamic_scoping
 from mathics.builtin.inference import get_assumptions_list, evaluate_predicate
+from mathics.builtin.numeric import _numeric_evaluation_with_prec
 
 
 @lru_cache(maxsize=1024)
@@ -133,7 +134,7 @@ class _MPMathFunction(SympyFunction):
             prec = min_prec(*args)
             d = dps(prec)
             args = [
-                Expression(SymbolN, arg, Integer(d)).evaluate(evaluation)
+                _numeric_evaluation_with_prec(arg, evaluation, Integer(d))
                 for arg in args
             ]
             with mpmath.workprec(prec):

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -133,10 +133,7 @@ class _MPMathFunction(SympyFunction):
         else:
             prec = min_prec(*args)
             d = dps(prec)
-            args = [
-                apply_N(arg, evaluation, Integer(d))
-                for arg in args
-            ]
+            args = [apply_N(arg, evaluation, Integer(d)) for arg in args]
             with mpmath.workprec(prec):
                 mpmath_args = [x.to_mpmath() for x in args]
                 if None in mpmath_args:

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -47,7 +47,7 @@ from mathics.builtin.lists import _IterationFunction
 from mathics.core.convert import from_sympy, SympyExpression, sympy_symbol_prefix
 from mathics.builtin.scoping import dynamic_scoping
 from mathics.builtin.inference import get_assumptions_list, evaluate_predicate
-from mathics.builtin.numeric import _numeric_evaluation_with_prec
+from mathics.builtin.numeric import apply_N
 
 
 @lru_cache(maxsize=1024)
@@ -134,7 +134,7 @@ class _MPMathFunction(SympyFunction):
             prec = min_prec(*args)
             d = dps(prec)
             args = [
-                _numeric_evaluation_with_prec(arg, evaluation, Integer(d))
+                apply_N(arg, evaluation, Integer(d))
                 for arg in args
             ]
             with mpmath.workprec(prec):

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -527,11 +527,13 @@ class BinaryOperator(Operator):
 class Test(Builtin):
     def apply(self, expr, evaluation) -> Symbol:
         "%(name)s[expr_]"
-
-        if self.test(expr):
+        tst = self.test(expr)
+        if tst:
             return SymbolTrue
-        else:
+        elif tst is False:
             return SymbolFalse
+        else:
+            return
 
 
 class SympyFunction(SympyObject):

--- a/mathics/builtin/comparison.py
+++ b/mathics/builtin/comparison.py
@@ -198,7 +198,7 @@ class _InequalityOperator(BinaryOperator):
     def numerify_args(items, evaluation):
         items_sequence = items.get_sequence()
         all_numeric = all(
-            item.is_numeric() and item.get_precision() is None
+            item.is_numeric(evaluation) and item.get_precision() is None
             for item in items_sequence
         )
 

--- a/mathics/builtin/datentime.py
+++ b/mathics/builtin/datentime.py
@@ -630,7 +630,7 @@ class DateObject(_DateFormat):
             timezone = Real(-time.timezone / 3600.0)
         else:
             timezone = options["System`TimeZone"].evaluate(evaluation)
-            if not timezone.is_numeric():
+            if not timezone.is_numeric(evaluation):
                 evaluation.message("DateObject", "notz", timezone)
 
         # TODO: if tz != timezone, shift the datetime list.
@@ -1123,7 +1123,7 @@ if sys.platform != "win32" and ("Pyston" not in sys.version):
         def apply_3(self, expr, t, failexpr, evaluation):
             "TimeConstrained[expr_, t_, failexpr_]"
             t = t.evaluate(evaluation)
-            if not t.is_numeric():
+            if not t.is_numeric(evaluation):
                 evaluation.message("TimeConstrained", "timc", t)
                 return
             try:

--- a/mathics/builtin/inference.py
+++ b/mathics/builtin/inference.py
@@ -156,7 +156,7 @@ def logical_expand_assumptions(assumptions_list, evaluation):
                 evaluation.message("Assumption", "faas")
                 changed = True
                 continue
-            if assumption.is_numeric():
+            if assumption.is_numeric(evaluation):
                 evaluation.message("Assumption", "baas")
                 changed = True
                 continue
@@ -306,7 +306,7 @@ def get_assumption_rules_dispatch(evaluation):
         if pat.has_form("Equal", 2):
             if value:
                 lhs, rhs = pat._leaves
-                if lhs.is_numeric():
+                if lhs.is_numeric(evaluation):
                     assumption_rules.append(Rule(rhs, lhs))
                 else:
                     assumption_rules.append(Rule(lhs, rhs))

--- a/mathics/builtin/intfns/divlike.py
+++ b/mathics/builtin/intfns/divlike.py
@@ -367,7 +367,7 @@ class QuotientRemainder(Builtin):
 
     def apply(self, m, n, evaluation):
         "QuotientRemainder[m_, n_]"
-        if m.is_numeric() and n.is_numeric():
+        if m.is_numeric(evaluation) and n.is_numeric():
             py_m = m.to_python()
             py_n = n.to_python()
             if py_n == 0:

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -2704,7 +2704,7 @@ class _Cluster(Builtin):
                     raise _IllegalDataPoint
                 yield v
 
-        if dist_p[0].is_numeric():
+        if dist_p[0].is_numeric(evaluation):
             numeric_p = [[x] for x in convert_scalars(dist_p)]
         else:
             numeric_p = list(convert_vectors(dist_p))

--- a/mathics/builtin/moments/basic.py
+++ b/mathics/builtin/moments/basic.py
@@ -49,7 +49,7 @@ class Median(_Rectangular):
                 return self.rect(l)
             except _NotRectangularException:
                 evaluation.message("Median", "rectn", Expression("Median", l))
-        elif all(leaf.is_numeric() for leaf in l.leaves):
+        elif all(leaf.is_numeric(evaluation) for leaf in l.leaves):
             v = l.get_mutable_leaves()  # copy needed for introselect
             n = len(v)
             if n % 2 == 0:  # even number of elements?

--- a/mathics/builtin/numbers/algebra.py
+++ b/mathics/builtin/numbers/algebra.py
@@ -1476,7 +1476,7 @@ class _CoefficientHandler(Builtin):
         def key_powers(lst):
             key = Expression("Plus", *lst)
             key = key.evaluate(evaluation)
-            if key.is_numeric():
+            if key.is_numeric(evaluation):
                 return key.to_python()
             return 0
 

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -18,7 +18,6 @@ from mathics.core.expression import (
     SymbolTrue,
     SymbolFalse,
     SymbolList,
-    SymbolN,
     SymbolRule,
     SymbolUndefined,
     from_python,
@@ -27,6 +26,7 @@ from mathics.core.convert import sympy_symbol_prefix, SympyExpression, from_symp
 from mathics.core.rules import Pattern
 from mathics.core.numbers import dps
 from mathics.builtin.scoping import dynamic_scoping
+from mathics.builtin.numeric import _numeric_evaluation_with_prec
 from mathics import Symbol
 
 import sympy
@@ -1280,9 +1280,8 @@ def find_root_newton(f, x0, x, opts, evaluation) -> (Number, bool):
         # TODO: use Precision goal...
         if x1 == x0:
             break
-        x0 = Expression(SymbolN, x1).evaluate(
-            evaluation
-        )  # N required due to bug in sympy arithmetic
+        x0 = _numeric_evaluation_with_prec(x1, evaluation)
+        # N required due to bug in sympy arithmetic
         count += 1
     else:
         evaluation.message("FindRoot", "maxiter")
@@ -1377,7 +1376,7 @@ class FindRoot(Builtin):
     def apply(self, f, x, x0, evaluation, options):
         "FindRoot[f_, {x_, x0_}, OptionsPattern[]]"
         # First, determine x0 and x
-        x0 = Expression(SymbolN, x0).evaluate(evaluation)
+        x0 = _numeric_evaluation_with_prec(x0, evaluation)
         if not isinstance(x0, Number):
             evaluation.message("FindRoot", "snum", x0)
             return
@@ -1545,7 +1544,7 @@ class SeriesData(Builtin):
 
         expansion = []
         for i, leaf in enumerate(data.leaves):
-            if leaf.is_numeric() and leaf.is_zero:
+            if leaf.is_numeric(evaluation) and leaf.is_zero:
                 continue
             if powers[i].is_zero:
                 expansion.append(leaf)

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -26,7 +26,7 @@ from mathics.core.convert import sympy_symbol_prefix, SympyExpression, from_symp
 from mathics.core.rules import Pattern
 from mathics.core.numbers import dps
 from mathics.builtin.scoping import dynamic_scoping
-from mathics.builtin.numeric import _numeric_evaluation_with_prec
+from mathics.builtin.numeric import apply_N
 from mathics import Symbol
 
 import sympy
@@ -1280,7 +1280,7 @@ def find_root_newton(f, x0, x, opts, evaluation) -> (Number, bool):
         # TODO: use Precision goal...
         if x1 == x0:
             break
-        x0 = _numeric_evaluation_with_prec(x1, evaluation)
+        x0 = apply_N(x1, evaluation)
         # N required due to bug in sympy arithmetic
         count += 1
     else:
@@ -1376,7 +1376,7 @@ class FindRoot(Builtin):
     def apply(self, f, x, x0, evaluation, options):
         "FindRoot[f_, {x_, x0_}, OptionsPattern[]]"
         # First, determine x0 and x
-        x0 = _numeric_evaluation_with_prec(x0, evaluation)
+        x0 = apply_N(x0, evaluation)
         if not isinstance(x0, Number):
             evaluation.message("FindRoot", "snum", x0)
             return

--- a/mathics/builtin/numbers/numbertheory.py
+++ b/mathics/builtin/numbers/numbertheory.py
@@ -20,7 +20,7 @@ from mathics.core.expression import (
 from mathics.core.convert import from_sympy, SympyPrime
 import mpmath
 
-from mathics.builtin.numeric import _numeric_evaluation_with_prec
+from mathics.builtin.numeric import apply_N
 
 
 class ContinuedFraction(SympyFunction):
@@ -413,13 +413,13 @@ class MantissaExponent(Builtin):
             return expr
 
         if n_sympy.is_constant():
-            temp_n = _numeric_evaluation_with_prec(n, evaluation)
+            temp_n = apply_N(n, evaluation)
             py_n = temp_n.to_python()
         else:
             return expr
 
         if b_sympy.is_constant():
-            temp_b = _numeric_evaluation_with_prec(b, evaluation)
+            temp_b = apply_N(b, evaluation)
             py_b = temp_b.to_python()
         else:
             return expr
@@ -444,7 +444,7 @@ class MantissaExponent(Builtin):
             return expr
         # Handle Input with special cases such as PI and E
         if n_sympy.is_constant():
-            temp_n = _numeric_evaluation_with_prec(n, evaluation)
+            temp_n = apply_N(n, evaluation)
             py_n = temp_n.to_python()
         else:
             return expr

--- a/mathics/builtin/numbers/numbertheory.py
+++ b/mathics/builtin/numbers/numbertheory.py
@@ -16,10 +16,11 @@ from mathics.core.expression import (
     Rational,
     Symbol,
     from_python,
-    SymbolN,
 )
 from mathics.core.convert import from_sympy, SympyPrime
 import mpmath
+
+from mathics.builtin.numeric import _numeric_evaluation_with_prec
 
 
 class ContinuedFraction(SympyFunction):
@@ -412,13 +413,13 @@ class MantissaExponent(Builtin):
             return expr
 
         if n_sympy.is_constant():
-            temp_n = Expression(SymbolN, n).evaluate(evaluation)
+            temp_n = _numeric_evaluation_with_prec(n, evaluation)
             py_n = temp_n.to_python()
         else:
             return expr
 
         if b_sympy.is_constant():
-            temp_b = Expression(SymbolN, b).evaluate(evaluation)
+            temp_b = _numeric_evaluation_with_prec(b, evaluation)
             py_b = temp_b.to_python()
         else:
             return expr
@@ -443,7 +444,7 @@ class MantissaExponent(Builtin):
             return expr
         # Handle Input with special cases such as PI and E
         if n_sympy.is_constant():
-            temp_n = Expression(SymbolN, n).evaluate(evaluation)
+            temp_n = _numeric_evaluation_with_prec(n, evaluation)
             py_n = temp_n.to_python()
         else:
             return expr

--- a/mathics/builtin/numbers/randomnumbers.py
+++ b/mathics/builtin/numbers/randomnumbers.py
@@ -251,7 +251,7 @@ class _RandomBase(Builtin):
 
     def _size_to_python(self, domain, size, evaluation):
         is_proper_spec = size.get_head_name() == "System`List" and all(
-            n.is_numeric() for n in size.leaves
+            n.is_numeric(evaluation) for n in size.leaves
         )
 
         py_size = size.to_python() if is_proper_spec else None
@@ -589,7 +589,7 @@ class _RandomSelection(_RandomBase):
         # we need to normalize weights as numpy.rand.randchoice expects this and as we can limit
         # accuracy problems with very large or very small weights by normalizing with sympy
         is_proper_spec = weights.get_head_name() == "System`List" and all(
-            w.is_numeric() for w in weights.leaves
+            w.is_numeric(evaluation) for w in weights.leaves
         )
 
         if (
@@ -599,7 +599,7 @@ class _RandomSelection(_RandomBase):
                 "Divide", weights, Expression("Total", weights)
             ).evaluate(evaluation)
             if norm_weights is None or not all(
-                w.is_numeric() for w in norm_weights.leaves
+                w.is_numeric(evaluation) for w in norm_weights.leaves
             ):
                 return evaluation.message(self.get_name(), "wghtv", weights), None
             weights = norm_weights

--- a/mathics/builtin/numeric.py
+++ b/mathics/builtin/numeric.py
@@ -62,7 +62,7 @@ def log_n_b(py_n, py_b) -> int:
     return int(mpmath.ceil(mpmath.log(py_n, py_b))) if py_n != 0 and py_n != 1 else 1
 
 
-def _numeric_evaluation_with_prec(expression, evaluation, prec=SymbolMachinePrecision):
+def apply_N(expression, evaluation, prec=SymbolMachinePrecision):
     return Expression("N", expression, prec).evaluate(evaluation)
 
 

--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -358,7 +358,7 @@ class ReplaceRepeated(BinaryOperator):
             return rules
 
         maxit = self.get_option(options, "MaxIterations", evaluation)
-        if maxit.is_numeric():
+        if maxit.is_numeric(evaluation):
             maxit = maxit.get_int_value()
         else:
             maxit = -1

--- a/mathics/builtin/procedural.py
+++ b/mathics/builtin/procedural.py
@@ -433,7 +433,7 @@ class FixedPoint(Builtin):
 
         if count is None:
             count = self.get_option(options, "MaxIterations", evaluation)
-            if count.is_numeric():
+            if count.is_numeric(evaluation):
                 count = count.get_int_value()
             else:
                 count = None

--- a/mathics/builtin/recurrence.py
+++ b/mathics/builtin/recurrence.py
@@ -100,7 +100,7 @@ class RSolve(Builtin):
                     left.get_head_name() == func.get_head_name()
                     and len(left.leaves) == 1  # noqa
                     and isinstance(l.leaves[0].to_python(), int)
-                    and r.is_numeric()
+                    and r.is_numeric(evaluation)
                 ):
 
                     r_sympy = r.to_sympy()

--- a/mathics/builtin/sparse.py
+++ b/mathics/builtin/sparse.py
@@ -83,7 +83,7 @@ class SparseArray(Builtin):
             for i, leaf in enumerate(array.leaves):
                 if leaf.has_form("SparseArray", None) or leaf.has_form("List", None):
                     return
-                if leaf.is_numeric() and leaf.is_zero:
+                if leaf.is_numeric(evaluation) and leaf.is_zero:
                     continue
                 leaves.append(
                     Expression("Rule", Expression("List", Integer(i + 1)), leaf)

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -735,6 +735,8 @@ def get_tag_position(pattern, name) -> typing.Optional[str]:
         head_name = pattern.get_head_name()
         if head_name == name:
             return "down"
+        elif head_name == "System`N" and len(pattern.leaves) == 2:
+            return "n"
         elif head_name == "System`Condition" and len(pattern.leaves) > 0:
             return get_tag_position(pattern.leaves[0], name)
         elif pattern.get_lookup_name() == name:
@@ -802,8 +804,6 @@ class Definition(object):
         self.downvalues = downvalues
         self.subvalues = subvalues
         self.upvalues = upvalues
-        for rule in rules:
-            self.add_rule(rule)
         self.formatvalues = dict((name, list) for name, list in formatvalues.items())
         self.messages = messages
         self.attributes = set(attributes)
@@ -813,6 +813,8 @@ class Definition(object):
         self.nvalues = nvalues
         self.defaultvalues = defaultvalues
         self.builtin = builtin
+        for rule in rules:
+            self.add_rule(rule)
 
     def get_values_list(self, pos):
         assert pos.isalpha()


### PR DESCRIPTION
This PR keeps from #1569 those changes related to `N` and `NumericQ`.
Now, 
* NumericQ uses the definitions instead of just a subset of predefined numeric functions.
* A bug in the `Definitions.__init__` method was corrected, which allows distinguishing rules of the form `N[expr_]:=(definition)` of other definitions.
* `Expression("N",expr_,prec_).evaluate(evaluation)` now is a function that avoid to pass through the pattern matching based calling way.


